### PR TITLE
[#11] UICollectionView 실전 예제 학습 문서를 추가한다

### DIFF
--- a/docs/guide/uikit/collection-views/_meta.json
+++ b/docs/guide/uikit/collection-views/_meta.json
@@ -50,6 +50,130 @@
   },
   {
     "type": "custom-link",
+    "label": "예제",
+    "link": "/guide/uikit/collection-views/examples/index",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "예제 한눈에 보기",
+        "link": "/guide/uikit/collection-views/examples/index"
+      },
+      {
+        "type": "custom-link",
+        "label": "Data Source",
+        "collapsible": true,
+        "collapsed": true,
+        "items": [
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewDataSource",
+            "link": "/guide/uikit/collection-views/examples/data-source"
+          },
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewDiffableDataSource",
+            "link": "/guide/uikit/collection-views/examples/diffable-data-source"
+          },
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewDataSourcePrefetching",
+            "link": "/guide/uikit/collection-views/examples/data-source-prefetching"
+          }
+        ]
+      },
+      {
+        "type": "custom-link",
+        "label": "Delegate",
+        "collapsible": true,
+        "collapsed": true,
+        "items": [
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewDelegate",
+            "collapsible": true,
+            "collapsed": true,
+            "items": [
+              {
+                "type": "custom-link",
+                "label": "전통적인 방식",
+                "link": "/guide/uikit/collection-views/examples/traditional-delegate"
+              },
+              {
+                "type": "custom-link",
+                "label": "현대적인 방식",
+                "link": "/guide/uikit/collection-views/examples/modern-delegate"
+              }
+            ]
+          },
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewDelegateFlowLayout",
+            "link": "/guide/uikit/collection-views/examples/flow-layout-delegate"
+          },
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewDragDelegate",
+            "link": "/guide/uikit/collection-views/examples/drag-delegate"
+          },
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewDropDelegate",
+            "link": "/guide/uikit/collection-views/examples/drop-delegate"
+          }
+        ]
+      },
+      {
+        "type": "custom-link",
+        "label": "Layout",
+        "collapsible": true,
+        "collapsed": true,
+        "items": [
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewFlowLayout",
+            "link": "/guide/uikit/collection-views/examples/flow-layout"
+          },
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewCompositionalLayout",
+            "collapsible": true,
+            "collapsed": true,
+            "items": [
+              {
+                "type": "custom-link",
+                "label": "기본 예제",
+                "link": "/guide/uikit/collection-views/examples/compositional-layout"
+              },
+              {
+                "type": "custom-link",
+                "label": "List Layout",
+                "link": "/guide/uikit/collection-views/examples/list-layout"
+              }
+            ]
+          },
+          {
+            "type": "custom-link",
+            "label": "Custom UICollectionViewLayout",
+            "link": "/guide/uikit/collection-views/examples/custom-layout"
+          },
+          {
+            "type": "custom-link",
+            "label": "UICollectionViewTransitionLayout",
+            "link": "/guide/uikit/collection-views/examples/transition-layout"
+          }
+        ]
+      },
+      {
+        "type": "custom-link",
+        "label": "실무 확장 예제",
+        "link": "/guide/uikit/collection-views/examples/practical-recipes"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
     "label": "뷰",
     "collapsible": true,
     "collapsed": true,

--- a/docs/guide/uikit/collection-views/examples/compositional-layout.md
+++ b/docs/guide/uikit/collection-views/examples/compositional-layout.md
@@ -1,0 +1,456 @@
+---
+title: 'UICollectionViewCompositionalLayout 예제'
+description: 'UICollectionViewCompositionalLayout의 item·group·section을 조합해 가로 추천 카드와 반응형 사진 격자, section header를 하나의 Collection View에 구현합니다.'
+---
+
+# UICollectionViewCompositionalLayout 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewCompositionalLayout`은 item을 group으로, group을 section으로 조합해 section마다 서로 다른 크기·간격·스크롤 방식을 선언하는 Collection View layout이에요.
+
+이 예제에서는 `추천 사진`을 가로로 넘기는 큰 카드로, `모든 사진`을 화면 너비에 따라 열 수가 바뀌는 격자로 만들어요. Data source는 snapshot으로 여러 section을 표현하기 쉬운 Diffable Data Source를 사용해요.
+
+## 먼저 알아둘 용어
+
+| 용어                        | 쉬운 뜻                                                                         |
+| --------------------------- | ------------------------------------------------------------------------------- |
+| item                        | 셀 하나가 차지하는 가장 작은 layout 단위예요.                                   |
+| group                       | 하나 이상의 item이나 하위 group을 가로·세로로 묶는 단위예요.                    |
+| section                     | group을 반복하고 inset, header, 가로 스크롤 같은 정책을 정하는 단위예요.        |
+| fractional dimension        | 바로 바깥 컨테이너 크기에 대한 비율로 너비나 높이를 정하는 값이에요.            |
+| layout environment          | 현재 container의 유효 크기와 trait 정보를 section provider에 전달하는 값이에요. |
+| orthogonal scrolling        | 전체 세로 스크롤과 직각인 가로 방향으로 특정 section만 움직이는 방식이에요.     |
+| boundary supplementary item | section 경계에 놓는 header나 footer의 layout 정보예요.                          |
+
+## 화면 section과 item 식별자를 정의해요
+
+```swift
+private enum GallerySection: Int, CaseIterable {
+  case featured
+  case library
+
+  var title: String {
+    switch self {
+    case .featured:
+      return "추천 사진"
+    case .library:
+      return "모든 사진"
+    }
+  }
+}
+
+private enum GalleryItemID: Hashable {
+  case featured(Photo.ID)
+  case library(Photo.ID)
+
+  var photoID: Photo.ID {
+    switch self {
+    case let .featured(id), let .library(id):
+      return id
+    }
+  }
+}
+```
+
+하나의 사진을 추천 section과 전체 section에 동시에 표시하려면 snapshot 안의 item identifier는 서로 달라야 해요. 모델 ID에 화면 역할을 더한 `GalleryItemID`를 사용하면 같은 `Photo`를 두 위치에 표현할 수 있어요.
+
+## 공통 header layout을 만들어요
+
+```swift
+private func makeSectionHeader()
+  -> NSCollectionLayoutBoundarySupplementaryItem
+{
+  let size = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .estimated(52)
+  )
+
+  return NSCollectionLayoutBoundarySupplementaryItem(
+    layoutSize: size,
+    elementKind: UICollectionView.elementKindSectionHeader,
+    alignment: .top
+  )
+}
+```
+
+Layout은 header가 차지할 위치와 크기만 요청해요. 실제 재사용 뷰는 뒤에서 supplementary registration으로 제공해요.
+
+## 추천 사진을 가로 카드로 만들어요
+
+```swift
+private func makeFeaturedSection()
+  -> NSCollectionLayoutSection
+{
+  let itemSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .fractionalHeight(1)
+  )
+  let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+  let groupSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(0.82),
+    heightDimension: .absolute(220)
+  )
+  let group = NSCollectionLayoutGroup.horizontal(
+    layoutSize: groupSize,
+    subitems: [item]
+  )
+
+  let section = NSCollectionLayoutSection(group: group)
+  section.orthogonalScrollingBehavior = .groupPagingCentered
+  section.interGroupSpacing = 12
+  section.contentInsets = NSDirectionalEdgeInsets(
+    top: 8,
+    leading: 16,
+    bottom: 24,
+    trailing: 16
+  )
+  section.boundarySupplementaryItems = [
+    makeSectionHeader(),
+  ]
+  return section
+}
+```
+
+전체 Collection View는 세로로 스크롤하지만 `.featured` section만 가로로 움직여요. `.groupPagingCentered`는 한 번 넘길 때 group 단위로 이동하고 가운데에 맞춰요.
+
+Group 너비를 container의 82%로 정했기 때문에 다음 카드 일부가 보여 가로로 더 넘길 수 있다는 단서를 줘요.
+
+## 모든 사진을 반응형 격자로 만들어요
+
+```swift
+private func makeLibrarySection(
+  environment: NSCollectionLayoutEnvironment
+) -> NSCollectionLayoutSection {
+  let width =
+    environment.container.effectiveContentSize.width
+  let columnCount: Int
+
+  switch width {
+  case 900...:
+    columnCount = 5
+  case 600...:
+    columnCount = 3
+  default:
+    columnCount = 2
+  }
+
+  let itemSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .fractionalHeight(1)
+  )
+  let item = NSCollectionLayoutItem(layoutSize: itemSize)
+  item.contentInsets = NSDirectionalEdgeInsets(
+    top: 6,
+    leading: 6,
+    bottom: 6,
+    trailing: 6
+  )
+
+  let groupSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .fractionalWidth(
+      1 / CGFloat(columnCount)
+    )
+  )
+  let group = NSCollectionLayoutGroup.horizontal(
+    layoutSize: groupSize,
+    subitem: item,
+    count: columnCount
+  )
+
+  let section = NSCollectionLayoutSection(group: group)
+  section.contentInsets = NSDirectionalEdgeInsets(
+    top: 8,
+    leading: 10,
+    bottom: 24,
+    trailing: 10
+  )
+  section.boundarySupplementaryItems = [
+    makeSectionHeader(),
+  ]
+  return section
+}
+```
+
+`effectiveContentSize`를 기준으로 열 수를 고르면 화면 회전, Split View, 창 크기 변경에 대응할 수 있어요. 기기 모델을 기준으로 분기하지 않아도 돼요.
+
+item의 `.fractionalWidth(1)`은 Collection View 전체가 아니라 자신이 들어 있는 group 너비 전체를 뜻해요.
+
+예제는 iOS 15 지원을 위해 `horizontal(layoutSize:subitem:count:)`를 사용해요. iOS 16 이상만 지원한다면 같은 의미의 `horizontal(layoutSize:repeatingSubitem:count:)`를 사용할 수 있어요.
+
+## Section provider에서 배치를 선택해요
+
+```swift
+private func makeGalleryLayout()
+  -> UICollectionViewCompositionalLayout
+{
+  let configuration =
+    UICollectionViewCompositionalLayoutConfiguration()
+  configuration.interSectionSpacing = 16
+
+  return UICollectionViewCompositionalLayout(
+    sectionProvider: { sectionIndex, environment in
+      guard let section = GallerySection(
+        rawValue: sectionIndex
+      ) else {
+        return nil
+      }
+
+      switch section {
+      case .featured:
+        return makeFeaturedSection()
+      case .library:
+        return makeLibrarySection(
+          environment: environment
+        )
+      }
+    },
+    configuration: configuration
+  )
+}
+```
+
+이 예제는 snapshot에 항상 `.featured`, `.library` 순서로 section을 추가하므로 raw value로 layout을 선택해요. section 순서가 동적으로 바뀐다면 현재 snapshot의 section identifier를 조회해 layout을 결정하세요.
+
+## Header 재사용 뷰를 만들어요
+
+```swift
+final class GalleryHeaderView: UICollectionReusableView {
+  private let titleLabel = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    titleLabel.font = .preferredFont(forTextStyle: .title2)
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(titleLabel)
+
+    NSLayoutConstraint.activate([
+      titleLabel.topAnchor.constraint(
+        equalTo: topAnchor,
+        constant: 8
+      ),
+      titleLabel.leadingAnchor.constraint(
+        equalTo: leadingAnchor,
+        constant: 16
+      ),
+      titleLabel.trailingAnchor.constraint(
+        lessThanOrEqualTo: trailingAnchor,
+        constant: -16
+      ),
+      titleLabel.bottomAnchor.constraint(
+        equalTo: bottomAnchor,
+        constant: -8
+      ),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+
+  func configure(title: String) {
+    titleLabel.text = title
+  }
+}
+```
+
+Header도 셀과 마찬가지로 재사용되므로 구성 메서드가 현재 section의 모든 표시 상태를 덮어써야 해요.
+
+## View Controller와 Diffable Data Source를 연결해요
+
+아래 코드는 [공통 `PhotoCell`](./index)을 사용해요.
+
+```swift
+@MainActor
+final class CompositionalPhotoGalleryViewController:
+  UIViewController
+{
+  private var photosByID: [Photo.ID: Photo] = [:]
+  private var dataSource:
+    UICollectionViewDiffableDataSource<
+      GallerySection,
+      GalleryItemID
+    >!
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGalleryLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    configureCollectionView()
+    configureDataSource()
+    show(Photo.samples)
+  }
+
+  private func configureCollectionView() {
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+}
+```
+
+## Cell과 header registration을 구성해요
+
+```swift
+extension CompositionalPhotoGalleryViewController {
+  private func configureDataSource() {
+    let cellRegistration = UICollectionView.CellRegistration<
+      PhotoCell,
+      GalleryItemID
+    > { [weak self] cell, _, itemID in
+      guard let photo = self?.photosByID[itemID.photoID] else {
+        return
+      }
+      cell.configure(with: photo)
+    }
+
+    dataSource = UICollectionViewDiffableDataSource(
+      collectionView: collectionView
+    ) { collectionView, indexPath, itemID in
+      collectionView.dequeueConfiguredReusableCell(
+        using: cellRegistration,
+        for: indexPath,
+        item: itemID
+      )
+    }
+
+    let headerRegistration =
+      UICollectionView.SupplementaryRegistration<
+        GalleryHeaderView
+      >(
+        elementKind:
+          UICollectionView.elementKindSectionHeader
+      ) { [weak self] header, _, indexPath in
+        guard let section = self?.dataSource.sectionIdentifier(
+          for: indexPath.section
+        ) else {
+          return
+        }
+        header.configure(title: section.title)
+      }
+
+    dataSource.supplementaryViewProvider = {
+      collectionView,
+      _,
+      indexPath in
+
+      collectionView.dequeueConfiguredReusableSupplementary(
+        using: headerRegistration,
+        for: indexPath
+      )
+    }
+  }
+}
+```
+
+Supplementary Registration은 provider 안에서 매번 만들지 않고 provider 밖에서 한 번 만들어요. iOS 15 이상에서는 provider 안에서 생성하면 재사용을 막고 예외가 발생할 수 있어요.
+
+## 여러 section의 snapshot을 적용해요
+
+```swift
+extension CompositionalPhotoGalleryViewController {
+  private func show(_ photos: [Photo]) {
+    photosByID = Dictionary(
+      uniqueKeysWithValues: photos.map { ($0.id, $0) }
+    )
+
+    let featuredIDs = photos.prefix(3).map {
+      GalleryItemID.featured($0.id)
+    }
+    let libraryIDs = photos.map {
+      GalleryItemID.library($0.id)
+    }
+
+    var snapshot = NSDiffableDataSourceSnapshot<
+      GallerySection,
+      GalleryItemID
+    >()
+    snapshot.appendSections([.featured, .library])
+    snapshot.appendItems(
+      featuredIDs,
+      toSection: .featured
+    )
+    snapshot.appendItems(
+      libraryIDs,
+      toSection: .library
+    )
+    dataSource.apply(
+      snapshot,
+      animatingDifferences: false
+    )
+  }
+}
+```
+
+Layout의 section 순서와 snapshot의 section 순서가 같아야 해요. 추천 사진을 전체 격자에도 표시하기 위해 서로 다른 `GalleryItemID` case를 사용했으므로 snapshot identifier 중복도 발생하지 않아요.
+
+## 한 section만 고정 header로 바꿔요
+
+```swift
+let header = makeSectionHeader()
+header.pinToVisibleBounds = true
+header.zIndex = 2
+section.boundarySupplementaryItems = [header]
+```
+
+`pinToVisibleBounds`를 켜면 해당 section이 보이는 동안 header가 화면 경계에 머물러요. 여러 고정 header가 겹치지 않는지 실제 스크롤로 확인하세요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                     | 먼저 확인할 것                                                             |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| 다른 section의 layout이 적용돼요.        | section provider index와 snapshot section 순서가 같은지 확인해요.          |
+| 같은 사진을 두 section에 넣을 수 없어요. | 화면 역할을 포함한 별도 item identifier를 사용했는지 확인해요.             |
+| Header가 나타나지 않아요.                | boundary item과 supplementary provider를 모두 설정했는지 확인해요.         |
+| 격자 높이가 예상과 달라요.               | fractional dimension이 바로 바깥 container를 기준으로 계산되는지 확인해요. |
+| 가로 스크롤 제스처가 불편해요.           | 카드 너비와 paging 방식, 셀 내부 제스처 충돌을 실제 기기에서 확인해요.     |
+
+## 언제 Compositional Layout을 사용해야 하나요
+
+- section마다 목록, 격자, 큰 카드처럼 배치가 다를 때 잘 맞아요.
+- 세로 화면 안에 가로 스크롤 section을 넣을 때 중첩 Collection View를 줄일 수 있어요.
+- 모든 section이 같은 두 열 격자라면 [Flow Layout](./flow-layout)이 더 짧고 읽기 쉬울 수 있어요.
+- 작은 화면에서도 item, group, section 객체가 많아질 수 있으므로 layout helper를 역할별로 나눠 이름을 붙이세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Item, group, section의 관계를 설명해 주세요.
+
+Item은 셀 하나의 배치 단위이고, group은 item을 가로·세로 또는 사용자 정의 방식으로 묶어요. Section은 group을 반복하며 inset, header, 가로 스크롤처럼 구역 전체의 정책을 정해요.
+
+### 같은 모델을 두 section에 표시할 때 왜 별도 identifier가 필요한가요?
+
+Diffable snapshot 안에서 item identifier는 유일해야 하기 때문이에요. 같은 `Photo.ID`에 `featured`와 `library`라는 화면 역할을 더하면 모델은 같아도 서로 다른 화면 item으로 표현할 수 있어요.
+
+## 함께 읽으면 좋아요
+
+Compositional Layout의 여러 section에서 선택한 item을 안정적인 모델 ID로 해석하는 방법은 [현대적인 `UICollectionViewDelegate` 예제](./modern-delegate)에서 이어서 확인할 수 있어요.
+
+설정 화면처럼 표준 목록이 필요하다면 [Collection View List Layout 예제](./list-layout)에서 list cell, accessory와 swipe action을 연결해 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewCompositionalLayout](https://developer.apple.com/documentation/uikit/uicollectionviewcompositionallayout)
+- [Apple Developer Documentation — Implementing modern collection views](https://developer.apple.com/documentation/uikit/implementing-modern-collection-views)
+- [Apple Developer Documentation — UICollectionView.SupplementaryRegistration](https://developer.apple.com/documentation/uikit/uicollectionview/supplementaryregistration)

--- a/docs/guide/uikit/collection-views/examples/custom-layout.md
+++ b/docs/guide/uikit/collection-views/examples/custom-layout.md
@@ -1,0 +1,258 @@
+---
+title: 'Custom UICollectionViewLayout 예제'
+description: 'UICollectionViewLayout을 상속한 태그 배치 예제로 prepare·contentSize·layout attributes·bounds invalidation의 책임과 성능 최적화 기준을 단계별로 설명합니다.'
+---
+
+# Custom UICollectionViewLayout 예제
+
+> **면접 답변 한 줄 요약:** Custom `UICollectionViewLayout`은 Collection View가 셀을 직접 배치하도록 만드는 것이 아니라, 각 item의 frame과 표시 속성을 `UICollectionViewLayoutAttributes`로 계산해 제공하는 layout 객체예요.
+
+Flow Layout이나 Compositional Layout으로 요구사항을 표현할 수 있다면 먼저 그 방법을 선택하세요. 이 문서는 너비가 다른 태그를 왼쪽부터 배치하고 남은 공간이 부족하면 다음 줄로 넘기는 작은 custom layout을 만들어요.
+
+## 먼저 알아둘 용어
+
+| 용어              | 쉬운 뜻                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| layout attributes | Item의 frame, 중심점, alpha, z-index처럼 화면 배치에 필요한 정보를 담는 객체예요.     |
+| `prepare()`       | Layout이 invalidation된 뒤 필요한 attributes와 content size를 미리 계산하는 단계예요. |
+| content size      | Collection View 안에서 스크롤할 수 있는 전체 콘텐츠 너비와 높이예요.                  |
+| invalidation      | 기존 배치 정보가 오래되었으니 필요한 부분을 다시 계산하라고 알리는 동작이에요.        |
+| query rect        | Collection View가 현재 화면 주변에서 필요한 attributes를 요청하는 사각형 영역이에요.  |
+
+## Layout이 필요한 너비를 Delegate로 받아요
+
+```swift
+protocol TagCloudLayoutDelegate: AnyObject {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    widthForItemAt indexPath: IndexPath
+  ) -> CGFloat
+}
+```
+
+Layout은 셀이나 모델을 직접 만들지 않아요. 화면이 알고 있는 제목 길이를 너비로 계산해 delegate를 통해 제공하게 해 책임을 나눠요.
+
+## Attributes Cache와 기본 값을 준비해요
+
+```swift
+final class TagCloudLayout: UICollectionViewLayout {
+  weak var delegate: (any TagCloudLayoutDelegate)?
+
+  var itemHeight: CGFloat = 44
+  var horizontalSpacing: CGFloat = 8
+  var verticalSpacing: CGFloat = 10
+  var sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+
+  private var cachedAttributes: [
+    UICollectionViewLayoutAttributes
+  ] = []
+  private var contentHeight: CGFloat = 0
+}
+```
+
+Attributes는 자주 요청되므로 `prepare()`에서 계산해 cache에 보관해요. Layout 프로퍼티가 바뀐다면 `invalidateLayout()`을 호출해 cache를 다시 계산하게 해야 해요.
+
+## `prepare()`에서 모든 Item Frame을 계산해요
+
+```swift
+override func prepare() {
+  super.prepare()
+
+  guard let collectionView else {
+    return
+  }
+
+  cachedAttributes.removeAll(keepingCapacity: true)
+
+  let availableMaxX =
+    collectionView.bounds.width
+    - collectionView.adjustedContentInset.left
+    - collectionView.adjustedContentInset.right
+    - sectionInset.right
+  var x = sectionInset.left
+  var y = sectionInset.top
+
+  for section in 0..<collectionView.numberOfSections {
+    for item in 0..<collectionView.numberOfItems(
+      inSection: section
+    ) {
+      let indexPath = IndexPath(
+        item: item,
+        section: section
+      )
+      let requestedWidth = delegate?.collectionView(
+        collectionView,
+        widthForItemAt: indexPath
+      ) ?? 80
+      let maximumWidth = max(
+        availableMaxX - sectionInset.left,
+        1
+      )
+      let width = min(max(requestedWidth, 1), maximumWidth)
+
+      if x + width > availableMaxX,
+        x > sectionInset.left
+      {
+        x = sectionInset.left
+        y += itemHeight + verticalSpacing
+      }
+
+      let attributes = UICollectionViewLayoutAttributes(
+        forCellWith: indexPath
+      )
+      attributes.frame = CGRect(
+        x: x,
+        y: y,
+        width: width,
+        height: itemHeight
+      )
+      cachedAttributes.append(attributes)
+
+      x += width + horizontalSpacing
+    }
+
+    x = sectionInset.left
+    y += itemHeight + sectionInset.bottom
+  }
+
+  contentHeight = y
+}
+```
+
+요청된 너비가 한 줄보다 크면 표시 가능한 최대 너비로 제한해요. 여러 section을 지원한다면 section 사이 inset과 header 공간을 요구사항에 맞게 더 정교하게 계산하세요.
+
+## Content Size와 Attributes를 제공해요
+
+```swift
+override var collectionViewContentSize: CGSize {
+  guard let collectionView else {
+    return .zero
+  }
+
+  return CGSize(
+    width: collectionView.bounds.width,
+    height: max(
+      contentHeight,
+      collectionView.bounds.height
+    )
+  )
+}
+
+override func layoutAttributesForElements(
+  in rect: CGRect
+) -> [UICollectionViewLayoutAttributes]? {
+  cachedAttributes.filter {
+    $0.frame.intersects(rect)
+  }
+}
+
+override func layoutAttributesForItem(
+  at indexPath: IndexPath
+) -> UICollectionViewLayoutAttributes? {
+  cachedAttributes.first {
+    $0.indexPath == indexPath
+  }
+}
+```
+
+Collection View는 화면 주변의 `rect`와 특정 `IndexPath` 두 방식으로 정보를 요청해요. 데이터가 매우 많다면 매번 전체 cache를 선형 검색하지 말고 y 좌표로 범위를 좁히거나 section별 index를 두세요.
+
+## 화면 너비가 바뀔 때만 다시 계산해요
+
+```swift
+override func shouldInvalidateLayout(
+  forBoundsChange newBounds: CGRect
+) -> Bool {
+  guard let collectionView else {
+    return false
+  }
+
+  return newBounds.width
+    != collectionView.bounds.width
+}
+```
+
+세로 스크롤에서 origin만 바뀔 때는 frame을 다시 계산할 필요가 없어요. 회전이나 Split View로 너비가 바뀌면 줄바꿈 위치가 달라지므로 layout을 invalidation해요.
+
+## View Controller에서 모델 너비를 계산해요
+
+```swift
+extension TagCloudViewController:
+  TagCloudLayoutDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    widthForItemAt indexPath: IndexPath
+  ) -> CGFloat {
+    let title = tags[indexPath.item]
+    let font = UIFont.preferredFont(
+      forTextStyle: .body
+    )
+    let textWidth = (title as NSString).size(
+      withAttributes: [.font: font]
+    ).width
+
+    return ceil(textWidth) + 32
+  }
+}
+```
+
+```swift
+private func makeCollectionView() -> UICollectionView {
+  let layout = TagCloudLayout()
+  layout.delegate = self
+
+  return UICollectionView(
+    frame: .zero,
+    collectionViewLayout: layout
+  )
+}
+```
+
+Dynamic Type가 바뀌면 글꼴과 item 너비도 바뀌므로 layout을 invalidation하세요.
+
+## Custom Layout을 선택하기 전에 비교해요
+
+| 요구사항                                  | 먼저 검토할 API                       |
+| ----------------------------------------- | ------------------------------------- |
+| 균일한 목록·격자                          | `UICollectionViewFlowLayout`          |
+| Section별 카드·가로 스크롤·복합 배치      | `UICollectionViewCompositionalLayout` |
+| 표준 설정 목록                            | Collection View List Layout           |
+| 기존 layout으로 표현하기 어려운 배치 규칙 | Custom `UICollectionViewLayout`       |
+
+Custom Layout은 계산·invalidation·삽입 삭제 animation·접근성·성능까지 직접 책임져야 해요. 단순히 셀 크기만 조금 다르다면 Flow Layout delegate나 Compositional Layout의 estimated dimension이 더 적합할 수 있어요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                | 먼저 확인할 것                                                                |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| 셀이 나타나지 않아요.               | Content size와 attributes 메서드가 유효한 frame을 반환하는지 확인해요.        |
+| 스크롤할수록 느려져요.              | Query rect 요청마다 모든 item을 다시 계산하거나 전체 cache를 검색하는지 봐요. |
+| 회전 뒤 줄바꿈이 이전 그대로예요.   | 너비 변경에서 layout을 invalidation하고 cache를 다시 만드는지 확인해요.       |
+| 삽입 뒤 기존 attributes가 어긋나요. | `prepare()`에서 오래된 cache를 비우고 현재 item 개수로 다시 계산하는지 봐요.  |
+| 큰 item이 화면 밖으로 나가요.       | Delegate가 준 너비를 실제 표시 가능한 너비로 제한하는지 확인해요.             |
+
+## 면접에서 이어질 수 있는 질문
+
+### Custom Layout의 필수 책임은 무엇인가요?
+
+Content size와 화면 영역·특정 item에 대한 layout attributes를 제공해야 해요. 보통 `prepare()`, `collectionViewContentSize`, `layoutAttributesForElements(in:)`, `layoutAttributesForItem(at:)`, bounds 변경 invalidation을 구현해요.
+
+### 셀은 Layout이 생성하나요?
+
+아니요. Data Source가 셀을 생성하고 구성하며, Layout은 해당 셀의 위치와 크기 같은 attributes만 계산해요. 이 책임을 분리해야 layout을 바꿔도 같은 데이터와 셀을 재사용할 수 있어요.
+
+## 다음 예제로 이동해요
+
+Custom layout과 다른 layout 사이를 gesture로 전환하려면 [`UICollectionViewTransitionLayout` 예제](./transition-layout)를 읽어 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewLayout](https://developer.apple.com/documentation/uikit/uicollectionviewlayout)
+- [Apple Developer Documentation — Customizing collection view layouts](https://developer.apple.com/documentation/uikit/customizing-collection-view-layouts)
+- [Apple Developer Documentation — UICollectionViewLayoutAttributes](https://developer.apple.com/documentation/uikit/uicollectionviewlayoutattributes)

--- a/docs/guide/uikit/collection-views/examples/data-source-prefetching.md
+++ b/docs/guide/uikit/collection-views/examples/data-source-prefetching.md
@@ -1,0 +1,211 @@
+---
+title: 'UICollectionViewDataSourcePrefetching 예제'
+description: 'UICollectionViewDataSourcePrefetching으로 곧 표시될 이미지 작업을 미리 시작하고, 모델 ID를 기준으로 중복 요청·취소·셀 재사용을 안전하게 처리합니다.'
+---
+
+# UICollectionViewDataSourcePrefetching 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewDataSourcePrefetching`은 곧 필요할 데이터의 위치를 미리 알려 주어 비동기 로딩을 앞당기되, 실제 셀 구성은 prefetch 성공 여부와 관계없이 동작하게 만드는 프로토콜이에요.
+
+이 문서는 [공통 사진 모델](./index)과 Data Source 예제에 원격 썸네일 로딩을 추가해요. Prefetch는 전통적인 `UICollectionViewDataSource`와 `UICollectionViewDiffableDataSource` 양쪽에서 사용할 수 있어요.
+
+## 먼저 알아둘 용어
+
+| 용어           | 쉬운 뜻                                                                      |
+| -------------- | ---------------------------------------------------------------------------- |
+| prefetch       | 화면에 나타나기 전에 필요할 가능성이 높은 데이터를 미리 준비하는 작업이에요. |
+| cache          | 이미 만든 결과를 다시 사용하기 위해 메모리나 디스크에 저장하는 공간이에요.   |
+| in-flight task | 시작했지만 아직 끝나지 않은 비동기 작업이에요.                               |
+| cancellation   | 더 이상 필요하지 않은 작업에 중단을 요청해 자원 낭비를 줄이는 동작이에요.    |
+| best effort    | 호출이 반드시 보장되지는 않으므로 성능 최적화로만 사용해야 한다는 뜻이에요.  |
+
+## Prefetch Data Source를 연결해요
+
+```swift
+override func viewDidLoad() {
+  super.viewDidLoad()
+
+  collectionView.prefetchDataSource = self
+}
+```
+
+`prefetchDataSource`는 item 개수와 셀을 제공하는 `dataSource`와 다른 역할이에요. Data Source가 화면에 필요한 셀을 제공한다면, prefetch data source는 앞으로 필요할 가능성이 있는 데이터 작업을 미리 시작해요.
+
+## 이미지 작업을 ID로 관리해요
+
+`IndexPath`는 삽입·삭제·정렬 뒤 달라질 수 있으므로 장기 작업의 key로 사용하지 않아요. Callback을 받은 즉시 `Photo.ID`와 URL로 바꿔요.
+
+```swift
+@MainActor
+final class PhotoThumbnailStore {
+  private let cache = NSCache<NSUUID, UIImage>()
+  private var tasks: [Photo.ID: Task<Void, Never>] = [:]
+
+  func cachedImage(for id: Photo.ID) -> UIImage? {
+    cache.object(forKey: id as NSUUID)
+  }
+
+  func prepare(id: Photo.ID, url: URL) {
+    guard cachedImage(for: id) == nil else {
+      return
+    }
+    guard tasks[id] == nil else {
+      return
+    }
+
+    tasks[id] = Task { [weak self] in
+      guard let self else {
+        return
+      }
+
+      defer {
+        tasks[id] = nil
+      }
+
+      do {
+        let (data, _) = try await URLSession.shared.data(
+          from: url
+        )
+        try Task.checkCancellation()
+
+        if let image = UIImage(data: data) {
+          cache.setObject(image, forKey: id as NSUUID)
+        }
+      } catch is CancellationError {
+        // 화면에서 멀어져 취소된 정상 흐름이에요.
+      } catch {
+        print("썸네일 준비 실패: \(error)")
+      }
+    }
+  }
+
+  func cancel(id: Photo.ID) {
+    tasks[id]?.cancel()
+  }
+}
+```
+
+같은 ID의 작업이 이미 진행 중이거나 cache에 결과가 있으면 새 요청을 만들지 않아요. 취소할 때 dictionary에서 즉시 제거하지 않는 이유는 취소된 task가 `defer`에서 스스로 정리되기 전에 같은 ID의 새 task가 등록되어 덮어써지는 경쟁을 피하기 위해서예요. 실제 앱에서는 URL 응답 상태와 MIME type도 검증하고, 화면을 다시 열어도 유지해야 한다면 디스크 cache를 함께 고려하세요.
+
+## Callback에서 모델 ID와 URL을 찾아요
+
+예제 view controller가 ID별 이미지 URL을 가진다고 가정해요.
+
+```swift
+private let thumbnailStore = PhotoThumbnailStore()
+private var imageURLsByID: [Photo.ID: URL] = [:]
+```
+
+전통적인 배열 기반 Data Source에서는 현재 배열을 조회해요.
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDataSourcePrefetching
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    prefetchItemsAt indexPaths: [IndexPath]
+  ) {
+    for indexPath in indexPaths {
+      guard photos.indices.contains(indexPath.item) else {
+        continue
+      }
+
+      let id = photos[indexPath.item].id
+      guard let url = imageURLsByID[id] else {
+        continue
+      }
+      thumbnailStore.prepare(id: id, url: url)
+    }
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cancelPrefetchingForItemsAt indexPaths: [IndexPath]
+  ) {
+    for indexPath in indexPaths {
+      guard photos.indices.contains(indexPath.item) else {
+        continue
+      }
+      thumbnailStore.cancel(id: photos[indexPath.item].id)
+    }
+  }
+}
+```
+
+Diffable Data Source에서는 배열 위치 대신 현재 snapshot의 identifier를 조회해요.
+
+```swift
+private func photoID(
+  at indexPath: IndexPath
+) -> Photo.ID? {
+  dataSource.itemIdentifier(for: indexPath)
+}
+```
+
+Prefetch와 취소 callback 모두 이 helper로 ID를 찾으면 돼요.
+
+## 셀 구성은 Prefetch 없이도 동작해야 해요
+
+Prefetch callback은 모든 item에 대해 호출된다고 보장되지 않아요. 셀 구성 시 cache miss가 발생하면 그 자리에서 같은 로딩 경로를 시작해야 해요.
+
+```swift
+func configureThumbnail(
+  for cell: RemotePhotoCell,
+  photoID: Photo.ID
+) {
+  cell.representedPhotoID = photoID
+
+  if let image = thumbnailStore.cachedImage(
+    for: photoID
+  ) {
+    cell.setThumbnail(image)
+    return
+  }
+
+  cell.setPlaceholder()
+
+  guard let url = imageURLsByID[photoID] else {
+    return
+  }
+  thumbnailStore.prepare(id: photoID, url: url)
+}
+```
+
+비동기 결과를 셀에 직접 전달한다면 완료 시점에 `representedPhotoID`가 여전히 같은 ID인지 확인하세요. 셀은 재사용되므로 요청을 시작한 위치만 기억하면 다른 사진에 이전 이미지가 들어갈 수 있어요.
+
+## 취소는 Cache 삭제가 아니에요
+
+`cancelPrefetchingForItemsAt`은 화면에서 멀어진 작업을 줄일 기회예요. 이미 완성된 cache까지 지우라는 뜻은 아니에요. 또한 같은 ID를 보이는 다른 셀이 작업 결과를 기다릴 수 있다면 단순히 하나의 취소 callback만으로 공유 작업을 중단하면 안 돼요.
+
+실무에서는 다음 중 하나를 선택해요.
+
+- 화면 전용 작업이면 ID별 task를 바로 취소해요.
+- 여러 소비자가 공유한다면 참조 수나 subscriber를 관리해 마지막 소비자가 사라질 때 취소해요.
+- HTTP cache와 이미지 pipeline이 중복·취소를 관리한다면 prefetch callback에서 해당 라이브러리 API를 호출해요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                  | 먼저 확인할 것                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------------------- |
+| 같은 이미지가 여러 번 다운로드돼요.   | cache와 진행 중 task를 ID 기준으로 함께 확인하는지 봐요.                        |
+| 스크롤 뒤 다른 이미지가 나타나요.     | 셀의 현재 ID와 완료된 요청의 ID를 비교하는지 확인해요.                          |
+| Prefetch를 껐더니 이미지가 안 나와요. | 셀 구성 경로도 cache miss에서 로딩을 시작하는지 확인해요.                       |
+| 취소 뒤 다시 나타난 이미지가 비어요.  | 재요청이 가능하고 취소가 완성된 cache를 지우지 않는지 확인해요.                 |
+| 삽입 뒤 엉뚱한 작업이 취소돼요.       | 오래된 `IndexPath`가 아니라 callback 시점에 변환한 ID로 task를 관리하는지 봐요. |
+
+## 면접에서 이어질 수 있는 질문
+
+### Prefetch는 데이터 정확성을 보장하는 기능인가요?
+
+아니요. Prefetch는 데이터를 조금 일찍 준비하는 성능 최적화예요. 호출되지 않거나 취소될 수 있으므로 실제 셀 구성 경로가 독립적으로 데이터를 준비할 수 있어야 해요.
+
+### `IndexPath` 대신 ID로 작업을 관리하는 이유는 무엇인가요?
+
+`IndexPath`는 현재 위치라서 삽입·삭제·정렬 뒤 다른 모델을 가리킬 수 있어요. 안정적인 모델 ID를 task와 cache의 key로 사용하면 item이 이동해도 같은 요청과 결과를 찾을 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDataSourcePrefetching](https://developer.apple.com/documentation/uikit/uicollectionviewdatasourceprefetching)
+- [Apple Developer Documentation — Building high-performance lists and collection views](https://developer.apple.com/documentation/uikit/building-high-performance-lists-and-collection-views)
+- [Apple Developer Documentation — UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)

--- a/docs/guide/uikit/collection-views/examples/data-source.md
+++ b/docs/guide/uikit/collection-views/examples/data-source.md
@@ -1,0 +1,276 @@
+---
+title: 'UICollectionViewDataSource 예제'
+description: 'UICollectionViewDataSource의 필수 메서드로 사진 격자를 구성하고, 모델과 batch update의 순서를 맞춰 item을 삽입·삭제·이동하는 방법을 설명합니다.'
+---
+
+# UICollectionViewDataSource 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewDataSource`는 Collection View가 요청한 item 개수와 재사용 셀을 `IndexPath` 기준으로 제공하며, 화면 갱신 시 모델과 update 명령을 개발자가 직접 일치시켜야 해요.
+
+이 예제에서는 [공통 `Photo` 모델과 `PhotoCell`](./index)을 사용해 두 열 사진 격자를 만들어요. 기존 UIKit 프로젝트에서 가장 자주 만나는 protocol 기반 data source의 전체 흐름을 확인할 수 있어요.
+
+## 먼저 알아둘 용어
+
+| 용어             | 쉬운 뜻                                                                                             |
+| ---------------- | --------------------------------------------------------------------------------------------------- |
+| `IndexPath`      | section과 item의 현재 위치예요. `IndexPath(item: 2, section: 0)`은 첫 section의 세 번째 item이에요. |
+| reuse identifier | 등록한 셀 종류와 dequeue할 셀을 연결하는 문자열이에요.                                              |
+| batch update     | 여러 삽입·삭제·이동을 하나의 화면 갱신 단위로 실행하는 작업이에요.                                  |
+| backing store    | 화면이 참조하는 실제 모델 저장소예요. 이 예제에서는 `photos` 배열이에요.                            |
+
+## Flow Layout으로 기본 격자를 준비해요
+
+이 문서에서는 data source에 집중하기 위해 고정된 두 열 격자를 사용해요. 화면 너비에 따라 열 수를 바꾸는 방법은 [`UICollectionViewFlowLayout` 예제](./flow-layout)에서 다뤄요.
+
+```swift
+private func makeGridLayout() -> UICollectionViewFlowLayout {
+  let layout = UICollectionViewFlowLayout()
+  layout.scrollDirection = .vertical
+  layout.minimumInteritemSpacing = 12
+  layout.minimumLineSpacing = 12
+  layout.sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+  layout.itemSize = CGSize(width: 160, height: 160)
+  return layout
+}
+```
+
+`minimumInteritemSpacing`은 같은 행의 item 사이 최소 간격이고, `minimumLineSpacing`은 행 사이 최소 간격이에요.
+
+## Collection View를 만들고 data source를 연결해요
+
+```swift
+@MainActor
+final class ClassicPhotoGridViewController: UIViewController {
+  private var photos = Photo.samples
+  var onSelectPhoto: ((Photo.ID) -> Void)?
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.delegate = self
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+}
+```
+
+Collection View는 data source를 강하게 보유하지 않아요. 이 예제처럼 view controller 자신을 연결하거나, 별도 data source 객체를 프로퍼티로 강하게 보관해야 해요.
+
+## 필수 data source 메서드 두 개를 구현해요
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+}
+```
+
+`numberOfItemsInSection`이 반환한 개수와 배열의 실제 개수는 항상 같아야 해요. `cellForItemAt`에서는 셀을 직접 생성하지 않고 등록된 재사용 셀을 dequeue해요.
+
+## 선택한 위치를 모델 식별자로 바꿔요
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    let selectedPhotoID = photos[indexPath.item].id
+    onSelectPhoto?(selectedPhotoID)
+  }
+}
+```
+
+Delegate가 전달한 `IndexPath`는 선택 순간의 위치예요. 다음 화면이나 비동기 작업에는 위치 대신 `Photo.ID`를 전달해야 중간에 item이 삽입되어도 같은 사진을 가리켜요.
+
+## item을 삽입할 때 모델을 먼저 바꿔요
+
+```swift
+extension ClassicPhotoGridViewController {
+  func append(_ photo: Photo) {
+    let newIndexPath = IndexPath(
+      item: photos.count,
+      section: 0
+    )
+
+    photos.append(photo)
+    collectionView.performBatchUpdates {
+      collectionView.insertItems(at: [newIndexPath])
+    }
+  }
+}
+```
+
+새 `IndexPath`는 배열을 변경하기 전의 `photos.count`로 계산해요. 그 위치는 append 뒤 새 item의 마지막 위치가 돼요.
+
+## item을 삭제할 때도 모델을 먼저 바꿔요
+
+```swift
+extension ClassicPhotoGridViewController {
+  func deletePhoto(id: Photo.ID) {
+    guard let index = photos.firstIndex(
+      where: { $0.id == id }
+    ) else {
+      return
+    }
+
+    photos.remove(at: index)
+    collectionView.performBatchUpdates {
+      collectionView.deleteItems(
+        at: [IndexPath(item: index, section: 0)]
+      )
+    }
+  }
+}
+```
+
+화면만 삭제하고 배열을 그대로 두거나, 배열은 바꿨지만 다른 위치를 삭제하면 update 전후 item 개수가 일치하지 않아 예외가 발생할 수 있어요.
+
+## 재배치 결과를 모델 배열에 반영해요
+
+`UICollectionViewDataSource`의 선택 메서드를 구현하면 Collection View가 재배치 결과를 알려 줄 수 있어요.
+
+```swift
+extension ClassicPhotoGridViewController {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    canMoveItemAt indexPath: IndexPath
+  ) -> Bool {
+    true
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    moveItemAt sourceIndexPath: IndexPath,
+    to destinationIndexPath: IndexPath
+  ) {
+    let movedPhoto = photos.remove(
+      at: sourceIndexPath.item
+    )
+    photos.insert(
+      movedPhoto,
+      at: destinationIndexPath.item
+    )
+  }
+}
+```
+
+화면 위치만 바꾸고 배열 순서를 갱신하지 않으면 다음 `reloadData()`에서 원래 순서로 돌아가요. 서버에 순서를 저장해야 한다면 배열을 바꾼 뒤 새 ID 순서를 repository에 전달하세요.
+
+## 여러 section을 사용할 때는 이차원 모델을 준비해요
+
+```swift
+struct PhotoSection {
+  let title: String
+  var photos: [Photo]
+}
+
+private var sections: [PhotoSection] = []
+
+func numberOfSections(
+  in collectionView: UICollectionView
+) -> Int {
+  sections.count
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  numberOfItemsInSection section: Int
+) -> Int {
+  sections[section].photos.count
+}
+```
+
+화면의 section 구조와 backing store 구조를 같은 모양으로 유지하면 `IndexPath.section`과 `IndexPath.item`을 안전하게 해석하기 쉬워요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                    | 먼저 확인할 것                                                                     |
+| --------------------------------------- | ---------------------------------------------------------------------------------- |
+| 셀이 하나도 나타나지 않아요.            | `dataSource` 연결과 `numberOfItemsInSection` 반환값을 확인해요.                    |
+| dequeue 시 예외가 발생해요.             | 등록과 dequeue에 같은 reuse identifier를 사용했는지 확인해요.                      |
+| batch update에서 item 개수 예외가 나요. | 모델 변경과 insert·delete 명령의 전후 개수가 맞는지 확인해요.                      |
+| 스크롤 뒤 셀에 이전 내용이 남아요.      | `configure(with:)`가 모든 상태를 덮어쓰고 `prepareForReuse()`가 초기화하는지 봐요. |
+| 정렬 뒤 선택한 사진이 달라져요.         | 선택 상태와 비동기 작업을 `IndexPath`가 아니라 `Photo.ID`로 저장했는지 확인해요.   |
+
+## 언제 이 방식을 사용해야 하나요
+
+- item 변경이 거의 없는 작은 기존 화면이라면 protocol 방식으로도 충분해요.
+- 낮은 배포 대상이나 오래된 코드 구조를 유지해야 할 때 자연스럽게 연결돼요.
+- 삽입·삭제·이동이 자주 겹친다면 직접 batch update를 맞추는 비용이 커질 수 있어요.
+- 목표 상태를 한 값으로 표현하고 싶다면 [Diffable Data Source 예제](./diffable-data-source)를 검토하세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 필수 메서드는 무엇인가요?
+
+`collectionView(_:numberOfItemsInSection:)`과 `collectionView(_:cellForItemAt:)` 두 개예요. 여러 section, supplementary view, 재배치가 필요할 때 선택 메서드를 추가해요.
+
+### 모델을 먼저 바꿔야 하는 이유는 무엇인가요?
+
+Collection View는 update 전후 data source가 보고한 item 개수와 삽입·삭제 명령을 검증해요. 화면과 backing store가 같은 최종 상태를 설명해야 갱신을 안전하게 완료할 수 있어요.
+
+## 다음 예제로 이동해요
+
+데이터와 셀을 표시했다면 [전통적인 `UICollectionViewDelegate` 예제](./traditional-delegate)에서 배열의 `IndexPath`를 모델 ID로 바꾸어 선택·하이라이트·메뉴를 처리해 보세요.
+
+원격 이미지가 있다면 [`UICollectionViewDataSourcePrefetching` 예제](./data-source-prefetching)에서 곧 보일 item의 작업을 미리 준비해 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdatasource)
+- [Apple Developer Documentation — UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)

--- a/docs/guide/uikit/collection-views/examples/diffable-data-source.md
+++ b/docs/guide/uikit/collection-views/examples/diffable-data-source.md
@@ -1,0 +1,323 @@
+---
+title: 'UICollectionViewDiffableDataSource 예제'
+description: 'UICollectionViewDiffableDataSource와 Cell Registration을 연결하고 안정적인 Photo.ID snapshot으로 초기 표시, 삽입·삭제·내용 변경·선택을 구현합니다.'
+---
+
+# UICollectionViewDiffableDataSource 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewDiffableDataSource`는 안정적인 section·item 식별자로 목표 상태 snapshot을 적용하고 이전 상태와의 차이를 계산해 Collection View의 삽입·삭제·이동을 반영해요.
+
+이 예제에서는 [공통 `Photo` 모델과 `PhotoCell`](./index)을 사용해 사진 격자를 만들어요. 전통적인 data source와 화면 모양은 같지만, 위치 대신 `Photo.ID`로 데이터를 찾고 snapshot으로 갱신해요.
+
+## 먼저 알아둘 용어
+
+| 용어          | 쉬운 뜻                                                                        |
+| ------------- | ------------------------------------------------------------------------------ |
+| identifier    | item이 이동해도 같은 데이터임을 구분하는 `Hashable` 값이에요.                  |
+| snapshot      | 특정 시점의 section과 item 순서를 나타내는 값이에요.                           |
+| cell provider | item identifier를 받아 구성된 셀을 반환하는 closure예요.                       |
+| backing store | identifier로 실제 최신 모델을 찾는 저장소예요. 이 예제에서는 `photosByID`예요. |
+| reconfigure   | item 정체성과 셀을 유지하면서 표시 내용을 다시 구성하는 갱신이에요.            |
+
+## 모델 저장소와 화면 순서를 분리해요
+
+```swift
+@MainActor
+final class DiffablePhotoGridViewController: UIViewController {
+  private enum Section {
+    case main
+  }
+
+  private var photosByID: [Photo.ID: Photo] = [:]
+  private var photoIDs: [Photo.ID] = []
+
+  private var dataSource:
+    UICollectionViewDiffableDataSource<Section, Photo.ID>!
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    configureCollectionView()
+    configureDataSource()
+    show(Photo.samples, animatingDifferences: false)
+  }
+}
+```
+
+`photosByID`는 ID로 최신 모델을 찾고, `photoIDs`는 화면에 보여 줄 순서를 보관해요. 제목이나 즐겨찾기 여부가 바뀌어도 `Photo.ID`는 유지돼요.
+
+## Flow Layout을 준비해요
+
+이 문서에서는 data source 흐름에 집중할 수 있도록 고정 격자를 사용해요.
+
+```swift
+private func makeGridLayout() -> UICollectionViewFlowLayout {
+  let layout = UICollectionViewFlowLayout()
+  layout.minimumInteritemSpacing = 12
+  layout.minimumLineSpacing = 12
+  layout.sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+  layout.itemSize = CGSize(width: 160, height: 160)
+  return layout
+}
+```
+
+Data source와 layout은 독립적이므로 나중에 [Compositional Layout](./compositional-layout)로 바꿔도 snapshot 흐름은 유지할 수 있어요.
+
+## Collection View를 화면에 배치해요
+
+```swift
+extension DiffablePhotoGridViewController {
+  private func configureCollectionView() {
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.delegate = self
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+}
+```
+
+Diffable Data Source를 생성하면 대상 Collection View의 `dataSource`로 연결돼요. 그 뒤 `collectionView.dataSource`를 다른 객체로 교체하지 마세요.
+
+## Cell Registration과 cell provider를 연결해요
+
+```swift
+extension DiffablePhotoGridViewController {
+  private func configureDataSource() {
+    let registration = UICollectionView.CellRegistration<
+      PhotoCell,
+      Photo.ID
+    > { [weak self] cell, _, photoID in
+      guard let photo = self?.photosByID[photoID] else {
+        return
+      }
+
+      cell.configure(with: photo)
+    }
+
+    dataSource = UICollectionViewDiffableDataSource(
+      collectionView: collectionView
+    ) { collectionView, indexPath, photoID in
+      collectionView.dequeueConfiguredReusableCell(
+        using: registration,
+        for: indexPath,
+        item: photoID
+      )
+    }
+  }
+}
+```
+
+Cell Registration은 셀 타입과 구성 코드를 묶어요. `dequeueConfiguredReusableCell`을 사용하면 별도의 reuse identifier 등록을 하지 않아도 돼요.
+
+`registration`의 item 타입이 반드시 data source의 item identifier 타입과 같아야 하는 것은 아니에요. 이 예제에서는 ID를 받아 backing store에서 모델을 찾는 흐름을 명확히 하기 위해 둘 다 `Photo.ID`로 사용해요.
+
+## 초기 상태를 snapshot으로 표시해요
+
+```swift
+extension DiffablePhotoGridViewController {
+  private func show(
+    _ photos: [Photo],
+    animatingDifferences: Bool = true
+  ) {
+    photosByID = Dictionary(
+      uniqueKeysWithValues: photos.map { ($0.id, $0) }
+    )
+    photoIDs = photos.map(\.id)
+
+    applyCurrentSnapshot(
+      animatingDifferences: animatingDifferences
+    )
+  }
+
+  private func applyCurrentSnapshot(
+    animatingDifferences: Bool = true
+  ) {
+    var snapshot =
+      NSDiffableDataSourceSnapshot<Section, Photo.ID>()
+    snapshot.appendSections([.main])
+    snapshot.appendItems(photoIDs, toSection: .main)
+
+    dataSource.apply(
+      snapshot,
+      animatingDifferences: animatingDifferences
+    )
+  }
+}
+```
+
+각 section identifier와 item identifier는 snapshot 안에서 유일해야 해요. 같은 `Photo.ID`를 두 번 append하면 예외가 발생해요.
+
+## item을 삽입하고 삭제해요
+
+```swift
+extension DiffablePhotoGridViewController {
+  func append(_ photo: Photo) {
+    guard photosByID[photo.id] == nil else {
+      return
+    }
+
+    photosByID[photo.id] = photo
+    photoIDs.append(photo.id)
+    applyCurrentSnapshot()
+  }
+
+  func deletePhoto(id: Photo.ID) {
+    photosByID[id] = nil
+    photoIDs.removeAll { $0 == id }
+    applyCurrentSnapshot()
+  }
+}
+```
+
+앱은 여전히 모델 변화를 감지하고 backing store를 갱신할 책임이 있어요. Diffable Data Source는 새 snapshot과 현재 snapshot의 차이를 화면에 반영하지만 서버나 저장소를 자동으로 관찰하지 않아요.
+
+## 기존 item의 내용만 다시 구성해요
+
+```swift
+extension DiffablePhotoGridViewController {
+  func toggleFavorite(id: Photo.ID) {
+    guard photosByID[id] != nil else {
+      return
+    }
+
+    photosByID[id]?.isFavorite.toggle()
+
+    var snapshot = dataSource.snapshot()
+    guard snapshot.indexOfItem(id) != nil else {
+      return
+    }
+
+    snapshot.reconfigureItems([id])
+    dataSource.apply(snapshot, animatingDifferences: true)
+  }
+}
+```
+
+`reconfigureItems(_:)`는 ID와 기존 셀 상태를 유지하면서 cell provider를 다시 호출해요. iOS 15 이상에서 사용할 수 있어요.
+
+모델 전체를 item identifier로 넣고 자동 생성된 `Hashable`을 사용하면 `isFavorite` 변경 뒤 다른 값으로 판단될 수 있어요. 같은 사진의 내용만 바뀐 경우에는 안정적인 `Photo.ID`를 유지하세요.
+
+## 선택한 위치를 identifier로 바꿔요
+
+```swift
+extension DiffablePhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    guard let photoID = dataSource.itemIdentifier(
+      for: indexPath
+    ) else {
+      return
+    }
+
+    toggleFavorite(id: photoID)
+  }
+}
+```
+
+선택 순간의 `IndexPath`는 identifier를 얻는 데만 사용해요. 비동기 작업, 선택 상태, 화면 이동에는 `Photo.ID`를 전달해요.
+
+## 원하는 위치로 item을 이동해요
+
+새 snapshot을 직접 수정해 특정 item을 이동할 수도 있어요.
+
+```swift
+extension DiffablePhotoGridViewController {
+  func movePhoto(
+    id: Photo.ID,
+    before destinationID: Photo.ID
+  ) {
+    guard
+      let sourceIndex = photoIDs.firstIndex(of: id),
+      let destinationIndex = photoIDs.firstIndex(
+        of: destinationID
+      )
+    else {
+      return
+    }
+
+    photoIDs.remove(at: sourceIndex)
+    photoIDs.insert(
+      id,
+      at: sourceIndex < destinationIndex
+        ? destinationIndex - 1
+        : destinationIndex
+    )
+    applyCurrentSnapshot()
+  }
+}
+```
+
+화면의 snapshot만 임시로 바꾸기보다 backing store의 순서를 먼저 변경한 뒤 snapshot을 다시 만드는 흐름이 다음 갱신을 예측하기 쉬워요.
+
+## 전통적인 data source와 비교해요
+
+| 질문                | `UICollectionViewDataSource`           | `UICollectionViewDiffableDataSource`       |
+| ------------------- | -------------------------------------- | ------------------------------------------ |
+| item을 찾는 기준    | 주로 현재 위치인 `IndexPath`           | 안정적인 `Hashable` identifier             |
+| 셀 제공 위치        | `cellForItemAt` protocol 메서드        | cell provider closure                      |
+| 삽입·삭제           | 모델과 batch update를 직접 맞춰요.     | 새 snapshot을 적용해 차이를 계산하게 해요. |
+| 기존 item 내용 변경 | `reloadItems(at:)` 등을 직접 호출해요. | `reconfigureItems(_:)`를 사용할 수 있어요. |
+| 주의점              | item 개수와 update 명령의 불일치       | 불안정하거나 중복된 identifier             |
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                | 먼저 확인할 것                                                           |
+| ----------------------------------- | ------------------------------------------------------------------------ |
+| snapshot 적용 중 중복 예외가 나요.  | section과 item identifier가 각각 유일한지 확인해요.                      |
+| 내용 변경 뒤 선택이 사라져요.       | 바뀌는 모델 전체가 아니라 `Photo.ID`를 identifier로 사용했는지 확인해요. |
+| 셀 provider에서 모델을 찾지 못해요. | snapshot을 적용하기 전에 `photosByID`를 최신 상태로 갱신했는지 확인해요. |
+| 삭제한 item이 다시 나타나요.        | `photosByID`와 `photoIDs` 양쪽에서 제거했는지 확인해요.                  |
+| 셀이 전혀 표시되지 않아요.          | `configureDataSource()` 뒤 초기 snapshot을 적용했는지 확인해요.          |
+
+## 면접에서 이어질 수 있는 질문
+
+### Diffable Data Source가 모델도 자동으로 갱신하나요?
+
+아니요. 앱이 데이터 변화를 감지하고 backing store를 먼저 갱신한 뒤 새 snapshot을 적용해야 해요. Diffable Data Source는 두 snapshot의 차이를 Collection View에 반영해요.
+
+### 왜 모델 전체가 아니라 ID를 snapshot에 넣나요?
+
+제목이나 즐겨찾기처럼 바뀌는 속성이 item의 정체성에 섞이지 않게 하기 위해서예요. 안정적인 ID를 사용하면 같은 item의 선택, 포커스, 셀 상태를 유지하며 내용만 다시 구성할 수 있어요.
+
+## 다음 예제로 이동해요
+
+- 선택 callback을 identifier와 snapshot에 연결하려면 [현대적인 `UICollectionViewDelegate` 예제](./modern-delegate)를 읽어 보세요.
+- 곧 보일 이미지 작업을 미리 시작하려면 [`UICollectionViewDataSourcePrefetching` 예제](./data-source-prefetching)를 읽어 보세요.
+- section마다 다른 배치를 만들려면 [`UICollectionViewCompositionalLayout` 예제](./compositional-layout)로 이동하세요.
+- 새로고침과 prefetch는 [실무 확장 예제](./practical-recipes)에서 이어서 구현해요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — Updating collection views using diffable data sources](https://developer.apple.com/documentation/uikit/updating-collection-views-using-diffable-data-sources)
+- [Apple Developer Documentation — UICollectionViewDiffableDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource)
+- [Apple Developer Documentation — NSDiffableDataSourceSnapshot](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot)
+- [Apple Developer Documentation — UICollectionView.CellRegistration](https://developer.apple.com/documentation/uikit/uicollectionview/cellregistration)

--- a/docs/guide/uikit/collection-views/examples/drag-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/drag-delegate.md
@@ -1,0 +1,203 @@
+---
+title: 'UICollectionViewDragDelegate 예제'
+description: 'UICollectionViewDragDelegate로 단일·다중 사진 drag를 시작하고 NSItemProvider와 localObject를 구성하며 drag preview와 허용 조건을 안전하게 제어합니다.'
+---
+
+# UICollectionViewDragDelegate 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewDragDelegate`는 사용자가 item을 들어 올릴 때 외부 전달용 `NSItemProvider`와 앱 내부 최적화용 `localObject`를 담은 `UIDragItem`을 제공해 drag를 시작하는 프로토콜이에요.
+
+이 문서는 사진 갤러리에서 drag를 시작하는 쪽을 구현해요. 실제 위치 변경과 외부 데이터 수신은 [`UICollectionViewDropDelegate` 예제](./drop-delegate)에서 이어서 다뤄요.
+
+## 먼저 알아둘 용어
+
+| 용어             | 쉬운 뜻                                                                     |
+| ---------------- | --------------------------------------------------------------------------- |
+| drag session     | 사용자가 하나 이상의 item을 들어 올려 이동하는 동안 유지되는 작업 단위예요. |
+| `NSItemProvider` | 다른 앱과도 교환할 수 있도록 데이터 타입과 로딩 방법을 설명하는 객체예요.   |
+| `UIDragItem`     | Drag 하나에 포함되는 데이터 한 건과 로컬 객체를 묶는 값이에요.              |
+| `localObject`    | 같은 앱 안에서 drag할 때 직렬화 없이 빠르게 전달하는 임시 객체예요.         |
+| drag preview     | 손가락을 따라 움직이는 item의 시각적 모양이에요.                            |
+
+## Drag Delegate를 연결해요
+
+```swift
+override func viewDidLoad() {
+  super.viewDidLoad()
+
+  collectionView.dragDelegate = self
+  collectionView.dragInteractionEnabled = true
+}
+```
+
+iPhone에서는 `dragInteractionEnabled`를 명시적으로 켜야 하는 경우가 있어요. `dragDelegate`는 Collection View의 선택을 다루는 일반 `delegate`와 별도 프로퍼티예요.
+
+## 필수 메서드에서 Drag Item을 만들어요
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDragDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    itemsForBeginning session: UIDragSession,
+    at indexPath: IndexPath
+  ) -> [UIDragItem] {
+    guard photos.indices.contains(indexPath.item) else {
+      return []
+    }
+
+    let photo = photos[indexPath.item]
+    let provider = NSItemProvider(
+      object: photo.title as NSString
+    )
+    let dragItem = UIDragItem(itemProvider: provider)
+    dragItem.localObject = photo.id
+
+    return [dragItem]
+  }
+}
+```
+
+빈 배열을 반환하면 해당 item의 drag를 시작하지 않아요. `NSItemProvider`에는 다른 앱이 이해할 수 있는 문자열·이미지·파일 표현을 넣고, `localObject`에는 같은 앱 안에서 모델을 빠르게 찾을 `Photo.ID`를 넣었어요.
+
+## Drag 가능 여부를 모델에서 판단해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  itemsForBeginning session: UIDragSession,
+  at indexPath: IndexPath
+) -> [UIDragItem] {
+  let photo = photos[indexPath.item]
+
+  guard !photo.title.isEmpty else {
+    return []
+  }
+
+  return [makeDragItem(for: photo)]
+}
+
+private func makeDragItem(
+  for photo: Photo
+) -> UIDragItem {
+  let provider = NSItemProvider(
+    object: photo.title as NSString
+  )
+  let item = UIDragItem(itemProvider: provider)
+  item.localObject = photo.id
+  return item
+}
+```
+
+다운로드 중이거나 이동할 수 없는 고정 item이라면 빈 배열을 반환해요. 단, 사용자가 이유를 이해할 수 있도록 잠금 모양이나 안내 문구 같은 화면 피드백도 제공하세요.
+
+## 진행 중인 Session에 Item을 추가해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  itemsForAddingTo session: UIDragSession,
+  at indexPath: IndexPath,
+  point: CGPoint
+) -> [UIDragItem] {
+  guard photos.indices.contains(indexPath.item) else {
+    return []
+  }
+
+  return [makeDragItem(for: photos[indexPath.item])]
+}
+```
+
+사용자가 drag 도중 다른 item을 탭하면 같은 session에 추가할 수 있어요. 선택된 item을 한꺼번에 drag하는 화면이라면 중복 ID가 session에 들어가지 않도록 현재 `session.items`의 `localObject`도 확인하세요.
+
+## 다중 선택을 한 번에 Drag해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  itemsForBeginning session: UIDragSession,
+  at indexPath: IndexPath
+) -> [UIDragItem] {
+  let selected = collectionView.indexPathsForSelectedItems
+    ?? []
+  let sourceIndexPaths = selected.contains(indexPath)
+    ? selected
+    : [indexPath]
+
+  return sourceIndexPaths.compactMap { path in
+    guard photos.indices.contains(path.item) else {
+      return nil
+    }
+    return makeDragItem(for: photos[path.item])
+  }
+}
+```
+
+사용자가 선택하지 않은 item에서 drag를 시작했다면 그 item 하나만 반환해요. 정렬이나 삽입이 자주 일어나는 화면에서는 각 `IndexPath`를 즉시 모델 ID로 바꿔 이후 상태를 ID로 관리하세요.
+
+## Preview의 보이는 영역을 조정해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  dragPreviewParametersForItemAt indexPath: IndexPath
+) -> UIDragPreviewParameters? {
+  guard let cell = collectionView.cellForItem(
+    at: indexPath
+  ) else {
+    return nil
+  }
+
+  let parameters = UIDragPreviewParameters()
+  parameters.visiblePath = UIBezierPath(
+    roundedRect: cell.bounds,
+    cornerRadius: 14
+  )
+  parameters.backgroundColor = .clear
+  return parameters
+}
+```
+
+셀 전체의 사각형 대신 실제 카드 모양만 preview에 포함했어요. Preview는 표현만 바꾸며 drag 데이터나 허용 정책은 바꾸지 않아요.
+
+## `NSItemProvider`와 `localObject`의 역할을 구분해요
+
+| 이동 범위                 | 읽는 값                 | 이유                                                        |
+| ------------------------- | ----------------------- | ----------------------------------------------------------- |
+| 같은 Collection View 내부 | `localObject`의 모델 ID | 직렬화와 비동기 로딩 없이 현재 모델을 바로 찾을 수 있어요.  |
+| 같은 앱의 다른 화면       | `localObject` 우선      | 같은 프로세스라면 빠른 전달이 가능해요.                     |
+| 다른 앱에서 들어온 Drop   | `NSItemProvider`        | 로컬 객체를 공유할 수 없으므로 등록된 데이터 표현을 읽어요. |
+| 다른 앱으로 나가는 Drag   | `NSItemProvider`        | 받는 앱이 지원하는 타입을 선택해 비동기로 로드해요.         |
+
+`localObject`만 설정하고 `NSItemProvider`를 비워 두는 방식은 다른 앱과의 교환을 막아요. 반대로 앱 내부 재배치인데도 provider를 매번 역직렬화하면 불필요한 비용이 생겨요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                | 먼저 확인할 것                                                              |
+| ----------------------------------- | --------------------------------------------------------------------------- |
+| Drag가 시작되지 않아요.             | `dragDelegate`, `dragInteractionEnabled`, 필수 메서드 반환 배열을 확인해요. |
+| 다른 앱에 데이터가 전달되지 않아요. | `NSItemProvider`가 받는 앱이 이해할 표현을 등록했는지 확인해요.             |
+| 내부 이동도 느려요.                 | `localObject`에 안정적인 모델 ID를 넣고 Drop에서 우선 사용하는지 봐요.      |
+| 여러 item이 중복으로 drag돼요.      | 선택 목록과 session의 기존 item을 ID로 중복 제거하는지 확인해요.            |
+| Preview가 셀 바깥까지 보여요.       | `visiblePath`가 셀의 실제 좌표계와 corner radius를 사용하는지 확인해요.     |
+
+## 면접에서 이어질 수 있는 질문
+
+### Drag Delegate의 필수 메서드는 무엇인가요?
+
+`collectionView(_:itemsForBeginning:at:)`이에요. 여기에서 빈 배열을 반환하면 drag가 시작되지 않고, 하나 이상의 `UIDragItem`을 반환하면 Collection View가 drag interaction을 진행해요.
+
+### 왜 `localObject`와 `NSItemProvider`를 함께 사용하나요?
+
+`localObject`는 같은 앱 안에서 모델 ID를 빠르게 전달하고, `NSItemProvider`는 프로세스 경계를 넘어 데이터를 교환해요. 두 경로를 함께 준비하면 내부 재배치와 외부 공유를 모두 지원할 수 있어요.
+
+## 다음 예제로 이동해요
+
+Drag item을 만들었다면 [`UICollectionViewDropDelegate` 예제](./drop-delegate)에서 내부 재배치와 외부 데이터 삽입을 구현해 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDragDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdragdelegate)
+- [Apple Developer Documentation — Supporting drag and drop in collection views](https://developer.apple.com/documentation/uikit/supporting-drag-and-drop-in-collection-views)
+- [Apple Developer Documentation — UIDragItem](https://developer.apple.com/documentation/uikit/uidragitem)

--- a/docs/guide/uikit/collection-views/examples/drop-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/drop-delegate.md
@@ -1,0 +1,240 @@
+---
+title: 'UICollectionViewDropDelegate 예제'
+description: 'UICollectionViewDropDelegate로 내부 재배치와 외부 문자열 삽입을 구분하고, Drop Proposal·모델 갱신·Coordinator 애니메이션의 순서를 안전하게 맞춥니다.'
+---
+
+# UICollectionViewDropDelegate 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewDropDelegate`는 들어온 drag 데이터를 받을 수 있는지와 삽입 방식·위치를 결정하고, 모델을 먼저 갱신한 뒤 coordinator에 최종 drop 위치를 알려 주는 프로토콜이에요.
+
+이 문서는 [`UICollectionViewDragDelegate` 예제](./drag-delegate)에서 만든 `UIDragItem`을 같은 갤러리 안에서 재배치하고, 다른 앱에서 온 문자열을 새 사진으로 추가해요.
+
+## 먼저 알아둘 용어
+
+| 용어             | 쉬운 뜻                                                                           |
+| ---------------- | --------------------------------------------------------------------------------- |
+| drop session     | Drag 데이터가 Collection View 영역에 들어와 위치를 움직이는 동안의 작업 단위예요. |
+| drop proposal    | 현재 위치에 데이터를 복사·이동할지, 어떤 방식으로 삽입할지 표현한 값이에요.       |
+| drop coordinator | Drop item, 목적지와 애니메이션을 실제 데이터 갱신에 맞춰 연결하는 객체예요.       |
+| local drag       | 같은 앱 안에서 시작해 `localObject`를 바로 읽을 수 있는 drag예요.                 |
+| external drop    | 다른 앱에서 시작해 `NSItemProvider`를 비동기로 읽어야 하는 drop이에요.            |
+
+## Drop Delegate를 연결해요
+
+```swift
+override func viewDidLoad() {
+  super.viewDidLoad()
+
+  collectionView.dropDelegate = self
+}
+```
+
+내부 재배치까지 지원한다면 Drag Delegate도 함께 연결해요. Drop만 지원하는 화면이라면 외부 앱에서 들어온 데이터만 받을 수도 있어요.
+
+## 받을 수 있는 데이터 타입을 선언해요
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDropDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    canHandle session: UIDropSession
+  ) -> Bool {
+    session.canLoadObjects(ofClass: NSString.self)
+      || session.localDragSession != nil
+  }
+}
+```
+
+지원하지 않는 데이터는 일찍 `false`를 반환해요. 실제 앱에서 이미지 파일을 받는다면 `UIImage`, `UTType.image` 또는 앱의 문서 타입처럼 목적에 맞는 표현을 확인하세요.
+
+## 이동과 복사를 Proposal로 구분해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  dropSessionDidUpdate session: UIDropSession,
+  withDestinationIndexPath destinationIndexPath: IndexPath?
+) -> UICollectionViewDropProposal {
+  if session.localDragSession != nil {
+    return UICollectionViewDropProposal(
+      operation: .move,
+      intent: .insertAtDestinationIndexPath
+    )
+  }
+
+  return UICollectionViewDropProposal(
+    operation: .copy,
+    intent: .insertAtDestinationIndexPath
+  )
+}
+```
+
+같은 앱 안의 item은 기존 모델을 옮기므로 `.move`, 외부 데이터는 새 모델을 만들므로 `.copy`를 사용해요. `.forbidden`을 반환하면 현재 위치에서 drop할 수 없다는 피드백을 표시해요.
+
+## 목적지 IndexPath를 안전한 범위로 보정해요
+
+```swift
+private func resolvedDestination(
+  from coordinator: UICollectionViewDropCoordinator
+) -> IndexPath {
+  if let destination = coordinator.destinationIndexPath {
+    return IndexPath(
+      item: min(destination.item, photos.count),
+      section: 0
+    )
+  }
+
+  return IndexPath(item: photos.count, section: 0)
+}
+```
+
+빈 공간에 drop하면 목적지가 `nil`일 수 있어 마지막 위치를 사용해요. 기존 item을 같은 배열 안에서 아래쪽으로 이동할 때는 source 제거로 index가 하나 줄어드는 점도 처리해야 해요.
+
+## 같은 Collection View 안에서 Item을 이동해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  performDropWith coordinator: UICollectionViewDropCoordinator
+) {
+  var destination = resolvedDestination(from: coordinator)
+
+  for item in coordinator.items {
+    guard
+      let source = item.sourceIndexPath,
+      let photoID = item.dragItem.localObject as? Photo.ID,
+      let sourceIndex = photos.firstIndex(
+        where: { $0.id == photoID }
+      )
+    else {
+      loadExternalItem(
+        item,
+        destination: destination,
+        coordinator: coordinator
+      )
+      destination = IndexPath(
+        item: destination.item + 1,
+        section: destination.section
+      )
+      continue
+    }
+
+    let photo = photos[sourceIndex]
+    let adjustedDestination = sourceIndex < destination.item
+      ? destination.item - 1
+      : destination.item
+    let insertionIndex = min(
+      max(adjustedDestination, 0),
+      photos.count
+    )
+    collectionView.performBatchUpdates {
+      photos.remove(at: sourceIndex)
+      photos.insert(photo, at: insertionIndex)
+      collectionView.moveItem(
+        at: source,
+        to: IndexPath(item: insertionIndex, section: 0)
+      )
+    }
+
+    coordinator.drop(
+      item.dragItem,
+      toItemAt: IndexPath(
+        item: insertionIndex,
+        section: 0
+      )
+    )
+  }
+}
+```
+
+`localObject`의 ID로 현재 모델 위치를 다시 찾아요. Drag 시작 뒤 배열이 바뀔 수 있으므로 오래된 source `IndexPath`만 모델 조회에 사용하지 않아요.
+
+## 외부 문자열을 비동기로 받아요
+
+```swift
+private func loadExternalItem(
+  _ item: UICollectionViewDropItem,
+  destination: IndexPath,
+  coordinator: UICollectionViewDropCoordinator
+) {
+  let placeholder = UICollectionViewDropPlaceholder(
+    insertionIndexPath: destination,
+    reuseIdentifier: PhotoCell.reuseIdentifier
+  )
+  let context = coordinator.drop(
+    item.dragItem,
+    to: placeholder
+  )
+
+  item.dragItem.itemProvider.loadObject(
+    ofClass: NSString.self
+  ) { [weak self] object, error in
+    DispatchQueue.main.async {
+      guard
+        let self,
+        error == nil,
+        let title = object as? String
+      else {
+        context.deletePlaceholder()
+        return
+      }
+
+      let photo = Photo(
+        id: UUID(),
+        title: title,
+        symbolName: "photo.fill",
+        isFavorite: false
+      )
+
+      context.commitInsertion { insertionIndexPath in
+        self.photos.insert(
+          photo,
+          at: insertionIndexPath.item
+        )
+      }
+    }
+  }
+}
+```
+
+외부 provider 로딩이 끝날 때까지 placeholder가 drop 위치를 유지해요. 로딩이 실패하면 placeholder를 삭제하고, 성공하면 `commitInsertion` 안에서 모델을 갱신해요.
+
+## Diffable Data Source에서는 Snapshot을 갱신해요
+
+전통적인 배열과 `moveItem` 대신 다음 순서를 사용해요.
+
+1. `localObject` 또는 item provider에서 안정적인 ID와 모델을 얻어요.
+2. Backing store의 순서를 먼저 변경해요.
+3. 현재 snapshot에서 `deleteItems`, `insertItems` 또는 새 전체 순서를 구성해요.
+4. Snapshot을 적용해 Collection View가 이동 차이를 계산하게 해요.
+5. Coordinator의 `drop(_:toItemAt:)`으로 drop preview의 목적지를 알려요.
+
+같은 변경에 `moveItem`과 Diffable snapshot을 동시에 적용하면 두 갱신 경로가 충돌할 수 있으므로 하나만 선택하세요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                    | 먼저 확인할 것                                                         |
+| --------------------------------------- | ---------------------------------------------------------------------- |
+| Drop 위치와 모델 순서가 달라요.         | Source 제거 뒤 destination index를 보정했는지 확인해요.                |
+| 외부 Drop이 아무 반응 없이 실패해요.    | `canHandle`, provider 타입, 비동기 오류와 placeholder 삭제를 확인해요. |
+| 재배치 중 update 예외가 발생해요.       | 모델 변경과 Collection View update의 전후 item 개수가 일치하는지 봐요. |
+| Diffable 화면에서 animation이 중복돼요. | Snapshot과 `moveItem`을 동시에 호출하지 않는지 확인해요.               |
+| Drag 시작 뒤 다른 item이 이동해요.      | `localObject`의 ID로 현재 모델 위치를 다시 찾는지 확인해요.            |
+
+## 면접에서 이어질 수 있는 질문
+
+### Drop Delegate의 필수 메서드는 무엇인가요?
+
+`collectionView(_:performDropWith:)`예요. 여기에서 받은 item을 모델과 Data Source에 반영하고 coordinator에 최종 drop 위치나 placeholder를 전달해요.
+
+### 내부 재배치와 외부 Drop은 어떻게 구분하나요?
+
+`session.localDragSession`과 `UIDragItem.localObject`를 사용할 수 있으면 같은 앱 내부 흐름으로 처리할 수 있어요. 외부 데이터는 `NSItemProvider`가 제공하는 등록 타입을 검사하고 비동기로 로드해 새 모델을 만들어요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDropDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdropdelegate)
+- [Apple Developer Documentation — Supporting drag and drop in collection views](https://developer.apple.com/documentation/uikit/supporting-drag-and-drop-in-collection-views)
+- [Apple Developer Documentation — UICollectionViewDropCoordinator](https://developer.apple.com/documentation/uikit/uicollectionviewdropcoordinator)

--- a/docs/guide/uikit/collection-views/examples/flow-layout-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/flow-layout-delegate.md
@@ -1,0 +1,196 @@
+---
+title: 'UICollectionViewDelegateFlowLayout 예제'
+description: 'UICollectionViewDelegateFlowLayout의 선택 메서드로 item 크기·section 여백·행과 item 간격·header 크기를 화면과 모델에 맞게 동적으로 계산합니다.'
+---
+
+# UICollectionViewDelegateFlowLayout 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewDelegateFlowLayout`은 `UICollectionViewFlowLayout`이 item 크기와 section 간격을 물을 때 화면별 값을 반환하여 같은 layout 객체를 데이터와 가용 너비에 맞게 조정하는 delegate예요.
+
+[`UICollectionViewFlowLayout` 예제](./flow-layout)가 layout 객체의 기본 설정을 다룬다면, 이 문서는 delegate가 각 section과 item마다 값을 바꾸는 방법에 집중해요.
+
+## 먼저 알아둘 용어
+
+| 용어               | 쉬운 뜻                                                                 |
+| ------------------ | ----------------------------------------------------------------------- |
+| layout delegate    | Layout이 크기와 간격을 물을 때 화면별 정책을 답하는 객체예요.           |
+| section inset      | Section 콘텐츠 바깥쪽에 두는 위·왼쪽·아래·오른쪽 여백이에요.            |
+| line spacing       | 세로 스크롤에서는 행 사이, 가로 스크롤에서는 열 사이의 최소 간격이에요. |
+| inter-item spacing | 한 행이나 열 안에서 서로 이웃한 item 사이의 최소 간격이에요.            |
+| supplementary view | Section의 header나 footer처럼 cell을 보조하는 재사용 뷰예요.            |
+
+## Collection View Delegate에 연결해요
+
+```swift
+override func viewDidLoad() {
+  super.viewDidLoad()
+
+  collectionView.delegate = self
+}
+```
+
+`UICollectionViewDelegateFlowLayout`은 `UICollectionViewDelegate`를 상속해요. 별도의 `flowLayoutDelegate` 프로퍼티는 없고 Collection View의 일반 `delegate`에 연결해요.
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDelegateFlowLayout
+{
+  // 선택과 layout callback을 함께 구현할 수 있어요.
+}
+```
+
+모든 메서드는 선택 사항이에요. 구현하지 않은 값은 `UICollectionViewFlowLayout`의 `itemSize`, `sectionInset`, spacing 프로퍼티를 사용해요.
+
+## 가용 너비로 열 크기를 계산해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  sizeForItemAt indexPath: IndexPath
+) -> CGSize {
+  let horizontalInset: CGFloat = 16
+  let spacing: CGFloat = 12
+  let minimumWidth: CGFloat = 150
+
+  let availableWidth =
+    collectionView.bounds.width
+    - collectionView.adjustedContentInset.left
+    - collectionView.adjustedContentInset.right
+    - horizontalInset * 2
+
+  let columns = max(
+    1,
+    Int((availableWidth + spacing) / (minimumWidth + spacing))
+  )
+  let totalSpacing = spacing * CGFloat(columns - 1)
+  let width = floor(
+    (availableWidth - totalSpacing) / CGFloat(columns)
+  )
+
+  return CGSize(width: width, height: width + 48)
+}
+```
+
+화면 너비에서 safe area가 반영된 content inset과 section inset, 열 사이 간격을 모두 빼야 해요. 반환하는 너비와 높이는 0보다 커야 하고, 세로 격자의 item 너비가 표시 가능한 영역을 넘지 않게 해야 해요.
+
+## Section 여백과 간격을 한곳에서 맞춰요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  insetForSectionAt section: Int
+) -> UIEdgeInsets {
+  UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 24,
+    right: 16
+  )
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  minimumLineSpacingForSectionAt section: Int
+) -> CGFloat {
+  16
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  minimumInteritemSpacingForSectionAt section: Int
+) -> CGFloat {
+  12
+}
+```
+
+`minimumInteritemSpacing`은 최소값이에요. Flow Layout은 한 행에 남은 공간을 배분하면서 실제 간격을 더 크게 만들 수 있어요. 정확한 열 너비가 중요하다면 앞의 item 크기 계산에 같은 inset과 spacing 값을 사용하세요.
+
+## 모델에 따라 item 높이를 바꿔요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  sizeForItemAt indexPath: IndexPath
+) -> CGSize {
+  let photo = photos[indexPath.item]
+  let width = max(collectionView.bounds.width - 32, 1)
+  let titleHeight: CGFloat = photo.title.count > 20 ? 64 : 44
+
+  return CGSize(
+    width: width,
+    height: 120 + titleHeight
+  )
+}
+```
+
+이 방식은 item마다 계산 비용이 작고 높이를 미리 알 수 있을 때 적합해요. 텍스트와 Auto Layout으로 높이를 측정해야 한다면 `estimatedItemSize` 기반 self-sizing을 검토하세요.
+
+## Header와 Footer 크기를 제공해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  referenceSizeForHeaderInSection section: Int
+) -> CGSize {
+  CGSize(
+    width: collectionView.bounds.width,
+    height: 52
+  )
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  referenceSizeForFooterInSection section: Int
+) -> CGSize {
+  section == 0
+    ? CGSize(width: collectionView.bounds.width, height: 32)
+    : .zero
+}
+```
+
+크기만 반환한다고 header나 footer가 자동 생성되지는 않아요. 재사용 뷰를 등록하고 Data Source의 `viewForSupplementaryElementOfKind`에서도 실제 뷰를 제공해야 해요.
+
+## Layout 프로퍼티와 Delegate 값의 우선순위를 구분해요
+
+| 요구사항                            | 적합한 위치                   |
+| ----------------------------------- | ----------------------------- |
+| 모든 item이 같은 고정 크기          | `flowLayout.itemSize`         |
+| 화면 너비에 따라 열 수 변경         | Delegate의 `sizeForItemAt`    |
+| 모든 section의 같은 inset과 spacing | Flow Layout 프로퍼티          |
+| Section마다 다른 inset과 spacing    | Delegate의 section별 메서드   |
+| Auto Layout으로 내용 기반 크기      | `estimatedItemSize`와 셀 제약 |
+
+Delegate 값은 해당 항목의 Flow Layout 기본 프로퍼티보다 우선해요. 둘을 동시에 설정해도 동작하지만 실제 값을 찾기 어려워질 수 있으므로, 동적인 항목만 delegate로 옮기세요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                       | 먼저 확인할 것                                                                 |
+| ------------------------------------------ | ------------------------------------------------------------------------------ |
+| 크기 callback이 호출되지 않아요.           | Layout이 실제 `UICollectionViewFlowLayout`이고 delegate가 연결됐는지 확인해요. |
+| 마지막 열이 다음 줄로 넘어가요.            | Content inset, section inset, 전체 spacing을 모두 빼고 너비를 계산했는지 봐요. |
+| Header 공간만 있고 뷰가 안 보여요.         | Header 등록과 Data Source 제공 메서드를 함께 구현했는지 확인해요.              |
+| 회전 뒤 이전 크기가 남아요.                | Bounds 크기 변경 시 layout이 invalidation되는지 확인해요.                      |
+| Self-sizing 크기와 delegate 값이 충돌해요. | 크기 결정 방식을 하나로 정하고 `estimatedItemSize` 설정을 확인해요.            |
+
+## 면접에서 이어질 수 있는 질문
+
+### `UICollectionViewDelegate`와 무엇이 다른가요?
+
+`UICollectionViewDelegate`는 선택과 highlight 같은 사용자 상호작용을 다뤄요. `UICollectionViewDelegateFlowLayout`은 이를 상속하면서 Flow Layout이 필요한 item 크기와 spacing 정보를 추가로 제공해요.
+
+### 모든 item이 같은 크기여도 Delegate가 필요한가요?
+
+아니요. 고정된 크기라면 `UICollectionViewFlowLayout.itemSize`를 설정하는 편이 더 단순해요. 화면 너비나 section, 모델에 따라 값이 달라질 때 delegate가 유용해요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDelegateFlowLayout](https://developer.apple.com/documentation/uikit/uicollectionviewdelegateflowlayout)
+- [Apple Developer Documentation — UICollectionViewFlowLayout](https://developer.apple.com/documentation/uikit/uicollectionviewflowlayout)
+- [Apple Developer Documentation — collectionView(_:layout:sizeForItemAt:)](<https://developer.apple.com/documentation/uikit/uicollectionviewdelegateflowlayout/collectionview(_:layout:sizeforitemat:)>)

--- a/docs/guide/uikit/collection-views/examples/flow-layout.md
+++ b/docs/guide/uikit/collection-views/examples/flow-layout.md
@@ -1,0 +1,316 @@
+---
+title: 'UICollectionViewFlowLayout 예제'
+description: 'UICollectionViewFlowLayout으로 균일한 사진 격자를 만들고, delegate에서 가용 너비를 계산해 회전과 Split View에 대응하는 반응형 셀·헤더를 구현합니다.'
+---
+
+# UICollectionViewFlowLayout 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewFlowLayout`은 item을 스크롤 축과 반대 방향으로 차례대로 배치하고 공간이 부족하면 다음 줄로 넘기며, delegate로 section별 크기와 간격을 동적으로 정할 수 있어요.
+
+이 예제에서는 [공통 `Photo` 모델과 `PhotoCell`](./index)을 사용해 화면 너비에 반응하는 사진 격자를 만들어요. Data source는 [전통적인 방식](./data-source)과 [Diffable 방식](./diffable-data-source) 중 어느 쪽을 사용해도 돼요.
+
+## 먼저 알아둘 용어
+
+| 용어                | 쉬운 뜻                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| scroll direction    | 전체 콘텐츠가 움직이는 방향이에요. `.vertical`이면 item은 가로로 놓이다 다음 행으로 넘어가요. |
+| interitem spacing   | 같은 행이나 열 안에서 이웃한 item 사이의 최소 간격이에요.                                     |
+| line spacing        | 행과 행 또는 열과 열 사이의 최소 간격이에요.                                                  |
+| section inset       | section 콘텐츠와 Collection View 가장자리 사이 여백이에요.                                    |
+| layout invalidation | 이전 크기·위치 계산이 유효하지 않으니 다시 계산하라고 layout에 알리는 과정이에요.             |
+| self-sizing         | Auto Layout으로 셀 콘텐츠를 측정해 최종 크기를 정하는 방식이에요.                             |
+
+## 가장 작은 격자를 만들어요
+
+```swift
+private func makeFlowLayout() -> UICollectionViewFlowLayout {
+  let layout = UICollectionViewFlowLayout()
+  layout.scrollDirection = .vertical
+  layout.itemSize = CGSize(width: 160, height: 180)
+  layout.minimumInteritemSpacing = 12
+  layout.minimumLineSpacing = 16
+  layout.sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+  return layout
+}
+```
+
+세로 스크롤에서는 item이 왼쪽에서 오른쪽으로 놓이고 남은 너비가 부족하면 다음 행으로 넘어가요. `itemSize`를 고정하면 구현은 짧지만 좁은 화면에서 한 열만 보이거나 넓은 화면에 빈 공간이 많이 남을 수 있어요.
+
+## Delegate로 현재 너비에 맞는 셀 크기를 계산해요
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDelegateFlowLayout
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
+    let sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    let spacing: CGFloat = 12
+
+    let availableWidth =
+      collectionView.bounds.width
+      - collectionView.adjustedContentInset.left
+      - collectionView.adjustedContentInset.right
+      - sectionInset.left
+      - sectionInset.right
+
+    let minimumCellWidth: CGFloat = 150
+    let columnCount = max(
+      1,
+      Int(
+        (availableWidth + spacing)
+          / (minimumCellWidth + spacing)
+      )
+    )
+    let totalSpacing =
+      CGFloat(columnCount - 1) * spacing
+    let cellWidth = floor(
+      (availableWidth - totalSpacing)
+        / CGFloat(columnCount)
+    )
+
+    return CGSize(
+      width: cellWidth,
+      height: cellWidth
+    )
+  }
+}
+```
+
+기기 이름으로 iPhone과 iPad를 나누지 않고 실제 가용 너비를 사용해요. 이 방식은 화면 회전과 iPad Split View, 창 크기 변경에도 같은 규칙을 적용할 수 있어요.
+
+`adjustedContentInset`과 section inset을 모두 빼야 안전 영역이나 navigation bar 조정 뒤에도 셀이 가장자리를 넘지 않아요.
+
+## 화면 크기가 바뀌면 layout을 다시 계산해요
+
+View controller 본문에 아래 override를 추가해요.
+
+```swift
+override func viewWillTransition(
+  to size: CGSize,
+  with coordinator: UIViewControllerTransitionCoordinator
+) {
+  super.viewWillTransition(to: size, with: coordinator)
+
+  coordinator.animate(
+    alongsideTransition: { [weak self] _ in
+      self?.collectionView.collectionViewLayout.invalidateLayout()
+    },
+    completion: nil
+  )
+}
+```
+
+Flow Layout은 bounds 변경을 감지해 다시 계산할 수 있지만, 회전 애니메이션과 정확히 맞춰야 하거나 사용자 정의 크기 계산을 확실히 다시 실행하려면 명시적으로 invalidate할 수 있어요.
+
+## Section마다 크기와 간격을 다르게 정해요
+
+`UICollectionViewDelegateFlowLayout`은 item 크기뿐 아니라 section별 여백과 간격도 제공해요.
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  insetForSectionAt section: Int
+) -> UIEdgeInsets {
+  section == 0
+    ? UIEdgeInsets(top: 24, left: 16, bottom: 32, right: 16)
+    : UIEdgeInsets(top: 12, left: 16, bottom: 24, right: 16)
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  layout collectionViewLayout: UICollectionViewLayout,
+  minimumLineSpacingForSectionAt section: Int
+) -> CGFloat {
+  section == 0 ? 20 : 12
+}
+```
+
+프로퍼티에 지정한 값은 기본값이고 delegate가 값을 반환하면 해당 section에서는 delegate 값이 사용돼요.
+
+## Header 크기를 layout에 알려요
+
+```swift
+private func makeFlowLayoutWithHeader()
+  -> UICollectionViewFlowLayout
+{
+  let layout = makeFlowLayout()
+  layout.headerReferenceSize = CGSize(
+    width: 0,
+    height: 52
+  )
+  layout.sectionHeadersPinToVisibleBounds = true
+  return layout
+}
+```
+
+`headerReferenceSize`는 header 공간을 만들고, 실제 header 뷰는 data source가 제공해요.
+
+```swift
+final class GalleryHeaderView: UICollectionReusableView {
+  private let titleLabel = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    titleLabel.font = .preferredFont(forTextStyle: .title2)
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(titleLabel)
+
+    NSLayoutConstraint.activate([
+      titleLabel.topAnchor.constraint(
+        equalTo: topAnchor,
+        constant: 8
+      ),
+      titleLabel.leadingAnchor.constraint(
+        equalTo: leadingAnchor,
+        constant: 16
+      ),
+      titleLabel.trailingAnchor.constraint(
+        lessThanOrEqualTo: trailingAnchor,
+        constant: -16
+      ),
+      titleLabel.bottomAnchor.constraint(
+        equalTo: bottomAnchor,
+        constant: -8
+      ),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+
+  func configure(title: String) {
+    titleLabel.text = title
+  }
+}
+```
+
+```swift
+collectionView.register(
+  GalleryHeaderView.self,
+  forSupplementaryViewOfKind:
+    UICollectionView.elementKindSectionHeader,
+  withReuseIdentifier: "GalleryHeaderView"
+)
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  viewForSupplementaryElementOfKind kind: String,
+  at indexPath: IndexPath
+) -> UICollectionReusableView {
+  guard kind == UICollectionView.elementKindSectionHeader else {
+    preconditionFailure("지원하지 않는 supplementary view예요.")
+  }
+
+  let header = collectionView.dequeueReusableSupplementaryView(
+    ofKind: kind,
+    withReuseIdentifier: "GalleryHeaderView",
+    for: indexPath
+  )
+
+  (header as? GalleryHeaderView)?.configure(
+    title: sections[indexPath.section].title
+  )
+  return header
+}
+```
+
+Header가 보이지 않는다면 layout에 크기를 지정했는지, 뷰를 등록했는지, data source가 뷰를 반환하는지 세 단계를 모두 확인하세요.
+
+## 가로 스크롤 목록을 만들어요
+
+```swift
+private func makeHorizontalFlowLayout()
+  -> UICollectionViewFlowLayout
+{
+  let layout = UICollectionViewFlowLayout()
+  layout.scrollDirection = .horizontal
+  layout.itemSize = CGSize(width: 280, height: 180)
+  layout.minimumLineSpacing = 12
+  layout.sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+  return layout
+}
+```
+
+가로 스크롤에서는 item이 위에서 아래로 놓이다 공간이 부족하면 다음 열로 넘어가요. 카드 하나만 세로로 보이게 하려면 Collection View 높이와 item 높이를 맞추세요.
+
+세로 Collection View 안에 가로 Collection View를 중첩할 수도 있지만, section 하나만 가로로 움직이는 화면이라면 [Compositional Layout의 orthogonal scrolling](./compositional-layout)을 사용하면 중첩을 줄일 수 있어요.
+
+## Self-sizing 셀을 사용할 때는 estimated 크기를 정해요
+
+```swift
+let layout = UICollectionViewFlowLayout()
+layout.estimatedItemSize = CGSize(
+  width: 160,
+  height: 120
+)
+```
+
+Self-sizing 셀은 `contentView` 내부 Auto Layout 제약으로 최종 크기를 계산해요. 위·아래와 좌·우 방향의 제약이 완성되지 않으면 크기가 모호하거나 반복 측정으로 스크롤이 흔들릴 수 있어요.
+
+균일한 사진 격자처럼 셀 크기가 예측 가능하다면 직접 `itemSize`를 계산하는 편이 더 단순하고 측정 비용도 줄어요.
+
+## Flow Layout과 Compositional Layout을 비교해요
+
+| 요구사항                         | Flow Layout                              | Compositional Layout                            |
+| -------------------------------- | ---------------------------------------- | ----------------------------------------------- |
+| 한 방향 목록이나 균일한 격자     | 설정이 짧고 이해하기 쉬워요.             | 가능하지만 구성 객체가 더 많아요.               |
+| item마다 크기가 조금씩 다른 격자 | delegate 메서드가 잘 맞아요.             | estimated size를 사용할 수 있어요.              |
+| section마다 전혀 다른 배치       | delegate 분기가 복잡해질 수 있어요.      | section별 group과 스크롤을 선언하기 쉬워요.     |
+| 세로 화면 안의 가로 카드         | 중첩 Collection View를 고려할 수 있어요. | orthogonal scrolling으로 한 section에 구성해요. |
+| 화면 너비 대응                   | delegate에서 `CGSize`를 계산해요.        | layout environment로 section을 구성해요.        |
+
+모든 section이 같은 격자라면 Flow Layout이 더 읽기 쉬워요. App Store처럼 section별 배치가 다르다면 [Compositional Layout 예제](./compositional-layout)를 검토하세요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                 | 먼저 확인할 것                                                                      |
+| ------------------------------------ | ----------------------------------------------------------------------------------- |
+| 마지막 열이 잘리거나 다음 줄로 가요. | inset과 item 간격을 제외한 실제 너비로 셀 크기를 계산했는지 확인해요.               |
+| 회전 뒤 열 수가 바뀌지 않아요.       | layout invalidation 뒤 `sizeForItemAt`이 다시 호출되는지 확인해요.                  |
+| 셀 높이가 예상과 달라요.             | `itemSize`, `estimatedItemSize`, delegate 크기 중 무엇이 최종 값을 제공하는지 봐요. |
+| Header가 나타나지 않아요.            | header 크기, 등록, data source 제공을 모두 확인해요.                                |
+| Self-sizing 중 스크롤이 흔들려요.    | 셀 내부 Auto Layout 제약과 estimated 크기가 현실적인지 확인해요.                    |
+
+## 면접에서 이어질 수 있는 질문
+
+### `minimumInteritemSpacing`은 항상 정확한 간격인가요?
+
+최소 간격이에요. Flow Layout은 한 행의 남는 공간을 배분하면서 실제 간격을 더 크게 만들 수 있어요. 정확한 열 너비가 필요하면 inset과 간격을 포함해 item 크기를 계산하세요.
+
+### 언제 layout을 invalidate해야 하나요?
+
+Collection View의 bounds, 셀 크기를 결정하는 데이터, layout 정책이 바뀌어 기존 attributes를 다시 계산해야 할 때예요. 단순한 셀 내용 변경만으로 frame이 바뀌지 않는다면 전체 invalidation이 필요하지 않을 수 있어요.
+
+## 함께 읽으면 좋아요
+
+Flow Layout 화면의 선택·하이라이트·메뉴는 [전통적인 `UICollectionViewDelegate` 예제](./traditional-delegate)에서 이어서 확인할 수 있어요.
+
+Item 크기와 section 간격을 delegate 역할에 집중해 다시 살펴보려면 [`UICollectionViewDelegateFlowLayout` 예제](./flow-layout-delegate)를 읽어 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewFlowLayout](https://developer.apple.com/documentation/uikit/uicollectionviewflowlayout)
+- [Apple Developer Documentation — UICollectionViewDelegateFlowLayout](https://developer.apple.com/documentation/uikit/uicollectionviewdelegateflowlayout)

--- a/docs/guide/uikit/collection-views/examples/index.md
+++ b/docs/guide/uikit/collection-views/examples/index.md
@@ -1,0 +1,252 @@
+---
+title: 'UICollectionView 예제 한눈에 보기'
+description: 'UICollectionView의 Data Source·Delegate·Layout 역할을 전체 구조로 비교하고 prefetch, drag and drop, List·Custom·Transition Layout 예제로 이어지는 공통 모델을 준비합니다.'
+---
+
+# UICollectionView 예제 한눈에 보기
+
+> **면접 답변 한 줄 요약:** `UICollectionView` 예제는 data source로 데이터와 셀을 연결하고 layout으로 배치를 정하며, 안정적인 item 식별자를 기준으로 갱신할 때 안전하게 확장할 수 있어요.
+
+이 섹션은 Collection View를 실제 화면으로 조립하는 예제를 역할별 문서로 나누어 설명해요. 모든 문서는 같은 사진 갤러리 모델과 셀을 사용하므로 데이터 제공, 사용자 상호작용, layout의 차이에 집중할 수 있어요.
+
+## 전체 역할 지도를 먼저 봐요
+
+```text
+UICollectionView
+├── Data Source
+│   ├── UICollectionViewDataSource
+│   ├── UICollectionViewDiffableDataSource
+│   └── UICollectionViewDataSourcePrefetching
+├── Delegate
+│   ├── UICollectionViewDelegate
+│   ├── UICollectionViewDelegateFlowLayout
+│   ├── UICollectionViewDragDelegate
+│   └── UICollectionViewDropDelegate
+└── Layout
+    ├── UICollectionViewFlowLayout
+    ├── UICollectionViewCompositionalLayout
+    │   └── List Layout
+    ├── Custom UICollectionViewLayout
+    └── UICollectionViewTransitionLayout
+```
+
+Data Source는 무엇을 표시할지, Delegate는 사용자와 item의 상호작용을 어떻게 처리할지, Layout은 어디에 배치할지를 결정해요. 각 역할은 조합할 수 있으므로 Diffable Data Source에 Flow Layout을 붙이는 것도 가능해요.
+
+## 어떤 예제부터 읽어야 하나요
+
+| 역할        | 구현하려는 내용                                | 예제 문서                                                            |
+| ----------- | ---------------------------------------------- | -------------------------------------------------------------------- |
+| Data Source | 배열로 item 개수와 셀 제공하기                 | [`UICollectionViewDataSource`](./data-source)                        |
+| Data Source | snapshot으로 삽입·삭제·내용 변경하기           | [`UICollectionViewDiffableDataSource`](./diffable-data-source)       |
+| Data Source | 곧 보일 이미지 작업을 미리 시작하기            | [`UICollectionViewDataSourcePrefetching`](./data-source-prefetching) |
+| Delegate    | 배열 기반 선택·하이라이트·메뉴 처리하기        | [전통적인 `UICollectionViewDelegate`](./traditional-delegate)        |
+| Delegate    | identifier 기반 선택·상호작용 처리하기         | [현대적인 `UICollectionViewDelegate`](./modern-delegate)             |
+| Delegate    | Flow Layout의 item 크기·간격을 동적으로 정하기 | [`UICollectionViewDelegateFlowLayout`](./flow-layout-delegate)       |
+| Delegate    | Item을 들어 올려 drag 시작하기                 | [`UICollectionViewDragDelegate`](./drag-delegate)                    |
+| Delegate    | 내부 재배치와 외부 drop 처리하기               | [`UICollectionViewDropDelegate`](./drop-delegate)                    |
+| Layout      | 균일한 목록·반응형 격자 만들기                 | [`UICollectionViewFlowLayout`](./flow-layout)                        |
+| Layout      | 가로 카드와 격자를 한 화면에 조합하기          | [`UICollectionViewCompositionalLayout`](./compositional-layout)      |
+| Layout      | 설정 화면과 표준 목록 만들기                   | [Collection View List Layout](./list-layout)                         |
+| Layout      | 직접 layout attributes를 계산하기              | [Custom `UICollectionViewLayout`](./custom-layout)                   |
+| Layout      | 두 layout 사이를 gesture로 전환하기            | [`UICollectionViewTransitionLayout`](./transition-layout)            |
+| 공통 확장   | 빈 상태·새로고침·페이지네이션 추가하기         | [실무 확장 예제](./practical-recipes)                                |
+
+처음이라면 전통적인 흐름이나 현대적인 흐름 하나를 먼저 완성한 뒤, 필요한 prefetch·drag and drop·고급 layout 예제로 확장하세요.
+
+## 먼저 알아둘 용어
+
+| 용어                 | 쉬운 뜻                                                                                   |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| data source          | Collection View가 item 개수와 셀을 물을 때 답하는 객체예요.                               |
+| `IndexPath`          | 현재 section과 item의 위치예요. 앞에 item이 추가되면 같은 데이터의 위치도 바뀔 수 있어요. |
+| item identifier      | 위치가 바뀌어도 같은 데이터임을 나타내는 안정적인 `Hashable` 값이에요.                    |
+| snapshot             | 특정 시점에 어떤 section과 item이 어떤 순서로 존재하는지 표현한 값이에요.                 |
+| cell registration    | 셀 타입과 셀 구성 코드를 묶어 재사용하는 값이에요.                                        |
+| Flow Layout          | item을 한 줄에 가능한 만큼 놓고 다음 줄로 넘기는 격자형 layout이에요.                     |
+| Compositional Layout | item, group, section을 조합해 section마다 서로 다른 배치를 만드는 layout이에요.           |
+
+## 공통 사진 모델을 만들어요
+
+모든 예제에서 아래 `Photo`를 사용해요. Diffable Data Source의 item identifier에는 바뀔 수 있는 모델 전체가 아니라 `Photo.ID`를 사용해요.
+
+```swift
+import UIKit
+
+struct Photo: Identifiable {
+  let id: UUID
+  var title: String
+  let symbolName: String
+  var isFavorite: Bool
+}
+
+extension Photo {
+  static let samples: [Photo] = [
+    Photo(
+      id: UUID(),
+      title: "여름 바다",
+      symbolName: "beach.umbrella.fill",
+      isFavorite: true
+    ),
+    Photo(
+      id: UUID(),
+      title: "도시 산책",
+      symbolName: "building.2.fill",
+      isFavorite: false
+    ),
+    Photo(
+      id: UUID(),
+      title: "주말 캠핑",
+      symbolName: "tent.fill",
+      isFavorite: false
+    ),
+    Photo(
+      id: UUID(),
+      title: "저녁 노을",
+      symbolName: "sunset.fill",
+      isFavorite: true
+    ),
+  ]
+}
+```
+
+제목이나 즐겨찾기 여부가 바뀌어도 같은 사진이라는 정체성은 유지되어야 해요. 모델 전체를 자동 생성 `Hashable` 값으로 사용하면 내용 변경을 삭제와 삽입으로 오해할 수 있으므로, 별도의 안정적인 ID를 두는 편이 안전해요.
+
+## 공통 재사용 셀을 만들어요
+
+전통적인 reuse identifier와 현대적인 cell registration 모두 같은 `PhotoCell`을 사용할 수 있어요.
+
+```swift
+final class PhotoCell: UICollectionViewCell {
+  static let reuseIdentifier = "PhotoCell"
+
+  private let imageView = UIImageView()
+  private let titleLabel = UILabel()
+  private let favoriteImageView = UIImageView(
+    image: UIImage(systemName: "heart.fill")
+  )
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = .systemIndigo
+
+    titleLabel.font = .preferredFont(forTextStyle: .headline)
+    titleLabel.numberOfLines = 1
+
+    favoriteImageView.tintColor = .systemPink
+    favoriteImageView.setContentHuggingPriority(
+      .required,
+      for: .horizontal
+    )
+
+    let titleRow = UIStackView(
+      arrangedSubviews: [titleLabel, favoriteImageView]
+    )
+    titleRow.axis = .horizontal
+    titleRow.spacing = 8
+    titleRow.alignment = .center
+
+    let stack = UIStackView(arrangedSubviews: [imageView, titleRow])
+    stack.axis = .vertical
+    stack.spacing = 10
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    contentView.addSubview(stack)
+    contentView.backgroundColor = .secondarySystemBackground
+    contentView.layer.cornerRadius = 14
+    contentView.layer.cornerCurve = .continuous
+
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(
+        equalTo: contentView.topAnchor,
+        constant: 12
+      ),
+      stack.leadingAnchor.constraint(
+        equalTo: contentView.leadingAnchor,
+        constant: 12
+      ),
+      stack.trailingAnchor.constraint(
+        equalTo: contentView.trailingAnchor,
+        constant: -12
+      ),
+      stack.bottomAnchor.constraint(
+        equalTo: contentView.bottomAnchor,
+        constant: -12
+      ),
+      imageView.heightAnchor.constraint(
+        greaterThanOrEqualToConstant: 72
+      ),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+
+  func configure(with photo: Photo) {
+    imageView.image = UIImage(systemName: photo.symbolName)
+    titleLabel.text = photo.title
+    favoriteImageView.isHidden = !photo.isFavorite
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+
+    imageView.image = nil
+    titleLabel.text = nil
+    favoriteImageView.isHidden = true
+  }
+
+  override var isSelected: Bool {
+    didSet {
+      contentView.layer.borderWidth = isSelected ? 3 : 0
+      contentView.layer.borderColor = UIColor.systemBlue.cgColor
+    }
+  }
+}
+```
+
+셀의 하위 뷰는 `contentView`에 넣어요. `prepareForReuse()`에서는 이전 item의 표시 상태를 초기화해요. 네트워크 이미지를 사용한다면 진행 중인 작업도 취소하고, 완료 시점에 셀이 여전히 같은 `Photo.ID`를 표시하는지 확인해야 해요.
+
+## Data Source와 layout은 독립적으로 선택해요
+
+| 선택 기준              | 단순한 출발점                       | 변경·배치가 복잡할 때                               |
+| ---------------------- | ----------------------------------- | --------------------------------------------------- |
+| 데이터 제공과 갱신     | `UICollectionViewDataSource`        | `UICollectionViewDiffableDataSource`                |
+| 셀 등록과 구성         | reuse identifier + protocol 메서드  | cell registration + cell provider                   |
+| 한 방향 목록·균일 격자 | `UICollectionViewFlowLayout`        | 둘 다 가능하지만 Flow Layout이 더 짧아요.           |
+| section별 다른 배치    | delegate 분기가 복잡해질 수 있어요. | `UICollectionViewCompositionalLayout`이 잘 맞아요.  |
+| 삽입·삭제              | 모델과 batch update를 직접 맞춰요.  | 목표 상태 snapshot을 적용해 차이를 계산하게 맡겨요. |
+
+전통적인 data source에 Compositional Layout을 붙이거나 Diffable Data Source에 Flow Layout을 붙이는 것도 가능해요. 데이터 제공과 화면 배치는 서로 다른 책임이기 때문이에요.
+
+## 예제의 지원 범위를 확인해요
+
+| API                                   | 최소 버전 |
+| ------------------------------------- | --------- |
+| `UICollectionViewDiffableDataSource`  | iOS 13    |
+| `UICollectionViewCompositionalLayout` | iOS 13    |
+| `UICollectionView.CellRegistration`   | iOS 14    |
+| Collection View List Layout           | iOS 14    |
+| Drag and Drop                         | iOS 11    |
+| Data Source Prefetching               | iOS 10    |
+| Interactive Layout Transition         | iOS 7     |
+| snapshot `reconfigureItems(_:)`       | iOS 15    |
+
+예제는 iOS 15 이상을 기준으로 작성해요. 더 낮은 배포 대상을 지원한다면 cell registration 대신 class·nib 등록을 사용하거나 `reconfigureItems(_:)` 대신 갱신 범위를 검토해 `reloadItems(_:)`를 사용하세요.
+
+## 다음 예제로 이동해요
+
+전통적인 흐름은 [`UICollectionViewDataSource` 예제](./data-source) → [전통적인 `UICollectionViewDelegate` 예제](./traditional-delegate) → [`UICollectionViewFlowLayout` 예제](./flow-layout) 순서로 읽어 보세요.
+
+현대적인 흐름은 [`UICollectionViewDiffableDataSource` 예제](./diffable-data-source) → [현대적인 `UICollectionViewDelegate` 예제](./modern-delegate) → [`UICollectionViewCompositionalLayout` 예제](./compositional-layout) 순서로 이어져요.
+
+기본 화면을 완성했다면 [`UICollectionViewDataSourcePrefetching`](./data-source-prefetching)으로 이미지 준비를 앞당기고, [`UICollectionViewDragDelegate`](./drag-delegate)와 [`UICollectionViewDropDelegate`](./drop-delegate)로 재배치를 추가해 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)
+- [Apple Developer Documentation — UICollectionViewCell](https://developer.apple.com/documentation/uikit/uicollectionviewcell)
+- [Apple Developer Documentation — UICollectionView.CellRegistration](https://developer.apple.com/documentation/uikit/uicollectionview/cellregistration)

--- a/docs/guide/uikit/collection-views/examples/list-layout.md
+++ b/docs/guide/uikit/collection-views/examples/list-layout.md
@@ -1,0 +1,278 @@
+---
+title: 'UICollectionView List Layout 예제'
+description: 'UICollectionLayoutListConfiguration과 UICollectionViewListCell로 설정형 목록을 만들고, Diffable Data Source·accessory·swipe action·section별 appearance를 연결합니다.'
+---
+
+# UICollectionView List Layout 예제
+
+> **면접 답변 한 줄 요약:** Collection View의 List Layout은 `UICollectionLayoutListConfiguration`을 Compositional Layout에 적용해 표준 목록 모양·구분선·accessory·swipe action을 Collection View의 재사용과 Diffable 갱신 방식으로 구현해요.
+
+List Layout은 `UITableView`처럼 보이는 목록을 Collection View로 만들 때 사용하는 Compositional Layout의 편의 API예요. iOS 14 이상에서 `UICollectionViewListCell`과 함께 사용하면 설정 화면, 사이드바, 계층형 목록을 일관된 방식으로 구성할 수 있어요.
+
+## 먼저 알아둘 용어
+
+| 용어                  | 쉬운 뜻                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| list appearance       | `.plain`, `.grouped`, `.insetGrouped`, `.sidebar`처럼 목록의 기본 시각 스타일이에요. |
+| list configuration    | Appearance, 구분선, header·footer, swipe action 정책을 모은 값이에요.                |
+| list cell             | 제목·부제·이미지·accessory 구성을 지원하는 Collection View 전용 표준 셀이에요.       |
+| accessory             | Disclosure indicator, checkmark처럼 셀 오른쪽이나 왼쪽에 붙는 보조 요소예요.         |
+| content configuration | 셀의 제목·이미지·색처럼 표시 내용을 값으로 구성하는 UIKit 방식이에요.                |
+
+## 가장 작은 List Layout을 만들어요
+
+```swift
+private func makeListLayout()
+  -> UICollectionViewCompositionalLayout
+{
+  var configuration = UICollectionLayoutListConfiguration(
+    appearance: .insetGrouped
+  )
+  configuration.headerMode = .supplementary
+  configuration.showsSeparators = true
+
+  return UICollectionViewCompositionalLayout.list(
+    using: configuration
+  )
+}
+```
+
+`UICollectionViewCompositionalLayout.list(using:)`은 모든 section에 같은 list configuration을 적용해요. 한 화면에 목록 section만 있고 모양도 같다면 가장 짧은 출발점이에요.
+
+## 화면 Section과 Item ID를 정의해요
+
+```swift
+enum SettingsSection: Hashable {
+  case account
+  case display
+}
+
+enum SettingsItem: Hashable {
+  case profile
+  case notifications
+  case darkMode
+
+  var title: String {
+    switch self {
+    case .profile:
+      "프로필"
+    case .notifications:
+      "알림"
+    case .darkMode:
+      "화면 모드"
+    }
+  }
+
+  var symbolName: String {
+    switch self {
+    case .profile:
+      "person.crop.circle"
+    case .notifications:
+      "bell"
+    case .darkMode:
+      "circle.lefthalf.filled"
+    }
+  }
+}
+```
+
+Snapshot에는 현재 위치가 아니라 안정적인 enum case를 넣어요. 항목이 이동해도 선택과 셀 상태가 같은 ID에 연결돼요.
+
+## List Cell Registration을 만들어요
+
+```swift
+private let cellRegistration =
+  UICollectionView.CellRegistration<
+    UICollectionViewListCell,
+    SettingsItem
+  > { cell, _, item in
+    var content = cell.defaultContentConfiguration()
+    content.text = item.title
+    content.image = UIImage(systemName: item.symbolName)
+    cell.contentConfiguration = content
+
+    switch item {
+    case .profile:
+      cell.accessories = [.disclosureIndicator()]
+    case .notifications:
+      cell.accessories = [
+        .label(text: "켜짐"),
+        .disclosureIndicator(),
+      ]
+    case .darkMode:
+      cell.accessories = [.checkmark()]
+    }
+  }
+```
+
+셀의 subview를 직접 추가하지 않고 content와 accessory configuration을 값으로 지정해요. 재사용될 때 registration closure가 새 item의 전체 상태를 다시 덮어쓰므로 이전 accessory가 남지 않아요.
+
+## Diffable Data Source와 연결해요
+
+```swift
+private lazy var dataSource =
+  UICollectionViewDiffableDataSource<
+    SettingsSection,
+    SettingsItem
+  >(
+    collectionView: collectionView
+  ) { [weak self] collectionView, indexPath, item in
+    guard let self else {
+      return nil
+    }
+
+    return collectionView.dequeueConfiguredReusableCell(
+      using: cellRegistration,
+      for: indexPath,
+      item: item
+    )
+  }
+```
+
+초기 snapshot은 section과 item 순서를 명시해요.
+
+```swift
+private func applyInitialSnapshot() {
+  var snapshot = NSDiffableDataSourceSnapshot<
+    SettingsSection,
+    SettingsItem
+  >()
+
+  snapshot.appendSections([.account, .display])
+  snapshot.appendItems(
+    [.profile, .notifications],
+    toSection: .account
+  )
+  snapshot.appendItems(
+    [.darkMode],
+    toSection: .display
+  )
+
+  dataSource.apply(
+    snapshot,
+    animatingDifferences: false
+  )
+}
+```
+
+## Swipe Action을 Configuration에 추가해요
+
+```swift
+private func makeEditableListLayout()
+  -> UICollectionViewCompositionalLayout
+{
+  var configuration = UICollectionLayoutListConfiguration(
+    appearance: .insetGrouped
+  )
+
+  configuration.trailingSwipeActionsConfigurationProvider = {
+    [weak self] indexPath in
+    guard
+      let self,
+      let item = dataSource.itemIdentifier(
+        for: indexPath
+      )
+    else {
+      return nil
+    }
+
+    let reset = UIContextualAction(
+      style: .normal,
+      title: "초기화"
+    ) { [weak self] _, _, completion in
+      self?.reset(item)
+      completion(true)
+    }
+    reset.backgroundColor = .systemOrange
+
+    return UISwipeActionsConfiguration(
+      actions: [reset]
+    )
+  }
+
+  return UICollectionViewCompositionalLayout.list(
+    using: configuration
+  )
+}
+```
+
+Swipe action closure가 받은 `IndexPath`를 즉시 Diffable identifier로 바꿔요. Action이 실행될 때 화면 순서가 달라져도 `SettingsItem`으로 올바른 모델을 갱신할 수 있어요.
+
+`reset(_:)`은 해당 item의 backing store를 초기화한 뒤 현재 snapshot에서 item을 `reconfigureItems(_:)`로 표시 갱신하는 화면 helper라고 가정했어요.
+
+## Section마다 다른 List 모양을 사용해요
+
+범위를 벗어난 section index를 안전하게 처리할 작은 extension을 먼저 추가해요.
+
+```swift
+extension Collection {
+  subscript(safe index: Index) -> Element? {
+    indices.contains(index) ? self[index] : nil
+  }
+}
+```
+
+```swift
+private func makeSectionedListLayout()
+  -> UICollectionViewCompositionalLayout
+{
+  UICollectionViewCompositionalLayout {
+    [weak self] sectionIndex, environment in
+    guard
+      let self,
+      let sectionID = dataSource.snapshot()
+        .sectionIdentifiers[safe: sectionIndex]
+    else {
+      return nil
+    }
+
+    let appearance: UICollectionLayoutListConfiguration.Appearance =
+      sectionID == .account ? .insetGrouped : .plain
+    let configuration = UICollectionLayoutListConfiguration(
+      appearance: appearance
+    )
+
+    return NSCollectionLayoutSection.list(
+      using: configuration,
+      layoutEnvironment: environment
+    )
+  }
+}
+```
+
+Section provider index는 현재 snapshot의 section 순서로 해석해요. 위 예제의 `[safe:]`는 범위를 확인해 optional element를 반환하는 배열 extension이라고 가정해요.
+
+## List Layout과 일반 Compositional Layout을 비교해요
+
+| 요구사항                             | List Layout                                     | 일반 Compositional Layout                 |
+| ------------------------------------ | ----------------------------------------------- | ----------------------------------------- |
+| 설정·메뉴 같은 한 열 목록            | 표준 모양과 accessory를 빠르게 구성해요.        | Item·group 크기를 직접 구성해야 해요.     |
+| Swipe action                         | List configuration에서 바로 제공해요.           | 별도 interaction 설계가 필요할 수 있어요. |
+| App Store형 카드와 격자              | 목적에 맞지 않아요.                             | Section별 group을 조합하기 좋아요.        |
+| 목록과 카드 section을 한 화면에 혼합 | Section provider에서 list section으로 사용해요. | 다른 section과 함께 조합할 수 있어요.     |
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                  | 먼저 확인할 것                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------ |
+| List Cell이 일반 빈 셀처럼 보여요.    | `UICollectionViewListCell`과 content configuration을 사용했는지 확인해요.      |
+| 재사용 뒤 accessory가 남아요.         | Registration closure에서 item마다 `accessories` 전체를 다시 지정하는지 봐요.   |
+| Swipe가 다른 item을 바꿔요.           | Action 생성 시 `IndexPath`를 identifier로 변환하는지 확인해요.                 |
+| Section에 다른 appearance가 적용돼요. | Section provider index와 snapshot section 순서가 같은지 확인해요.              |
+| Header가 안 보여요.                   | `headerMode`와 supplementary registration·provider를 함께 설정했는지 확인해요. |
+
+## 면접에서 이어질 수 있는 질문
+
+### List Layout도 Compositional Layout인가요?
+
+네. `UICollectionViewCompositionalLayout.list(using:)`이 list configuration을 사용하는 Compositional Layout을 만들어 줘요. 여러 section 중 일부만 목록으로 만들 때는 `NSCollectionLayoutSection.list(using:layoutEnvironment:)`을 사용해요.
+
+### `UITableView` 대신 반드시 List Layout을 써야 하나요?
+
+아니요. 단순한 기존 표라면 `UITableView`도 충분해요. 같은 화면에서 목록과 카드·격자를 조합하거나 Diffable Collection View 구성 방식을 통일할 때 List Layout의 이점이 커져요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewCompositionalLayout](https://developer.apple.com/documentation/uikit/uicollectionviewcompositionallayout)
+- [Apple Developer Documentation — UICollectionLayoutListConfiguration](https://developer.apple.com/documentation/uikit/uicollectionlayoutlistconfiguration)
+- [Apple Developer Documentation — UICollectionViewListCell](https://developer.apple.com/documentation/uikit/uicollectionviewlistcell)

--- a/docs/guide/uikit/collection-views/examples/modern-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/modern-delegate.md
@@ -1,0 +1,319 @@
+---
+title: '현대적인 UICollectionViewDelegate 예제'
+description: 'Diffable Data Source 기반 UICollectionView에서 delegate의 IndexPath를 item identifier로 변환해 선택·내용 갱신·표시 생명주기·컨텍스트 메뉴를 안전하게 처리합니다.'
+---
+
+# 현대적인 UICollectionViewDelegate 예제
+
+> **면접 답변 한 줄 요약:** Diffable Collection View에서도 상호작용은 `UICollectionViewDelegate`가 처리하지만, callback의 `IndexPath`를 Diffable Data Source의 item identifier로 변환해 모델과 snapshot을 갱신해야 해요.
+
+이 문서는 [`UICollectionViewDiffableDataSource` 예제](./diffable-data-source)의 `DiffablePhotoGridViewController`에 delegate 동작을 추가해요. 사용하는 delegate 프로토콜은 전통적인 방식과 같지만, 위치를 모델로 해석하는 방법이 달라요.
+
+아래 extension은 예제 view controller와 같은 Swift 파일에 두는 것을 기준으로 해요. 파일을 분리한다면 delegate가 필요한 data source와 backing store에 접근할 수 있도록 `private` 접근 수준을 조정하거나, view controller 내부 메서드로 동작을 노출하세요.
+
+## 먼저 알아둘 용어
+
+| 용어            | 쉬운 뜻                                                                         |
+| --------------- | ------------------------------------------------------------------------------- |
+| item identifier | item이 이동해도 같은 데이터임을 나타내는 안정적인 `Hashable` 값이에요.          |
+| snapshot        | 현재 화면의 section과 item 순서를 표현한 값이에요.                              |
+| reconfigure     | 기존 item의 정체성과 셀 상태를 유지하면서 표시 내용만 다시 구성하는 갱신이에요. |
+| backing store   | identifier로 실제 최신 모델을 찾는 저장소예요. 이 예제에서는 `photosByID`예요.  |
+| delegate        | Collection View의 선택·표시·메뉴 같은 상호작용을 전달받는 객체예요.             |
+
+## Delegate 연결은 전통적인 방식과 같아요
+
+```swift
+private func configureCollectionView() {
+  collectionView.delegate = self
+}
+```
+
+Diffable Data Source는 `collectionView.dataSource`를 맡지만 delegate를 대신하지 않아요. 선택과 사용자 상호작용이 필요하면 별도로 `delegate`를 연결해야 해요.
+
+## IndexPath를 identifier로 변환하는 helper를 만들어요
+
+```swift
+extension DiffablePhotoGridViewController {
+  private func photoID(
+    at indexPath: IndexPath
+  ) -> Photo.ID? {
+    dataSource.itemIdentifier(for: indexPath)
+  }
+}
+```
+
+`itemIdentifier(for:)`는 현재 snapshot에서 해당 위치의 ID를 찾아요. Callback마다 배열을 직접 index로 조회하지 않고 이 helper를 사용하면 상호작용 코드가 Diffable 상태를 기준으로 동작해요.
+
+## 선택 가능 여부를 최신 모델로 판단해요
+
+```swift
+extension DiffablePhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    shouldSelectItemAt indexPath: IndexPath
+  ) -> Bool {
+    guard
+      let id = photoID(at: indexPath),
+      let photo = photosByID[id]
+    else {
+      return false
+    }
+
+    return !photo.title.isEmpty
+  }
+}
+```
+
+Snapshot에는 ID가 있지만 backing store에서 모델을 찾지 못한다면 아직 두 상태가 동기화되지 않은 거예요. 선택을 허용하지 않고 모델과 snapshot 갱신 순서를 먼저 확인하세요.
+
+## 선택으로 모델을 바꾸고 item만 다시 구성해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  didSelectItemAt indexPath: IndexPath
+) {
+  guard let id = photoID(at: indexPath) else {
+    return
+  }
+
+  toggleFavorite(id: id)
+}
+```
+
+`toggleFavorite(id:)`는 backing store의 `isFavorite`를 바꾸고 현재 snapshot에서 해당 ID를 `reconfigureItems(_:)`로 지정해요.
+
+```swift
+private func toggleFavorite(id: Photo.ID) {
+  guard photosByID[id] != nil else {
+    return
+  }
+
+  photosByID[id]?.isFavorite.toggle()
+
+  var snapshot = dataSource.snapshot()
+  guard snapshot.indexOfItem(id) != nil else {
+    return
+  }
+
+  snapshot.reconfigureItems([id])
+  dataSource.apply(snapshot, animatingDifferences: true)
+}
+```
+
+선택 callback에서 보이는 셀만 직접 바꾸면 스크롤 뒤 재사용된 셀이 backing store의 이전 값으로 다시 구성될 수 있어요. 모델을 먼저 바꾸고 snapshot으로 표시를 갱신해요.
+
+## 다중 선택 상태를 ID로 저장해요
+
+다중 선택을 사용하는 화면에서는 앞의 즐겨찾기 전환용 `didSelectItemAt` 대신 아래 구현으로 선택 상태를 별도 관리해요.
+
+```swift
+private var selectedPhotoIDs: Set<Photo.ID> = []
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didSelectItemAt indexPath: IndexPath
+) {
+  guard let id = photoID(at: indexPath) else {
+    return
+  }
+  selectedPhotoIDs.insert(id)
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didDeselectItemAt indexPath: IndexPath
+) {
+  guard let id = photoID(at: indexPath) else {
+    return
+  }
+  selectedPhotoIDs.remove(id)
+}
+```
+
+새 snapshot을 적용한 뒤 현재 위치를 다시 조회해 선택을 복원할 수 있어요.
+
+```swift
+private func restoreSelection() {
+  removeMissingSelection()
+
+  for id in selectedPhotoIDs {
+    guard let indexPath = dataSource.indexPath(for: id) else {
+      continue
+    }
+
+    collectionView.selectItem(
+      at: indexPath,
+      animated: false,
+      scrollPosition: []
+    )
+  }
+}
+```
+
+`Set`을 순회하면서 같은 `Set`을 변경하지 않도록, 선택을 복원하기 전에 유효한 ID만 남겨요.
+
+```swift
+private func removeMissingSelection() {
+  selectedPhotoIDs = selectedPhotoIDs.filter {
+    dataSource.indexPath(for: $0) != nil
+  }
+}
+```
+
+`restoreSelection()`이 먼저 `removeMissingSelection()`을 호출하므로 삭제된 item은 선택 상태에서도 정리돼요.
+
+## 셀이 나타날 때 identifier로 노출을 기록해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  willDisplay cell: UICollectionViewCell,
+  forItemAt indexPath: IndexPath
+) {
+  guard let id = photoID(at: indexPath) else {
+    return
+  }
+  print("사진 노출: \(id)")
+}
+```
+
+`willDisplay`는 같은 ID에 여러 번 호출될 수 있어요. 한 번만 기록해야 한다면 `Set<Photo.ID>`로 중복을 제거하세요.
+
+`didEndDisplaying`에서는 전달된 `IndexPath`가 새 snapshot에서 다른 ID를 가리킬 수 있으므로 셀 자체의 task를 취소하는 데 집중해요.
+
+```swift
+protocol ImageRequestCancelling: AnyObject {
+  func cancelImageRequest()
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didEndDisplaying cell: UICollectionViewCell,
+  forItemAt indexPath: IndexPath
+) {
+  (cell as? any ImageRequestCancelling)?
+    .cancelImageRequest()
+}
+```
+
+## Context menu action도 identifier로 실행해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  contextMenuConfigurationForItemAt indexPath: IndexPath,
+  point: CGPoint
+) -> UIContextMenuConfiguration? {
+  guard let photoID = photoID(at: indexPath) else {
+    return nil
+  }
+
+  return UIContextMenuConfiguration(
+    identifier: photoID as NSUUID,
+    previewProvider: nil
+  ) { [weak self] _ in
+    let favorite = UIAction(
+      title: "즐겨찾기 전환",
+      image: UIImage(systemName: "heart")
+    ) { _ in
+      self?.toggleFavorite(id: photoID)
+    }
+
+    let delete = UIAction(
+      title: "삭제",
+      image: UIImage(systemName: "trash"),
+      attributes: .destructive
+    ) { _ in
+      self?.deletePhoto(id: photoID)
+    }
+
+    return UIMenu(children: [favorite, delete])
+  }
+}
+```
+
+메뉴 action이 실행될 때 item 위치가 달라져도 ID는 같은 모델을 가리켜요. 삭제 구현은 backing store와 ID 순서를 바꾼 뒤 새 snapshot을 적용해야 해요.
+
+## Compositional Layout의 section과 상호작용을 연결해요
+
+`GalleryItemID`처럼 화면 역할을 포함한 identifier를 사용한다면 delegate에서 모델 ID를 한 번 더 꺼내요.
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  didSelectItemAt indexPath: IndexPath
+) {
+  guard let itemID = dataSource.itemIdentifier(
+    for: indexPath
+  ) else {
+    return
+  }
+
+  let selectedPhotoID = itemID.photoID
+  onSelectPhoto?(selectedPhotoID)
+}
+```
+
+추천 section과 전체 section의 item identifier는 달라도 `photoID`는 같은 모델을 가리켜요. 즐겨찾기 내용이 바뀌면 같은 `Photo.ID`를 표현하는 두 화면 item을 모두 reconfigure해야 해요.
+
+```swift
+private func reconfigurePhoto(id: Photo.ID) {
+  var snapshot = dataSource.snapshot()
+  let candidates: [GalleryItemID] = [
+    .featured(id),
+    .library(id),
+  ]
+  let visibleIdentifiers = candidates.filter {
+    snapshot.indexOfItem($0) != nil
+  }
+
+  snapshot.reconfigureItems(visibleIdentifiers)
+  dataSource.apply(snapshot, animatingDifferences: true)
+}
+```
+
+## 전통적인 Delegate 처리와 비교해요
+
+| 단계               | 배열 기반 전통 방식                    | Diffable 기반 현대 방식                       |
+| ------------------ | -------------------------------------- | --------------------------------------------- |
+| callback이 주는 값 | `IndexPath`                            | `IndexPath`                                   |
+| 모델 ID 찾기       | `photos[indexPath.item].id`            | `dataSource.itemIdentifier(for:)`             |
+| 모델 내용 갱신     | 배열 원소를 수정해요.                  | ID로 backing store를 수정해요.                |
+| 화면 내용 갱신     | `reloadItems(at:)` 등을 직접 호출해요. | snapshot의 `reconfigureItems(_:)`를 적용해요. |
+| 선택 위치 복원     | 배열에서 ID의 현재 index를 검색해요.   | `dataSource.indexPath(for:)`로 조회해요.      |
+
+Delegate 프로토콜 자체가 현대적인 다른 타입으로 바뀌는 것은 아니에요. Data Source가 위치 중심에서 identifier 중심으로 바뀌면서 delegate callback을 모델로 해석하는 코드가 달라져요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                  | 먼저 확인할 것                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------ |
+| 선택한 모델을 찾지 못해요.            | callback의 `IndexPath`를 현재 data source의 identifier로 변환하는지 확인해요.  |
+| 내용 변경 뒤 셀이 원래대로 돌아가요.  | 보이는 셀만 직접 수정하지 않고 backing store와 snapshot을 갱신하는지 확인해요. |
+| 두 section 중 한 셀만 바뀌어요.       | 같은 모델을 나타내는 모든 화면 identifier를 reconfigure하는지 확인해요.        |
+| 선택 복원 중 잘못된 위치가 선택돼요.  | 저장한 `IndexPath` 대신 ID의 현재 `indexPath(for:)`를 조회하는지 확인해요.     |
+| 메뉴에서 삭제한 item이 다시 나타나요. | backing store와 snapshot 양쪽에서 ID를 제거했는지 확인해요.                    |
+
+## 면접에서 이어질 수 있는 질문
+
+### Diffable Data Source를 쓰면 다른 Delegate가 필요한가요?
+
+아니요. 선택과 상호작용은 동일한 `UICollectionViewDelegate`가 담당해요. 다만 callback의 `IndexPath`를 Diffable Data Source의 item identifier로 바꾸어 모델과 snapshot을 갱신해요.
+
+### 같은 모델이 여러 section에 보이면 어떻게 갱신하나요?
+
+Snapshot 안의 화면 identifier는 각각 유일해야 해요. 화면 역할을 포함한 identifier를 사용하고, 모델 내용이 바뀌면 같은 모델 ID를 나타내는 모든 화면 identifier를 reconfigure해요.
+
+## 다음 예제로 이동해요
+
+Delegate 상호작용을 연결했다면 [`UICollectionViewCompositionalLayout` 예제](./compositional-layout)에서 추천 카드와 반응형 격자를 한 화면에 구성해 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdelegate)
+- [Apple Developer Documentation — UICollectionViewDiffableDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource)
+- [Apple Developer Documentation — Changing the appearance of selected and highlighted cells](https://developer.apple.com/documentation/uikit/changing-the-appearance-of-selected-and-highlighted-cells)

--- a/docs/guide/uikit/collection-views/examples/practical-recipes.md
+++ b/docs/guide/uikit/collection-views/examples/practical-recipes.md
@@ -1,0 +1,370 @@
+---
+title: 'UICollectionView 실무 확장 예제'
+description: 'Diffable Collection View에 빈 상태, pull-to-refresh, 이미지 prefetch, 페이지네이션, 선택 상태 유지와 drag 재배치를 안전하게 추가하는 실무 예제를 설명합니다.'
+---
+
+# UICollectionView 실무 확장 예제
+
+> **면접 답변 한 줄 요약:** Collection View의 새로고침·prefetch·페이지네이션·선택·재배치는 변하는 `IndexPath`가 아니라 안정적인 item ID로 작업과 상태를 추적해야 데이터 변경 뒤에도 같은 item을 가리킬 수 있어요.
+
+이 문서는 [Diffable Data Source 예제](./diffable-data-source)의 `DiffablePhotoGridViewController`에 실무 기능을 하나씩 추가해요. 각 예제는 독립적으로 적용할 수 있으며, 앱의 repository와 이미지 loader 부분은 프로젝트 구조에 맞게 연결하세요.
+
+## 먼저 알아둘 용어
+
+| 용어            | 쉬운 뜻                                                                            |
+| --------------- | ---------------------------------------------------------------------------------- |
+| empty state     | 표시할 데이터가 없을 때 이유와 다음 행동을 안내하는 화면 상태예요.                 |
+| pull-to-refresh | 사용자가 스크롤 영역을 아래로 당겨 최신 데이터를 요청하는 동작이에요.              |
+| prefetch        | item이 보이기 전에 필요한 데이터를 준비하는 작업이에요.                            |
+| pagination      | 전체 데이터를 한 번에 받지 않고 페이지나 cursor 단위로 이어서 불러오는 방식이에요. |
+| cache           | 이미 준비한 이미지나 데이터를 다시 사용하기 위해 잠시 저장하는 공간이에요.         |
+| cursor          | 서버가 다음 페이지 위치를 나타내기 위해 주는 안정적인 값이에요.                    |
+
+## 예제 1: 빈 상태를 Collection View 안에 표시해요
+
+데이터가 없을 때 빈 셀을 억지로 만들기보다 `backgroundView`를 사용하면 data source와 안내 화면을 분리할 수 있어요.
+
+```swift
+private lazy var emptyLabel: UILabel = {
+  let label = UILabel()
+  label.text = "아직 사진이 없어요."
+  label.textAlignment = .center
+  label.textColor = .secondaryLabel
+  label.font = .preferredFont(forTextStyle: .headline)
+  return label
+}()
+
+private func updateEmptyState() {
+  collectionView.backgroundView =
+    photoIDs.isEmpty ? emptyLabel : nil
+}
+```
+
+`show(_:)`와 `applyCurrentSnapshot()`이 끝날 때 `updateEmptyState()`를 호출해요. 로딩 중과 오류 상태를 같은 label 하나로 표현하기 어려우면 상태 enum을 두고 서로 다른 안내 뷰를 선택하세요.
+
+```swift
+private enum ContentState {
+  case loading
+  case content
+  case empty
+  case failed(String)
+}
+```
+
+iOS 17 이상만 지원한다면 `UIContentUnavailableConfiguration`으로 빈 상태, 검색 결과 없음, 오류 상태를 더 체계적으로 구성할 수도 있어요.
+
+## 예제 2: Pull-to-refresh를 비동기 갱신과 연결해요
+
+`UIRefreshControl`은 Collection View를 포함한 `UIScrollView`에 연결할 수 있어요.
+
+```swift
+private func configureRefreshControl() {
+  let refreshControl = UIRefreshControl()
+  refreshControl.addTarget(
+    self,
+    action: #selector(refreshPhotos),
+    for: .valueChanged
+  )
+  collectionView.refreshControl = refreshControl
+}
+```
+
+비동기 작업의 성공과 실패에 상관없이 진행 표시를 종료해야 해요.
+
+```swift
+@objc
+private func refreshPhotos() {
+  Task { [weak self] in
+    guard let self else {
+      return
+    }
+
+    defer {
+      self.collectionView.refreshControl?.endRefreshing()
+    }
+
+    do {
+      let photos = try await self.photoRepository.fetchPhotos()
+      self.show(photos)
+    } catch {
+      self.presentRefreshError(error)
+    }
+  }
+}
+```
+
+`photoRepository`와 오류 표시는 앱 구조에 맞게 구현해요. 핵심은 새 데이터를 받은 뒤 backing store를 바꾸고 snapshot을 적용한 다음 refresh control을 끝내는 순서예요.
+
+사용자가 연속으로 당길 수 있다면 이미 새로고침 중인지 검사하거나 이전 요청을 취소하는 정책도 정하세요.
+
+## 예제 3: 곧 보일 이미지를 prefetch해요
+
+이미지 로딩은 네트워크 요청, downsampling, cache 조회가 필요할 수 있어요. Prefetch callback에서 현재 `IndexPath`를 identifier로 바꾼 뒤 loader에 전달해요.
+
+```swift
+protocol PhotoImageLoading: AnyObject {
+  func prefetchImage(for id: Photo.ID)
+  func cancelPrefetch(for id: Photo.ID)
+}
+```
+
+```swift
+extension DiffablePhotoGridViewController:
+  UICollectionViewDataSourcePrefetching
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    prefetchItemsAt indexPaths: [IndexPath]
+  ) {
+    for indexPath in indexPaths {
+      guard let id = dataSource.itemIdentifier(
+        for: indexPath
+      ) else {
+        continue
+      }
+      imageLoader.prefetchImage(for: id)
+    }
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cancelPrefetchingForItemsAt indexPaths: [IndexPath]
+  ) {
+    for indexPath in indexPaths {
+      guard let id = dataSource.itemIdentifier(
+        for: indexPath
+      ) else {
+        continue
+      }
+      imageLoader.cancelPrefetch(for: id)
+    }
+  }
+}
+```
+
+View controller에서 prefetch data source를 연결해요.
+
+```swift
+collectionView.prefetchDataSource = self
+```
+
+Prefetch는 모든 item에 대해 호출된다고 보장되지 않아요. 셀 구성 시점에는 다음 세 경우를 처리해야 해요.
+
+1. 이미지가 cache에 있어 바로 표시해요.
+2. prefetch 작업이 진행 중이라 같은 작업의 결과를 기다려요.
+3. prefetch가 호출되지 않아 셀 구성 코드가 직접 로딩을 시작해요.
+
+스크롤 방향이 바뀌면 필요 없어진 작업을 취소하고, 같은 ID의 요청을 중복 생성하지 않도록 loader에서 task를 관리하세요.
+
+## 예제 4: 재사용된 셀에 이전 이미지를 넣지 않아요
+
+네트워크 결과가 도착할 때 셀이 이미 다른 item을 표시할 수 있어요. 셀이 표현 중인 ID를 저장하고 완료 시점에 다시 확인해요.
+
+```swift
+final class AsyncPhotoCell: UICollectionViewCell {
+  private var representedID: Photo.ID?
+  private var imageTask: Task<Void, Never>?
+  private let imageView = UIImageView()
+
+  func configure(
+    photo: Photo,
+    imageLoader: PhotoImageLoader
+  ) {
+    representedID = photo.id
+    imageView.image = imageLoader.cachedImage(
+      for: photo.id
+    )
+
+    imageTask?.cancel()
+    imageTask = Task { [weak self] in
+      let image = await imageLoader.image(for: photo.id)
+
+      guard
+        !Task.isCancelled,
+        self?.representedID == photo.id
+      else {
+        return
+      }
+      self?.imageView.image = image
+    }
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+
+    representedID = nil
+    imageTask?.cancel()
+    imageTask = nil
+    imageView.image = nil
+  }
+}
+```
+
+`PhotoImageLoader`의 구체적인 네트워크 구현은 생략했어요. 중요한 점은 task 취소와 ID 검사를 둘 다 수행하는 것이에요. 취소가 늦게 반영되더라도 ID 검사가 다른 item에 이미지를 넣는 것을 막아요.
+
+## 예제 5: 마지막 item 근처에서 다음 페이지를 불러와요
+
+`willDisplay`는 같은 셀에 대해 여러 번 호출될 수 있어요. 로딩 중 여부와 다음 페이지 존재 여부를 함께 검사해야 중복 요청을 막을 수 있어요.
+
+```swift
+private var isLoadingNextPage = false
+private var hasNextPage = true
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  willDisplay cell: UICollectionViewCell,
+  forItemAt indexPath: IndexPath
+) {
+  guard
+    !isLoadingNextPage,
+    hasNextPage,
+    indexPath.item >= max(0, photoIDs.count - 5)
+  else {
+    return
+  }
+
+  loadNextPage()
+}
+```
+
+```swift
+private func loadNextPage() {
+  isLoadingNextPage = true
+
+  Task { [weak self] in
+    guard let self else {
+      return
+    }
+
+    defer {
+      self.isLoadingNextPage = false
+    }
+
+    do {
+      let page = try await self.photoRepository.fetchNextPage()
+      self.hasNextPage = page.hasNextPage
+
+      for photo in page.photos {
+        self.photosByID[photo.id] = photo
+        if !self.photoIDs.contains(photo.id) {
+          self.photoIDs.append(photo.id)
+        }
+      }
+      self.applyCurrentSnapshot()
+    } catch {
+      self.presentPaginationError(error)
+    }
+  }
+}
+```
+
+실제 서버가 cursor를 제공한다면 마지막 `IndexPath` 대신 서버 cursor를 저장하세요. 실패했을 때 `isLoadingNextPage`를 되돌려 재시도할 수 있게 하고, 이미 받은 ID는 중복 append하지 않아요.
+
+## 예제 6: 선택 상태를 ID로 저장해요
+
+여러 item을 선택할 때 `IndexPath` 집합을 저장하면 삽입과 정렬 뒤 다른 사진을 가리킬 수 있어요.
+
+```swift
+private var selectedPhotoIDs: Set<Photo.ID> = []
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didSelectItemAt indexPath: IndexPath
+) {
+  guard let id = dataSource.itemIdentifier(
+    for: indexPath
+  ) else {
+    return
+  }
+  selectedPhotoIDs.insert(id)
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didDeselectItemAt indexPath: IndexPath
+) {
+  guard let id = dataSource.itemIdentifier(
+    for: indexPath
+  ) else {
+    return
+  }
+  selectedPhotoIDs.remove(id)
+}
+```
+
+Snapshot을 크게 다시 구성하거나 전체 reload 뒤 선택을 복원해야 한다면 ID의 현재 위치를 다시 조회해요.
+
+```swift
+private func restoreSelection() {
+  for id in selectedPhotoIDs {
+    guard let indexPath = dataSource.indexPath(for: id) else {
+      continue
+    }
+    collectionView.selectItem(
+      at: indexPath,
+      animated: false,
+      scrollPosition: []
+    )
+  }
+}
+```
+
+삭제된 ID는 `selectedPhotoIDs`에서도 제거해 모델 상태와 화면 상태를 맞춰요.
+
+## 예제 7: Diffable 재배치 결과를 모델에 반영해요
+
+```swift
+private func configureReordering() {
+  dataSource.reorderingHandlers.canReorderItem = { _ in
+    true
+  }
+
+  dataSource.reorderingHandlers.didReorder = {
+    [weak self] transaction in
+
+    self?.photoIDs =
+      transaction.finalSnapshot.itemIdentifiers
+  }
+}
+```
+
+Snapshot만 바뀌고 `photoIDs`를 갱신하지 않으면 다음 데이터 갱신 때 이전 순서로 돌아가요. 영구 저장이 필요하면 새 ID 순서를 repository에 전달하고 실패 시 복구 정책을 정하세요.
+
+여러 section을 사용한다면 `transaction.finalSnapshot.itemIdentifiers(inSection:)`로 section별 순서를 가져와 각 backing store에 반영해요.
+
+## 기능을 붙이는 순서를 정리해요
+
+1. 초기 snapshot과 셀 재사용이 정상인지 먼저 확인해요.
+2. 빈 상태와 오류 상태를 데이터 개수와 분리해 표현해요.
+3. Pull-to-refresh에 중복 요청 방지와 항상 종료되는 경로를 추가해요.
+4. 이미지 로딩을 ID로 추적하고 cache·취소·셀 재사용을 확인해요.
+5. 페이지네이션에 로딩 중·마지막 페이지·중복 ID 검사를 추가해요.
+6. 선택과 재배치 결과를 ID 기반 모델 상태에 반영해요.
+7. 빠른 스크롤, 화면 회전, 요청 실패, 새로고침과 페이지 요청이 겹치는 상황을 테스트해요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                | 먼저 확인할 것                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------- |
+| 새로고침 indicator가 계속 돌아요.   | 성공·실패·취소 모든 경로에서 `endRefreshing()`이 호출되는지 확인해요.     |
+| 스크롤하면 다른 이미지가 나타나요.  | 완료 시 셀의 `representedID`를 다시 확인하고 이전 task를 취소하는지 봐요. |
+| 같은 페이지가 여러 번 요청돼요.     | 로딩 중 flag, 다음 cursor, 중복 ID 제거가 모두 있는지 확인해요.           |
+| 정렬 뒤 선택한 사진이 달라져요.     | 선택 상태를 `IndexPath` 대신 `Photo.ID`로 저장했는지 확인해요.            |
+| 재배치 뒤 순서가 원래대로 돌아가요. | transaction의 최종 snapshot 순서를 backing store에 반영했는지 확인해요.   |
+
+## 면접에서 이어질 수 있는 질문
+
+### Prefetch만 구현하면 셀에서 직접 로딩하지 않아도 되나요?
+
+아니요. Prefetch callback은 모든 item에 대해 호출된다고 보장되지 않아요. 셀 구성 코드는 cache 완료, 진행 중, 요청 전 세 상태를 모두 처리할 수 있어야 해요.
+
+### 비동기 이미지 작업을 왜 IndexPath로 관리하면 안 되나요?
+
+`IndexPath`는 현재 위치라서 삽입·삭제·이동 뒤 다른 item을 가리킬 수 있어요. 안정적인 ID로 task와 cache를 관리하고 셀에 결과를 적용할 때도 같은 ID인지 확인해야 해요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDataSourcePrefetching](https://developer.apple.com/documentation/uikit/uicollectionviewdatasourceprefetching)
+- [Apple Developer Documentation — Building high-performance lists and collection views](https://developer.apple.com/documentation/uikit/building-high-performance-lists-and-collection-views)
+- [Apple Developer Documentation — UIRefreshControl](https://developer.apple.com/documentation/uikit/uirefreshcontrol)
+- [Apple Developer Documentation — UICollectionViewDiffableDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource)

--- a/docs/guide/uikit/collection-views/examples/traditional-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/traditional-delegate.md
@@ -1,0 +1,295 @@
+---
+title: '전통적인 UICollectionViewDelegate 예제'
+description: '배열 기반 UICollectionView에서 UICollectionViewDelegate로 선택·하이라이트·표시 생명주기·다중 선택·컨텍스트 메뉴를 처리하고 IndexPath를 안전하게 해석합니다.'
+---
+
+# 전통적인 UICollectionViewDelegate 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewDelegate`는 Collection View item의 선택·하이라이트·표시·메뉴 같은 사용자 상호작용을 전달하며, 배열 기반 화면에서는 받은 `IndexPath`를 즉시 모델 ID로 변환해 처리해야 해요.
+
+이 문서는 [`UICollectionViewDataSource` 예제](./data-source)의 `ClassicPhotoGridViewController`에 상호작용을 추가해요. Data source는 무엇을 표시할지 제공하고, delegate는 사용자가 표시된 item과 어떻게 상호작용했는지 전달받아요.
+
+아래 extension은 예제 view controller와 같은 Swift 파일에 두는 것을 기준으로 해요. 파일을 분리한다면 delegate가 필요한 모델과 helper에 접근할 수 있도록 `private` 접근 수준을 조정하거나, view controller 내부 메서드로 동작을 노출하세요.
+
+## 먼저 알아둘 용어
+
+| 용어              | 쉬운 뜻                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------- |
+| selection         | 사용자가 하나 이상의 item을 선택한 상태예요.                                        |
+| highlight         | 손가락을 누르고 있는 짧은 동안 item이 반응하는 상태예요.                            |
+| display lifecycle | 셀이 화면에 나타나기 직전과 화면에서 사라진 뒤의 시점을 알려 주는 callback이에요.   |
+| context menu      | item을 길게 눌렀을 때 표시하는 빠른 작업 메뉴예요.                                  |
+| delegate          | 다른 객체에서 발생한 사건을 대신 전달받아 판단하거나 후속 동작을 실행하는 객체예요. |
+
+## Delegate를 Collection View에 연결해요
+
+```swift
+override func viewDidLoad() {
+  super.viewDidLoad()
+
+  collectionView.dataSource = self
+  collectionView.delegate = self
+}
+```
+
+`dataSource`와 `delegate`는 모두 weak reference예요. View controller 자신을 연결하면 화면이 살아 있는 동안 함께 유지돼요. 별도 delegate 객체를 연결한다면 프로퍼티로 강하게 보관하세요.
+
+## 선택 가능 여부를 먼저 판단해요
+
+특정 사진을 선택하지 못하게 하려면 선택 전에 판단할 수 있어요.
+
+```swift
+extension ClassicPhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    shouldSelectItemAt indexPath: IndexPath
+  ) -> Bool {
+    let photo = photos[indexPath.item]
+    return !photo.title.isEmpty
+  }
+}
+```
+
+`false`를 반환하면 `didSelectItemAt`이 호출되지 않아요. 로그인이나 권한이 필요한 item이라면 여기에서 선택을 막되, 사용자가 이유를 알 수 있도록 별도 안내도 제공하세요.
+
+## 선택된 위치를 모델 ID로 바꿔요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  didSelectItemAt indexPath: IndexPath
+) {
+  let selectedPhotoID = photos[indexPath.item].id
+  onSelectPhoto?(selectedPhotoID)
+}
+```
+
+`IndexPath`는 callback이 발생한 순간의 위치예요. 다음 화면, 비동기 작업, 선택 상태에는 `Photo.ID`를 전달해요. 그 사이 앞쪽에 item이 삽입되거나 정렬되면 같은 사진의 위치가 바뀔 수 있기 때문이에요.
+
+화면 이동 뒤 선택 표시를 없애려면 Collection View를 통해 deselect해요.
+
+```swift
+collectionView.deselectItem(
+  at: indexPath,
+  animated: true
+)
+```
+
+셀의 `isSelected`를 직접 바꾸기보다 `selectItem(at:animated:scrollPosition:)`과 `deselectItem(at:animated:)`을 사용해야 Collection View의 선택 상태와 셀 상태가 함께 바뀌어요.
+
+## Highlight에 눌림 피드백을 추가해요
+
+Highlight는 손가락을 누르는 동안의 짧은 상태이고, selection은 선택이 완료된 뒤 유지될 수 있는 상태예요.
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  didHighlightItemAt indexPath: IndexPath
+) {
+  guard let cell = collectionView.cellForItem(
+    at: indexPath
+  ) else {
+    return
+  }
+
+  UIView.animate(withDuration: 0.12) {
+    cell.transform = CGAffineTransform(
+      scaleX: 0.96,
+      y: 0.96
+    )
+  }
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didUnhighlightItemAt indexPath: IndexPath
+) {
+  guard let cell = collectionView.cellForItem(
+    at: indexPath
+  ) else {
+    return
+  }
+
+  UIView.animate(withDuration: 0.12) {
+    cell.transform = .identity
+  }
+}
+```
+
+선택 모양은 공통 `PhotoCell`의 `isSelected`에서 border를 갱신하고, highlight는 delegate에서 일시적인 scale만 적용했어요. 두 상태의 역할을 분리하면 손가락을 뗀 뒤에도 눌림 효과가 남는 문제를 피하기 쉬워요.
+
+## 셀이 나타날 때 모델을 확인해요
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  willDisplay cell: UICollectionViewCell,
+  forItemAt indexPath: IndexPath
+) {
+  let photoID = photos[indexPath.item].id
+  print("사진 노출: \(photoID)")
+}
+```
+
+`willDisplay`는 스크롤을 되돌리면 같은 item에 대해 여러 번 호출될 수 있어요. 노출을 한 번만 기록해야 한다면 `Set<Photo.ID>`로 이미 기록한 ID를 따로 관리하세요.
+
+```swift
+protocol ImageRequestCancelling: AnyObject {
+  func cancelImageRequest()
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didEndDisplaying cell: UICollectionViewCell,
+  forItemAt indexPath: IndexPath
+) {
+  // 이 시점에는 배열이 변경되어 indexPath가 더 이상
+  // 같은 모델을 가리키지 않을 수 있어요.
+  (cell as? any ImageRequestCancelling)?
+    .cancelImageRequest()
+}
+```
+
+`didEndDisplaying` 시점에는 item이 삭제되거나 이동했을 수 있어요. 전달된 셀 자체의 작업을 정리하고, 오래된 `IndexPath`로 현재 배열을 다시 조회하는 코드는 피하세요.
+
+## 다중 선택을 ID 집합으로 관리해요
+
+다중 선택을 사용하는 화면에서는 앞의 단일 선택 구현 대신 아래처럼 선택 상태를 ID 집합에 반영해요.
+
+```swift
+private var selectedPhotoIDs: Set<Photo.ID> = []
+
+private func configureMultipleSelection() {
+  collectionView.allowsMultipleSelection = true
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didSelectItemAt indexPath: IndexPath
+) {
+  selectedPhotoIDs.insert(photos[indexPath.item].id)
+}
+
+func collectionView(
+  _ collectionView: UICollectionView,
+  didDeselectItemAt indexPath: IndexPath
+) {
+  selectedPhotoIDs.remove(photos[indexPath.item].id)
+}
+```
+
+배열을 삭제·정렬한 뒤에는 선택한 ID의 현재 index를 다시 찾아 `selectItem`으로 화면 상태를 복원할 수 있어요.
+
+```swift
+private func restoreSelection() {
+  for id in selectedPhotoIDs {
+    guard let item = photos.firstIndex(
+      where: { $0.id == id }
+    ) else {
+      continue
+    }
+
+    collectionView.selectItem(
+      at: IndexPath(item: item, section: 0),
+      animated: false,
+      scrollPosition: []
+    )
+  }
+}
+```
+
+## Context menu 동작도 ID를 캡처해요
+
+먼저 배열에서 ID를 찾아 모델을 바꾸고, 변경된 위치만 다시 표시하는 helper를 추가해요.
+
+```swift
+private func toggleFavorite(id: Photo.ID) {
+  guard let index = photos.firstIndex(
+    where: { $0.id == id }
+  ) else {
+    return
+  }
+
+  photos[index].isFavorite.toggle()
+  collectionView.reloadItems(
+    at: [IndexPath(item: index, section: 0)]
+  )
+}
+```
+
+```swift
+func collectionView(
+  _ collectionView: UICollectionView,
+  contextMenuConfigurationForItemAt indexPath: IndexPath,
+  point: CGPoint
+) -> UIContextMenuConfiguration? {
+  let photoID = photos[indexPath.item].id
+
+  return UIContextMenuConfiguration(
+    identifier: photoID as NSUUID,
+    previewProvider: nil
+  ) { [weak self] _ in
+    let favorite = UIAction(
+      title: "즐겨찾기 전환",
+      image: UIImage(systemName: "heart")
+    ) { _ in
+      self?.toggleFavorite(id: photoID)
+    }
+
+    let delete = UIAction(
+      title: "삭제",
+      image: UIImage(systemName: "trash"),
+      attributes: .destructive
+    ) { _ in
+      self?.deletePhoto(id: photoID)
+    }
+
+    return UIMenu(children: [favorite, delete])
+  }
+}
+```
+
+메뉴가 열린 뒤 실행될 때는 처음의 `IndexPath`가 달라졌을 수 있어요. 메뉴 구성 시 `Photo.ID`로 바꾸어 action closure가 안정적인 ID를 캡처하게 해요.
+
+## Delegate, Data Source, Flow Layout Delegate를 구분해요
+
+| 타입                                 | 답하는 질문                                            |
+| ------------------------------------ | ------------------------------------------------------ |
+| `UICollectionViewDataSource`         | item이 몇 개이고 어떤 셀을 표시하나요?                 |
+| `UICollectionViewDelegate`           | 어떤 item을 선택·강조·표시했고 어떤 동작을 실행할까요? |
+| `UICollectionViewDelegateFlowLayout` | 이 section의 셀 크기와 간격은 얼마인가요?              |
+| `UICollectionViewFlowLayout`         | 계산한 크기와 간격으로 item을 어떤 순서로 배치할까요?  |
+
+`UICollectionViewDelegateFlowLayout`은 `UICollectionViewDelegate`를 상속해요. 하나의 view controller가 두 역할을 함께 구현할 수 있지만, 코드에서는 상호작용과 layout 계산을 extension으로 나누면 읽기 쉬워요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                             | 먼저 확인할 것                                                              |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| 선택 callback이 호출되지 않아요. | `delegate` 연결, `allowsSelection`, `shouldSelectItemAt` 반환값을 확인해요. |
+| 선택한 셀과 모델이 달라져요.     | callback의 `IndexPath`를 즉시 `Photo.ID`로 바꾸는지 확인해요.               |
+| 눌림 효과가 셀 재사용 뒤 남아요. | `didUnhighlight`와 셀의 재사용 초기화에서 transform을 되돌리는지 확인해요.  |
+| 노출 이벤트가 여러 번 기록돼요.  | `willDisplay`가 한 item에 여러 번 호출될 수 있음을 고려했는지 확인해요.     |
+| 메뉴에서 다른 item이 삭제돼요.   | action이 `IndexPath`가 아니라 메뉴 생성 시점의 ID를 캡처하는지 확인해요.    |
+
+## 면접에서 이어질 수 있는 질문
+
+### Highlight와 selection의 차이는 무엇인가요?
+
+Highlight는 사용자가 손가락을 누르고 있는 동안의 일시적인 상태예요. Selection은 선택 동작이 끝난 뒤에도 유지될 수 있는 상태이며, Collection View의 선택 API와 delegate callback으로 관리해요.
+
+### Delegate 메서드에서 IndexPath를 저장하면 왜 위험한가요?
+
+`IndexPath`는 현재 위치이므로 item 삽입·삭제·이동 뒤 다른 모델을 가리킬 수 있어요. Callback 안에서 안정적인 ID로 변환하고 장기 상태와 비동기 작업은 ID로 관리해야 해요.
+
+## 다음 예제로 이동해요
+
+상호작용을 연결했다면 [`UICollectionViewFlowLayout` 예제](./flow-layout)에서 같은 전통적인 화면의 셀 크기와 간격을 반응형으로 구성해 보세요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdelegate)
+- [Apple Developer Documentation — Changing the appearance of selected and highlighted cells](https://developer.apple.com/documentation/uikit/changing-the-appearance-of-selected-and-highlighted-cells)
+- [Apple Developer Documentation — UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)

--- a/docs/guide/uikit/collection-views/examples/transition-layout.md
+++ b/docs/guide/uikit/collection-views/examples/transition-layout.md
@@ -1,0 +1,227 @@
+---
+title: 'UICollectionViewTransitionLayout 예제'
+description: 'UICollectionViewTransitionLayout으로 격자와 목록 사이를 버튼 또는 pan gesture로 전환하고 transitionProgress·완료·취소·layout 상태를 안전하게 관리합니다.'
+---
+
+# UICollectionViewTransitionLayout 예제
+
+> **면접 답변 한 줄 요약:** `UICollectionViewTransitionLayout`은 현재 layout과 새 layout의 attributes를 진행률에 따라 보간하는 임시 layout으로, gesture가 `transitionProgress`를 갱신하고 완료 또는 취소를 결정하게 해요.
+
+이 문서는 같은 사진 데이터를 두 열 격자와 한 열 목록 사이에서 전환해요. 단순한 자동 animation과 사용자가 진행률을 조절하는 interactive transition을 나누어 설명해요.
+
+## 먼저 알아둘 용어
+
+| 용어                   | 쉬운 뜻                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| layout transition      | 같은 item을 유지한 채 배치 방식만 현재 layout에서 새 layout으로 바꾸는 과정이에요. |
+| interpolation          | 시작과 끝 attributes 사이의 중간 frame·위치를 진행률로 계산하는 동작이에요.        |
+| interactive transition | Gesture 이동량으로 사용자가 animation 진행률을 직접 조절하는 전환이에요.           |
+| transition progress    | 시작 layout은 0, 목표 layout은 1로 나타내는 전환 진행률이에요.                     |
+| finish / cancel        | 목표 layout을 설치해 끝낼지, 이전 layout으로 되돌릴지 결정하는 동작이에요.         |
+
+## 전환할 두 Layout을 준비해요
+
+```swift
+private lazy var gridLayout: UICollectionViewFlowLayout = {
+  let layout = UICollectionViewFlowLayout()
+  layout.itemSize = CGSize(width: 160, height: 208)
+  layout.minimumInteritemSpacing = 12
+  layout.minimumLineSpacing = 16
+  layout.sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+  return layout
+}()
+
+private lazy var listLayout: UICollectionViewFlowLayout = {
+  let layout = UICollectionViewFlowLayout()
+  layout.itemSize = CGSize(width: 320, height: 88)
+  layout.minimumLineSpacing = 8
+  layout.sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+  return layout
+}()
+```
+
+예제를 단순하게 유지하기 위해 두 Flow Layout을 사용했어요. Flow와 Compositional Layout처럼 서로 다른 `UICollectionViewLayout` 하위 타입 사이에서도 같은 전환 API를 사용할 수 있어요.
+
+## 버튼으로 자동 전환해요
+
+```swift
+private var showsGrid = true
+
+@objc
+private func toggleLayout() {
+  showsGrid.toggle()
+  let target = showsGrid ? gridLayout : listLayout
+
+  collectionView.setCollectionViewLayout(
+    target,
+    animated: true
+  )
+}
+```
+
+사용자가 진행률을 직접 조절할 필요가 없다면 이 API가 가장 단순해요. 전환 뒤에도 Data Source, 모델, 셀은 그대로 유지되고 layout만 바뀌어요.
+
+## Pan Gesture를 연결해요
+
+```swift
+private var transitionLayout:
+  UICollectionViewTransitionLayout?
+private var transitionTarget: UICollectionViewLayout?
+private var transitionShouldFinish = false
+
+private func configureLayoutGesture() {
+  let pan = UIPanGestureRecognizer(
+    target: self,
+    action: #selector(handleLayoutPan(_:))
+  )
+  collectionView.addGestureRecognizer(pan)
+}
+```
+
+전환 중인 임시 layout과 목표 layout을 프로퍼티로 강하게 보관해 gesture callback 사이에서 사용해요.
+
+## Gesture 시작에서 Interactive Transition을 만들어요
+
+```swift
+@objc
+private func handleLayoutPan(
+  _ gesture: UIPanGestureRecognizer
+) {
+  switch gesture.state {
+  case .began:
+    beginLayoutTransition()
+  case .changed:
+    updateLayoutTransition(with: gesture)
+  case .ended:
+    endLayoutTransition(cancelled: false)
+  case .cancelled, .failed:
+    endLayoutTransition(cancelled: true)
+  default:
+    break
+  }
+}
+
+private func beginLayoutTransition() {
+  guard transitionLayout == nil else {
+    return
+  }
+
+  let target = showsGrid ? listLayout : gridLayout
+  transitionTarget = target
+  transitionLayout = collectionView
+    .startInteractiveTransition(
+      to: target
+    ) { [weak self] completed, finished in
+      guard let self else {
+        return
+      }
+
+      if completed && finished {
+        showsGrid.toggle()
+      }
+      transitionLayout = nil
+      transitionTarget = nil
+      transitionShouldFinish = false
+    }
+}
+```
+
+`startInteractiveTransition`을 호출하면 Collection View가 반환된 `UICollectionViewTransitionLayout`을 전환 동안 임시 layout으로 사용해요.
+
+## 이동량을 0부터 1 사이 진행률로 바꿔요
+
+```swift
+private func updateLayoutTransition(
+  with gesture: UIPanGestureRecognizer
+) {
+  guard let transitionLayout else {
+    return
+  }
+
+  let translation = gesture.translation(
+    in: collectionView
+  )
+  let distance = max(collectionView.bounds.width, 1)
+  let progress = min(
+    max(abs(translation.x) / distance, 0),
+    1
+  )
+
+  transitionLayout.transitionProgress = progress
+  transitionLayout.invalidateLayout()
+
+  let velocity = gesture.velocity(
+    in: collectionView
+  ).x
+  transitionShouldFinish =
+    progress > 0.5 || abs(velocity) > 700
+}
+```
+
+`transitionProgress`를 변경한 뒤 layout을 invalidation해야 중간 attributes가 다시 계산돼요. 진행률은 0...1 범위로 제한해 overshoot를 피했어요.
+
+## 끝낼지 이전 Layout으로 돌아갈지 결정해요
+
+```swift
+private func endLayoutTransition(
+  cancelled: Bool
+) {
+  guard transitionLayout != nil else {
+    return
+  }
+
+  if !cancelled && transitionShouldFinish {
+    collectionView.finishInteractiveTransition()
+  } else {
+    collectionView.cancelInteractiveTransition()
+  }
+}
+```
+
+Finish하면 목표 layout이 최종 `collectionViewLayout`이 되고, cancel하면 시작 layout으로 돌아가요. 두 경우 모두 completion에서 임시 상태를 정리해 다음 gesture가 새 transition을 시작할 수 있게 해요.
+
+## 기본 Transition Layout으로 충분한지 판단해요
+
+기본 `UICollectionViewTransitionLayout`은 같은 `IndexPath`의 시작 attributes와 끝 attributes를 보간해요. 다음 요구사항이 없다면 별도 subclass가 필요하지 않아요.
+
+- 전환 중 item마다 다른 곡선이나 추가 속성을 적용해야 해요.
+- 특정 section은 고정하고 나머지만 움직여야 해요.
+- Custom layout attributes의 새 프로퍼티까지 보간해야 해요.
+
+이런 경우 `UICollectionViewTransitionLayout`을 상속하고 사용자 정의 값을 갱신한 뒤, `UICollectionViewDelegate`의 `collectionView(_:transitionLayoutForOldLayout:newLayout:)`에서 custom transition layout을 반환할 수 있어요.
+
+## 자주 발생하는 문제를 점검해요
+
+| 증상                                    | 먼저 확인할 것                                                                 |
+| --------------------------------------- | ------------------------------------------------------------------------------ |
+| Gesture를 움직여도 frame이 안 바뀌어요. | `transitionProgress` 변경 뒤 `invalidateLayout()`을 호출하는지 확인해요.       |
+| 두 번째 전환이 시작되지 않아요.         | Completion에서 transition 상태를 `nil`로 정리하는지 확인해요.                  |
+| 취소했는데 상태 flag가 바뀌어요.        | 실제 `completed`, `finished` 결과에서만 최종 layout 상태를 바꾸는지 봐요.      |
+| 전환 중 item이 사라져요.                | 두 layout과 Data Source가 같은 section·item `IndexPath`를 설명하는지 확인해요. |
+| 단순 전환 코드가 지나치게 복잡해요.     | Gesture 제어가 필요 없다면 `setCollectionViewLayout(animated:)`을 사용해요.    |
+
+## 면접에서 이어질 수 있는 질문
+
+### `setCollectionViewLayout`과 Interactive Transition의 차이는 무엇인가요?
+
+`setCollectionViewLayout(animated:)`은 UIKit이 animation 시간을 관리하는 자동 전환이에요. Interactive transition은 gesture가 `transitionProgress`를 갱신하고 마지막에 finish 또는 cancel을 직접 결정해요.
+
+### Transition Layout은 최종 Layout인가요?
+
+아니요. 현재 layout과 목표 layout 사이의 중간 attributes를 제공하는 임시 layout이에요. 전환을 완료하면 목표 layout이 설치되고, 취소하면 이전 layout으로 돌아가요.
+
+## 참고 자료
+
+- [Apple Developer Documentation — UICollectionViewTransitionLayout](https://developer.apple.com/documentation/uikit/uicollectionviewtransitionlayout)
+- [Apple Developer Documentation — startInteractiveTransition(to:completion:)](<https://developer.apple.com/documentation/uikit/uicollectionview/startinteractivetransition(to:completion:)>)
+- [Apple Developer Documentation — UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)

--- a/docs/guide/uikit/collection-views/index.md
+++ b/docs/guide/uikit/collection-views/index.md
@@ -38,6 +38,7 @@ description: UICollectionView의 데이터, 셀 재사용, 레이아웃, prefetc
 4. 셀 재사용과 prefetch를 이용한 데이터 준비를 이해해요.
 5. compositional layout으로 배치를 확장해요.
 6. 선택, 다중 선택, 드래그 앤 드롭을 연결해요.
+7. 별도 예제 섹션에서 data source와 layout 조합을 직접 구현해요.
 
 ## Collection View는 역할을 나눠 조합해요
 
@@ -240,6 +241,7 @@ private func renamePhoto(id: Photo.ID, title: String) {
 | 격자·목록·가로 스크롤 배치                | [레이아웃](./layout-guide)                          |
 | 선택과 하이라이트, 다중 선택              | [선택 상태](./selection)                            |
 | 앱 안팎으로 item 이동                     | [드래그 앤 드롭](./drag-and-drop)                   |
+| 네 가지 data source·layout 조합 실습      | [예제](./examples/index)                            |
 | `UICollectionView` 전체 API 확인          | [`UICollectionView`](./uicollectionview)            |
 | Layouts 공식 분류에서 API 찾기            | [Layouts API 모음](./layouts/index)                 |
 | Apple 원문과 Swift-KR 문서 대응 확인      | [공식 문서 인벤토리](./official-document-inventory) |


### PR DESCRIPTION
## Summary

UICollectionView를 처음 배우는 사람이 Data Source, Delegate, Layout의 역할을 구분하고 전통적인 배열 방식부터 Diffable·Compositional 방식까지 단계적으로 구현할 수 있는 실전 예제 섹션을 추가합니다.

공통 사진 갤러리 모델과 재사용 셀을 기준으로 데이터 제공, 선택과 상호작용, prefetch, drag and drop, 기본·목록·custom·transition layout을 각각 독립 문서에서 설명합니다.

## Changes

- Collection Views 사이드바의 `학습 가이드`와 `뷰` 사이에 접이식 `예제` 그룹을 추가했습니다.
- 예제 내비게이션을 `Data Source`, `Delegate`, `Layout` 역할로 나누고 하위 API 문서를 계층적으로 연결했습니다.
- `UICollectionViewDataSource`와 `UICollectionViewDiffableDataSource`의 셀 제공·삽입·삭제·이동·내용 갱신 예제를 추가했습니다.
- 전통적인 배열 방식과 Diffable identifier 방식의 `UICollectionViewDelegate` 예제를 각각 추가했습니다.
- `UICollectionViewDataSourcePrefetching`, `UICollectionViewDelegateFlowLayout`, `UICollectionViewDragDelegate`, `UICollectionViewDropDelegate` 예제를 추가했습니다.
- Flow Layout, Compositional Layout, List Layout, Custom `UICollectionViewLayout`, `UICollectionViewTransitionLayout` 예제를 추가했습니다.
- 빈 상태, pull-to-refresh, 이미지 prefetch, 페이지네이션, 선택 유지와 Diffable 재배치를 다루는 실무 확장 예제를 추가했습니다.
- 모든 문서에 면접 답변 한 줄 요약, 선행 용어, 단계별 Swift 코드, 문제 점검표, 후속 질문과 Apple 공식 참고 자료를 포함했습니다.

## Testing

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run docs:check-collection-views`
- [x] `npm run build`
- [x] `git diff --check`
- [x] 예제 Swift 코드 블록 120개 문법 검사
- [x] 신규 API 조합 6개 iOS 15 Simulator SDK 타입 검사
- [x] 신규 예제 페이지 8개 로컬 dev 서버 HTTP 200 확인
- [x] Rspress 빌드 결과에서 신규 문서 제목과 내부 링크 확인

## Related Issues

Closes #11

## Screenshots

- 문서 페이지와 접이식 사이드바는 로컬 dev 서버에서 확인했으며, 정적 스크린샷은 별도로 첨부하지 않았습니다.

## Notes

- Data Source, Delegate, Layout은 독립적인 책임이므로 전통·현대 API를 교차 조합할 수 있음을 예제 한눈에 보기에 명시했습니다.
- 예제는 iOS 15 이상을 기준으로 작성하고, 주요 API의 최소 지원 버전은 예제 한눈에 보기에서 별도로 안내합니다.
- 빌드 산출물과 Rspress cache는 커밋하지 않았습니다.
