### PR TITLE
[#7] Collection Views 한눈에 보기 구조도의 화질과 동작 흐름을 개선한다

### DIFF
--- a/docs/guide/uikit/collection-views/assets/collection-view-roles.svg
+++ b/docs/guide/uikit/collection-views/assets/collection-view-roles.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1400" height="760" viewBox="0 0 1400 760" role="img" aria-labelledby="title description" shape-rendering="geometricPrecision" text-rendering="optimizeLegibility">
   <title id="title">Collection View 구성 요소의 역할</title>
-  <desc id="description">앱 모델이 snapshot을 만들고 diffable data source가 Collection View에 상태를 적용한다. Collection View는 layout에서 위치 정보를 받고 재사용 셀을 화면에 표시한다.</desc>
+  <desc id="description">앱 모델이 snapshot을 만들고 diffable data source가 Collection View에 상태를 적용한다. Collection View는 layout과 재사용 셀에 필요한 정보를 요청하고, prefetch data source에 표시 전 데이터 준비를 요청하며, delegate에 사용자 이벤트를 전달한다.</desc>
   <defs>
     <style>
       .title { font-family: "Helvetica Neue", "Apple SD Gothic Neo", Arial, sans-serif; font-size: 32px; font-weight: 700; fill: #111827; }
@@ -11,6 +11,10 @@
       .label { font-family: "Helvetica Neue", "Apple SD Gothic Neo", Arial, sans-serif; font-size: 14px; font-weight: 700; fill: #075dcc; }
       .flow { fill: none; stroke: #1675ea; stroke-width: 3; stroke-linecap: round; }
       .request { fill: none; stroke: #7c3aed; stroke-width: 3; stroke-linecap: round; stroke-dasharray: 9 8; }
+      .prefetch { fill: none; stroke: #0f766e; stroke-width: 3; stroke-linecap: round; stroke-dasharray: 9 8; }
+      .delegate { fill: none; stroke: #d97706; stroke-width: 3; stroke-linecap: round; stroke-dasharray: 9 8; }
+      .code-teal { fill: #0f766e; }
+      .code-amber { fill: #b45309; font-size: 15px; }
     </style>
     <marker id="blue-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0 0L8 4L0 8Z" fill="#1675ea"/>
@@ -18,14 +22,20 @@
     <marker id="purple-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
       <path d="M0 0L8 4L0 8Z" fill="#7c3aed"/>
     </marker>
+    <marker id="teal-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#0f766e"/>
+    </marker>
+    <marker id="amber-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0L8 4L0 8Z" fill="#d97706"/>
+    </marker>
     <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
       <feDropShadow dx="0" dy="5" stdDeviation="7" flood-color="#0f172a" flood-opacity=".08"/>
     </filter>
   </defs>
 
   <rect width="1400" height="760" rx="28" fill="#f8fafc"/>
-  <text class="title" x="60" y="66">Collection View는 데이터·표시·배치를 나눠요</text>
-  <text class="subtitle" x="60" y="99">안정적인 식별자가 화면 상태를 흐르고, 뷰와 레이아웃은 필요한 순간에 조합돼요.</text>
+  <text class="title" x="60" y="66">Collection View는 데이터·표시·배치·이벤트를 나눠요</text>
+  <text class="subtitle" x="60" y="99">상태 적용부터 셀 구성, 미리 가져오기, 사용자 이벤트까지 역할별로 연결돼요.</text>
 
   <g>
     <rect x="60" y="170" width="250" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
@@ -87,34 +97,60 @@
   <text class="label" x="1077" y="247" text-anchor="middle">차이 반영</text>
 
   <g>
-    <rect x="195" y="510" width="390" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="195" y="510" width="390" height="160" rx="22" fill="#ffffff"/>
-    <path d="M217 510H563Q585 510 585 532V648Q585 670 563 670H217" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M217 510Q195 510 195 532V648Q195 670 217 670" fill="none" stroke="#7c3aed" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
-    <text class="box-title" x="225" y="558">Collection View Layout</text>
-    <text class="code" x="225" y="594">layoutAttributes</text>
-    <text class="box-text" x="225" y="630">셀·헤더의 크기와 위치를 계산</text>
+    <rect x="60" y="520" width="280" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
+    <rect x="60" y="520" width="280" height="160" rx="22" fill="#ffffff"/>
+    <path d="M82 520H318Q340 520 340 542V658Q340 680 318 680H82" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M82 520Q60 520 60 542V658Q60 680 82 680" fill="none" stroke="#7c3aed" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <text class="box-title" x="90" y="568">Layout</text>
+    <text class="code" x="90" y="604">layoutAttributes</text>
+    <text class="box-text" x="90" y="640">셀·헤더의 크기·위치 계산</text>
   </g>
 
   <g>
-    <rect x="815" y="510" width="390" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="815" y="510" width="390" height="160" rx="22" fill="#ffffff"/>
-    <path d="M837 510H1183Q1205 510 1205 532V648Q1205 670 1183 670H837" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    <path d="M837 510Q815 510 815 532V648Q815 670 837 670" fill="none" stroke="#7c3aed" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
-    <text class="box-title" x="845" y="558">Reusable Cells</text>
-    <text class="code" x="845" y="594">CellRegistration</text>
-    <text class="box-text" x="845" y="630">현재 item 데이터로 매번 다시 구성</text>
+    <rect x="390" y="520" width="280" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
+    <rect x="390" y="520" width="280" height="160" rx="22" fill="#ffffff"/>
+    <path d="M412 520H648Q670 520 670 542V658Q670 680 648 680H412" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M412 520Q390 520 390 542V658Q390 680 412 680" fill="none" stroke="#7c3aed" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <text class="box-title" x="420" y="568">Reusable Cells</text>
+    <text class="code" x="420" y="604">CellRegistration</text>
+    <text class="box-text" x="420" y="640">현재 item 데이터로 다시 구성</text>
   </g>
 
-  <path class="request" d="M1125 323C1020 420 820 444 585 555" marker-end="url(#purple-arrow)"/>
-  <rect x="820" y="415" width="112" height="28" rx="14" fill="#f3e8ff"/>
-  <text x="876" y="434" text-anchor="middle" style="font-family:'Helvetica Neue','Apple SD Gothic Neo',Arial,sans-serif;font-size:14px;font-weight:700;fill:#6d28d9">위치 정보 요청</text>
+  <g>
+    <rect x="730" y="520" width="280" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
+    <rect x="730" y="520" width="280" height="160" rx="22" fill="#ffffff"/>
+    <path d="M752 520H988Q1010 520 1010 542V658Q1010 680 988 680H752" fill="none" stroke="#5eead4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M752 520Q730 520 730 542V658Q730 680 752 680" fill="none" stroke="#0f766e" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <text class="box-title" x="760" y="568">Prefetch</text>
+    <text class="code code-teal" x="760" y="604">DataSourcePrefetching</text>
+    <text class="box-text" x="760" y="640">보이기 전 데이터 준비</text>
+    <text class="box-text" x="760" y="667">불필요해지면 작업 취소</text>
+  </g>
 
-  <path class="request" d="M1125 327C1080 410 1040 445 1015 500" marker-end="url(#purple-arrow)"/>
-  <rect x="1038" y="415" width="112" height="28" rx="14" fill="#f3e8ff"/>
-  <text x="1094" y="434" text-anchor="middle" style="font-family:'Helvetica Neue','Apple SD Gothic Neo',Arial,sans-serif;font-size:14px;font-weight:700;fill:#6d28d9">보이는 셀 요청</text>
+  <g>
+    <rect x="1060" y="520" width="280" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
+    <rect x="1060" y="520" width="280" height="160" rx="22" fill="#ffffff"/>
+    <path d="M1082 520H1318Q1340 520 1340 542V658Q1340 680 1318 680H1082" fill="none" stroke="#fbbf24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M1082 520Q1060 520 1060 542V658Q1060 680 1082 680" fill="none" stroke="#d97706" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    <text class="box-title" x="1090" y="568">Delegate</text>
+    <text class="code code-amber" x="1090" y="604">UICollectionViewDelegate</text>
+    <text class="box-text" x="1090" y="640">선택·표시·스크롤 이벤트</text>
+    <text class="box-text" x="1090" y="667">사용자 상호작용 전달</text>
+  </g>
 
-  <path class="flow" d="M750 330C690 430 645 475 585 550" marker-end="url(#blue-arrow)"/>
-  <rect x="636" y="431" width="98" height="28" rx="14" fill="#e8f3ff"/>
-  <text class="label" x="685" y="450" text-anchor="middle">배치와 독립</text>
+  <path class="request" d="M1135 326C930 390 520 430 200 510" marker-end="url(#purple-arrow)"/>
+  <rect x="470" y="395" width="112" height="28" rx="14" fill="#f3e8ff"/>
+  <text x="526" y="414" text-anchor="middle" style="font-family:'Helvetica Neue','Apple SD Gothic Neo',Arial,sans-serif;font-size:14px;font-weight:700;fill:#6d28d9">위치 정보 요청</text>
+
+  <path class="request" d="M1175 338C1035 400 790 450 530 510" marker-end="url(#purple-arrow)"/>
+  <rect x="720" y="431" width="112" height="28" rx="14" fill="#f3e8ff"/>
+  <text x="776" y="450" text-anchor="middle" style="font-family:'Helvetica Neue','Apple SD Gothic Neo',Arial,sans-serif;font-size:14px;font-weight:700;fill:#6d28d9">보이는 셀 요청</text>
+
+  <path class="prefetch" d="M1225 350C1150 405 1005 455 870 510" marker-end="url(#teal-arrow)"/>
+  <rect x="926" y="390" width="126" height="28" rx="14" fill="#ccfbf1"/>
+  <text x="989" y="409" text-anchor="middle" style="font-family:'Helvetica Neue','Apple SD Gothic Neo',Arial,sans-serif;font-size:14px;font-weight:700;fill:#0f766e">표시 전 준비 요청</text>
+
+  <path class="delegate" d="M1280 350C1310 405 1250 460 1200 510" marker-end="url(#amber-arrow)"/>
+  <rect x="1128" y="450" width="132" height="28" rx="14" fill="#fef3c7"/>
+  <text x="1194" y="469" text-anchor="middle" style="font-family:'Helvetica Neue','Apple SD Gothic Neo',Arial,sans-serif;font-size:14px;font-weight:700;fill:#b45309">선택·스크롤 알림</text>
 </svg>

--- a/docs/guide/uikit/collection-views/assets/collection-view-roles.svg
+++ b/docs/guide/uikit/collection-views/assets/collection-view-roles.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 760" role="img" aria-labelledby="title description">
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="760" viewBox="0 0 1400 760" role="img" aria-labelledby="title description" shape-rendering="geometricPrecision" text-rendering="optimizeLegibility">
   <title id="title">Collection View 구성 요소의 역할</title>
   <desc id="description">앱 모델이 snapshot을 만들고 diffable data source가 Collection View에 상태를 적용한다. Collection View는 layout에서 위치 정보를 받고 재사용 셀을 화면에 표시한다.</desc>
   <defs>
@@ -27,7 +27,8 @@
   <text class="title" x="60" y="66">Collection View는 데이터·표시·배치를 나눠요</text>
   <text class="subtitle" x="60" y="99">안정적인 식별자가 화면 상태를 흐르고, 뷰와 레이아웃은 필요한 순간에 조합돼요.</text>
 
-  <g filter="url(#shadow)">
+  <g>
+    <rect x="60" y="170" width="250" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
     <rect x="60" y="170" width="250" height="180" rx="22" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
     <rect x="60" y="170" width="8" height="180" rx="4" fill="#0f7ae5"/>
     <text class="box-title" x="90" y="218">앱 모델</text>
@@ -36,7 +37,8 @@
     <text class="box-text" x="90" y="321">정체성은 ID로 유지</text>
   </g>
 
-  <g filter="url(#shadow)">
+  <g>
+    <rect x="395" y="170" width="270" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
     <rect x="395" y="170" width="270" height="180" rx="22" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
     <rect x="395" y="170" width="8" height="180" rx="4" fill="#0f7ae5"/>
     <text class="box-title" x="425" y="218">Snapshot</text>
@@ -45,7 +47,8 @@
     <text class="box-text" x="425" y="321">화면의 목표 상태를 표현</text>
   </g>
 
-  <g filter="url(#shadow)">
+  <g>
+    <rect x="750" y="170" width="290" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
     <rect x="750" y="170" width="290" height="180" rx="22" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
     <rect x="750" y="170" width="8" height="180" rx="4" fill="#0f7ae5"/>
     <text class="box-title" x="780" y="218">Diffable Data Source</text>
@@ -54,7 +57,8 @@
     <text class="box-text" x="780" y="321">item ID로 셀 구성을 요청</text>
   </g>
 
-  <g filter="url(#shadow)">
+  <g>
+    <rect x="1125" y="170" width="215" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
     <rect x="1125" y="170" width="215" height="180" rx="22" fill="#ffffff" stroke="#1675ea" stroke-width="3"/>
     <rect x="1125" y="170" width="8" height="180" rx="4" fill="#1675ea"/>
     <text class="box-title" x="1155" y="218">UICollectionView</text>
@@ -78,7 +82,8 @@
   <rect x="1044" y="229" width="66" height="26" rx="13" fill="#e8f3ff"/>
   <text class="label" x="1077" y="247" text-anchor="middle">차이 반영</text>
 
-  <g filter="url(#shadow)">
+  <g>
+    <rect x="195" y="510" width="390" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
     <rect x="195" y="510" width="390" height="160" rx="22" fill="#ffffff" stroke="#a78bfa" stroke-width="2"/>
     <rect x="195" y="510" width="8" height="160" rx="4" fill="#7c3aed"/>
     <text class="box-title" x="225" y="558">Collection View Layout</text>
@@ -86,7 +91,8 @@
     <text class="box-text" x="225" y="630">셀·헤더의 크기와 위치를 계산</text>
   </g>
 
-  <g filter="url(#shadow)">
+  <g>
+    <rect x="815" y="510" width="390" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
     <rect x="815" y="510" width="390" height="160" rx="22" fill="#ffffff" stroke="#a78bfa" stroke-width="2"/>
     <rect x="815" y="510" width="8" height="160" rx="4" fill="#7c3aed"/>
     <text class="box-title" x="845" y="558">Reusable Cells</text>

--- a/docs/guide/uikit/collection-views/assets/collection-view-roles.svg
+++ b/docs/guide/uikit/collection-views/assets/collection-view-roles.svg
@@ -29,8 +29,9 @@
 
   <g>
     <rect x="60" y="170" width="250" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="60" y="170" width="250" height="180" rx="22" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
-    <rect x="60" y="170" width="8" height="180" rx="4" fill="#0f7ae5"/>
+    <rect x="60" y="170" width="250" height="180" rx="22" fill="#ffffff"/>
+    <path d="M82 170H288Q310 170 310 192V328Q310 350 288 350H82" fill="none" stroke="#cbd5e1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M82 170Q60 170 60 192V328Q60 350 82 350" fill="none" stroke="#0f7ae5" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
     <text class="box-title" x="90" y="218">앱 모델</text>
     <text class="code" x="90" y="254">[Photo.ID: Photo]</text>
     <text class="box-text" x="90" y="294">실제 데이터와 상태를 저장</text>
@@ -39,8 +40,9 @@
 
   <g>
     <rect x="395" y="170" width="270" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="395" y="170" width="270" height="180" rx="22" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
-    <rect x="395" y="170" width="8" height="180" rx="4" fill="#0f7ae5"/>
+    <rect x="395" y="170" width="270" height="180" rx="22" fill="#ffffff"/>
+    <path d="M417 170H643Q665 170 665 192V328Q665 350 643 350H417" fill="none" stroke="#cbd5e1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M417 170Q395 170 395 192V328Q395 350 417 350" fill="none" stroke="#0f7ae5" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
     <text class="box-title" x="425" y="218">Snapshot</text>
     <text class="code" x="425" y="254">Section + Item.ID</text>
     <text class="box-text" x="425" y="294">한 시점의 순서와 포함 관계</text>
@@ -49,8 +51,9 @@
 
   <g>
     <rect x="750" y="170" width="290" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="750" y="170" width="290" height="180" rx="22" fill="#ffffff" stroke="#cbd5e1" stroke-width="2"/>
-    <rect x="750" y="170" width="8" height="180" rx="4" fill="#0f7ae5"/>
+    <rect x="750" y="170" width="290" height="180" rx="22" fill="#ffffff"/>
+    <path d="M772 170H1018Q1040 170 1040 192V328Q1040 350 1018 350H772" fill="none" stroke="#cbd5e1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M772 170Q750 170 750 192V328Q750 350 772 350" fill="none" stroke="#0f7ae5" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
     <text class="box-title" x="780" y="218">Diffable Data Source</text>
     <text class="code" x="780" y="254">apply(snapshot)</text>
     <text class="box-text" x="780" y="294">이전 상태와 차이를 계산</text>
@@ -59,8 +62,9 @@
 
   <g>
     <rect x="1125" y="170" width="215" height="180" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="1125" y="170" width="215" height="180" rx="22" fill="#ffffff" stroke="#1675ea" stroke-width="3"/>
-    <rect x="1125" y="170" width="8" height="180" rx="4" fill="#1675ea"/>
+    <rect x="1125" y="170" width="215" height="180" rx="22" fill="#ffffff"/>
+    <path d="M1147 170H1318Q1340 170 1340 192V328Q1340 350 1318 350H1147" fill="none" stroke="#1675ea" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M1147 170Q1125 170 1125 192V328Q1125 350 1147 350" fill="none" stroke="#1675ea" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
     <text class="box-title" x="1155" y="218">UICollectionView</text>
     <text class="box-text" x="1155" y="260">스크롤·선택 관리</text>
     <text class="box-text" x="1155" y="290">재사용 뷰 요청</text>
@@ -84,8 +88,9 @@
 
   <g>
     <rect x="195" y="510" width="390" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="195" y="510" width="390" height="160" rx="22" fill="#ffffff" stroke="#a78bfa" stroke-width="2"/>
-    <rect x="195" y="510" width="8" height="160" rx="4" fill="#7c3aed"/>
+    <rect x="195" y="510" width="390" height="160" rx="22" fill="#ffffff"/>
+    <path d="M217 510H563Q585 510 585 532V648Q585 670 563 670H217" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M217 510Q195 510 195 532V648Q195 670 217 670" fill="none" stroke="#7c3aed" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
     <text class="box-title" x="225" y="558">Collection View Layout</text>
     <text class="code" x="225" y="594">layoutAttributes</text>
     <text class="box-text" x="225" y="630">셀·헤더의 크기와 위치를 계산</text>
@@ -93,8 +98,9 @@
 
   <g>
     <rect x="815" y="510" width="390" height="160" rx="22" fill="#ffffff" filter="url(#shadow)"/>
-    <rect x="815" y="510" width="390" height="160" rx="22" fill="#ffffff" stroke="#a78bfa" stroke-width="2"/>
-    <rect x="815" y="510" width="8" height="160" rx="4" fill="#7c3aed"/>
+    <rect x="815" y="510" width="390" height="160" rx="22" fill="#ffffff"/>
+    <path d="M837 510H1183Q1205 510 1205 532V648Q1205 670 1183 670H837" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M837 510Q815 510 815 532V648Q815 670 837 670" fill="none" stroke="#7c3aed" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
     <text class="box-title" x="845" y="558">Reusable Cells</text>
     <text class="code" x="845" y="594">CellRegistration</text>
     <text class="box-text" x="845" y="630">현재 item 데이터로 매번 다시 구성</text>

--- a/docs/guide/uikit/collection-views/index.md
+++ b/docs/guide/uikit/collection-views/index.md
@@ -1,11 +1,11 @@
 ---
 title: UIKit Collection Views 한눈에 보기
-description: UICollectionView의 데이터, 셀 재사용, 레이아웃, 선택, 드래그 앤 드롭을 어떤 순서로 학습하고 조합하는지 전체 구조부터 설명합니다.
+description: UICollectionView의 데이터, 셀 재사용, 레이아웃, prefetch, delegate, 선택과 드래그 앤 드롭을 어떤 순서로 조합하는지 전체 구조부터 설명합니다.
 ---
 
 # UIKit Collection Views 한눈에 보기
 
-> **면접 답변 한 줄 요약:** `UICollectionView`는 데이터를 셀로 재사용해 보여 주고, 데이터 소스가 무엇을 표시할지 결정하며 레이아웃 객체가 어디에 배치할지 결정하는 UIKit의 범용 목록 화면이에요.
+> **면접 답변 한 줄 요약:** `UICollectionView`는 데이터 소스와 재사용 셀로 내용을 표시하고, 레이아웃으로 위치를 계산하며, prefetch와 delegate로 데이터 준비와 사용자 상호작용을 연결하는 UIKit의 범용 목록 화면이에요.
 
 사진 격자, 앱스토어처럼 가로로 넘기는 카드가 섞인 화면, 설정 목록은 겉모습이 서로 달라요. 하지만 모두 **반복되는 데이터를 화면 크기에 맞게 배치하고, 스크롤하면서 필요한 뷰만 만들어 쓰는 문제**를 풀어야 해요. UIKit의 Collection View는 이 문제를 데이터, 셀, 레이아웃이라는 역할로 나누어 해결해요.
 
@@ -27,6 +27,7 @@ description: UICollectionView의 데이터, 셀 재사용, 레이아웃, 선택,
 | layout                        | 셀과 헤더의 크기와 위치를 계산하는 객체예요. 데이터 내용이 아니라 화면의 배치를 책임져요.                                                                       |
 | cell                          | item 하나를 화면에 표현하는 재사용 가능한 뷰예요. 보이는 범위를 벗어난 셀은 나중에 다른 item을 표시하는 데 다시 사용될 수 있어요.                               |
 | supplementary·decoration view | supplementary view는 헤더처럼 데이터를 보조하고, decoration view는 section 배경처럼 레이아웃을 꾸며요.                                                          |
+| prefetch                      | 곧 화면에 나타날 item의 데이터가 필요하다는 사실을 미리 알려 네트워크 요청이나 이미지 준비를 일찍 시작하게 하는 기능이에요.                                     |
 | delegate                      | 선택이나 스크롤처럼 Collection View에서 발생한 사건을 전달받는 객체예요. Swift의 Delegation 패턴은 [별도 문서](/guide/design-patterns/delegation)에서 설명해요. |
 
 이 섹션에서는 다음 순서로 Collection Views를 배워요.
@@ -34,24 +35,25 @@ description: UICollectionView의 데이터, 셀 재사용, 레이아웃, 선택,
 1. Collection View를 이루는 역할을 구분해요.
 2. 작은 사진 격자를 화면에 띄워요.
 3. diffable data source와 snapshot으로 데이터를 갱신해요.
-4. 셀 재사용과 상태 구성을 이해해요.
+4. 셀 재사용과 prefetch를 이용한 데이터 준비를 이해해요.
 5. compositional layout으로 배치를 확장해요.
 6. 선택, 다중 선택, 드래그 앤 드롭을 연결해요.
 
-## Collection View는 네 역할을 조합해요
+## Collection View는 역할을 나눠 조합해요
 
-Collection View 화면을 구성할 때 가장 먼저 아래 네 질문을 나눠야 해요.
+Collection View 화면을 구성할 때 가장 먼저 아래 질문을 나눠야 해요.
 
-| 질문                                    | 담당 객체·개념                              |
-| --------------------------------------- | ------------------------------------------- |
-| 어떤 section과 item을 보여 주나요?      | 데이터 모델, snapshot, data source          |
-| item을 어떤 뷰로 표현하나요?            | cell registration, cell, supplementary view |
-| 셀을 어디에 얼마나 크게 배치하나요?     | collection view layout                      |
-| 사용자가 선택하거나 끌면 무엇을 하나요? | delegate, drag delegate, drop delegate      |
+| 질문                                                 | 담당 객체·개념                              |
+| ---------------------------------------------------- | ------------------------------------------- |
+| 어떤 section과 item을 보여 주나요?                   | 데이터 모델, snapshot, data source          |
+| item을 어떤 뷰로 표현하나요?                         | cell registration, cell, supplementary view |
+| 셀을 어디에 얼마나 크게 배치하나요?                  | collection view layout                      |
+| 곧 나타날 item의 데이터를 언제 준비하나요?           | prefetch data source                        |
+| 사용자가 선택하거나 스크롤하거나 끌면 무엇을 하나요? | delegate, drag delegate, drop delegate      |
 
-![데이터 모델과 snapshot, 데이터 소스, Collection View, 레이아웃, 셀의 역할을 연결한 구조도](./assets/collection-view-roles.svg)
+![데이터 모델과 snapshot, 데이터 소스, Collection View, 레이아웃, 재사용 셀, prefetch, delegate의 역할을 연결한 구조도](./assets/collection-view-roles.svg)
 
-화살표를 한 방향으로만 읽을 필요는 없어요. 예를 들어 data source는 item 식별자를 받아 셀을 구성하고, Collection View는 layout이 계산한 위치에 그 셀을 표시해요. 중요한 점은 **데이터의 순서와 화면의 배치를 같은 객체가 모두 책임지지 않는다**는 것이에요.
+화살표를 한 방향으로만 읽을 필요는 없어요. 예를 들어 data source는 item 식별자를 받아 셀을 구성하고, Collection View는 layout이 계산한 위치에 그 셀을 표시해요. 곧 나타날 item은 prefetch data source에 미리 알려 데이터 준비를 시작하고, 선택·표시·스크롤 이벤트는 delegate에 전달해요. 중요한 점은 **데이터의 순서, 화면의 배치, 사전 준비, 사용자 상호작용을 같은 객체가 모두 책임지지 않는다**는 것이에요.
 
 ## 가장 작은 사진 격자를 만들어요
 


### PR DESCRIPTION
## Summary

Collection Views 학습 가이드의 역할 구조도에서 흐릿하거나 겹쳐 보이던 SVG 렌더링을 개선하고, `Prefetch`와 `Delegate`까지 포함한 전체 동작 흐름을 한 화면에 정리합니다.

## Changes

- `collection-view-roles.svg`에 `1400×760` 고유 크기를 명시해 작은 기본 크기로 해석된 이미지를 확대하지 않도록 했습니다.
- 카드 그룹 전체에 적용되던 그림자 필터를 배경 레이어로 분리해 텍스트와 테두리가 래스터화되지 않도록 했습니다.
- 카드의 일반 테두리와 왼쪽 컬러 테두리를 별도 경로로 분리해 두 선이 겹쳐 보이지 않도록 했습니다.
- 구조도 하단을 `Layout`, `Reusable Cells`, `Prefetch`, `Delegate`로 재구성했습니다.
- `UICollectionView`가 위치 정보, 보이는 셀, 표시 전 데이터 준비, 사용자 이벤트를 각 객체에 전달하는 방향을 색상별 화살표로 구분했습니다.
- 한눈에 보기 문서에 prefetch 용어와 역할 질문, 전체 흐름 설명, 접근성 대체 텍스트를 보강했습니다.

## Testing

- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run docs:check-collection-views`
- `xmllint --noout docs/guide/uikit/collection-views/assets/collection-view-roles.svg`
- Rspress 개발 화면과 SVG 원본 화면에서 카드, 타입명, 화살표 및 컬러 테두리 렌더링 확인

## Related Issues

Closes #7

## References

- [UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)
- [UICollectionViewDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdelegate)
- [UICollectionViewDataSourcePrefetching](https://developer.apple.com/documentation/uikit/uicollectionviewdatasourceprefetching)

## Notes

- 구조도는 SVG 형식을 유지하며 별도의 래스터 이미지나 빌드 산출물은 추가하지 않습니다.
