### PR TITLE
[#13] UICollectionView 예제에 전체 최종 코드를 추가한다

### DIFF
--- a/docs/guide/uikit/collection-views/examples/compositional-layout.md
+++ b/docs/guide/uikit/collection-views/examples/compositional-layout.md
@@ -267,7 +267,7 @@ Header도 셀과 마찬가지로 재사용되므로 구성 메서드가 현재 s
 final class CompositionalPhotoGalleryViewController:
   UIViewController
 {
-  private var photosByID: [Photo.ID: Photo] = [:]
+  private var photos: [Photo] = []
   private var dataSource:
     UICollectionViewDiffableDataSource<
       GallerySection,
@@ -319,7 +319,11 @@ extension CompositionalPhotoGalleryViewController {
       PhotoCell,
       GalleryItemID
     > { [weak self] cell, _, itemID in
-      guard let photo = self?.photosByID[itemID.photoID] else {
+      guard
+        let photo = self?.photos.first(
+          where: { $0.id == itemID.photoID }
+        )
+      else {
         return
       }
       cell.configure(with: photo)
@@ -370,15 +374,13 @@ Supplementary Registration은 provider 안에서 매번 만들지 않고 provide
 
 ```swift
 extension CompositionalPhotoGalleryViewController {
-  private func show(_ photos: [Photo]) {
-    photosByID = Dictionary(
-      uniqueKeysWithValues: photos.map { ($0.id, $0) }
-    )
+  private func show(_ newPhotos: [Photo]) {
+    photos = newPhotos
 
-    let featuredIDs = photos.prefix(3).map {
+    let featuredIDs = newPhotos.prefix(3).map {
       GalleryItemID.featured($0.id)
     }
-    let libraryIDs = photos.map {
+    let libraryIDs = newPhotos.map {
       GalleryItemID.library($0.id)
     }
 
@@ -448,6 +450,329 @@ Diffable snapshot 안에서 item identifier는 유일해야 하기 때문이에�
 Compositional Layout의 여러 section에서 선택한 item을 안정적인 모델 ID로 해석하는 방법은 [현대적인 `UICollectionViewDelegate` 예제](./modern-delegate)에서 이어서 확인할 수 있어요.
 
 설정 화면처럼 표준 목록이 필요하다면 [Collection View List Layout 예제](./list-layout)에서 list cell, accessory와 swipe action을 연결해 보세요.
+
+## 전체 최종 코드
+
+아래 최종본은 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 추천 가로 카드, 반응형 격자, header, Diffable snapshot을 모두 연결해요. 모델 원본은 `[Photo]` 하나만 유지하고 두 section의 화면 역할은 `GalleryItemID`로 구분해요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+private enum GallerySection: Int, CaseIterable {
+  case featured
+  case library
+
+  var title: String {
+    switch self {
+    case .featured:
+      return "추천 사진"
+    case .library:
+      return "모든 사진"
+    }
+  }
+}
+
+private enum GalleryItemID: Hashable {
+  case featured(Photo.ID)
+  case library(Photo.ID)
+
+  var photoID: Photo.ID {
+    switch self {
+    case let .featured(id), let .library(id):
+      return id
+    }
+  }
+}
+
+private func makeSectionHeader()
+  -> NSCollectionLayoutBoundarySupplementaryItem
+{
+  let size = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .estimated(52)
+  )
+  return NSCollectionLayoutBoundarySupplementaryItem(
+    layoutSize: size,
+    elementKind: UICollectionView.elementKindSectionHeader,
+    alignment: .top
+  )
+}
+
+private func makeFeaturedSection()
+  -> NSCollectionLayoutSection
+{
+  let itemSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .fractionalHeight(1)
+  )
+  let item = NSCollectionLayoutItem(layoutSize: itemSize)
+  let groupSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(0.82),
+    heightDimension: .absolute(220)
+  )
+  let group = NSCollectionLayoutGroup.horizontal(
+    layoutSize: groupSize,
+    subitems: [item]
+  )
+  let section = NSCollectionLayoutSection(group: group)
+  section.orthogonalScrollingBehavior = .groupPagingCentered
+  section.interGroupSpacing = 12
+  section.contentInsets = NSDirectionalEdgeInsets(
+    top: 8,
+    leading: 16,
+    bottom: 24,
+    trailing: 16
+  )
+  section.boundarySupplementaryItems = [
+    makeSectionHeader(),
+  ]
+  return section
+}
+
+private func makeLibrarySection(
+  environment: NSCollectionLayoutEnvironment
+) -> NSCollectionLayoutSection {
+  let width =
+    environment.container.effectiveContentSize.width
+  let columnCount: Int
+  switch width {
+  case 900...:
+    columnCount = 5
+  case 600...:
+    columnCount = 3
+  default:
+    columnCount = 2
+  }
+
+  let itemSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .fractionalHeight(1)
+  )
+  let item = NSCollectionLayoutItem(layoutSize: itemSize)
+  item.contentInsets = NSDirectionalEdgeInsets(
+    top: 6,
+    leading: 6,
+    bottom: 6,
+    trailing: 6
+  )
+  let groupSize = NSCollectionLayoutSize(
+    widthDimension: .fractionalWidth(1),
+    heightDimension: .fractionalWidth(
+      1 / CGFloat(columnCount)
+    )
+  )
+  let group = NSCollectionLayoutGroup.horizontal(
+    layoutSize: groupSize,
+    subitem: item,
+    count: columnCount
+  )
+  let section = NSCollectionLayoutSection(group: group)
+  section.contentInsets = NSDirectionalEdgeInsets(
+    top: 8,
+    leading: 10,
+    bottom: 24,
+    trailing: 10
+  )
+  section.boundarySupplementaryItems = [
+    makeSectionHeader(),
+  ]
+  return section
+}
+
+private func makeGalleryLayout()
+  -> UICollectionViewCompositionalLayout
+{
+  let configuration =
+    UICollectionViewCompositionalLayoutConfiguration()
+  configuration.interSectionSpacing = 16
+
+  return UICollectionViewCompositionalLayout(
+    sectionProvider: { sectionIndex, environment in
+      guard let section = GallerySection(
+        rawValue: sectionIndex
+      ) else {
+        return nil
+      }
+      switch section {
+      case .featured:
+        return makeFeaturedSection()
+      case .library:
+        return makeLibrarySection(environment: environment)
+      }
+    },
+    configuration: configuration
+  )
+}
+
+final class CompositionalGalleryHeaderView:
+  UICollectionReusableView
+{
+  private let titleLabel = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    titleLabel.font = .preferredFont(forTextStyle: .title2)
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(titleLabel)
+    NSLayoutConstraint.activate([
+      titleLabel.topAnchor.constraint(
+        equalTo: topAnchor,
+        constant: 8
+      ),
+      titleLabel.leadingAnchor.constraint(
+        equalTo: leadingAnchor,
+        constant: 16
+      ),
+      titleLabel.trailingAnchor.constraint(
+        lessThanOrEqualTo: trailingAnchor,
+        constant: -16
+      ),
+      titleLabel.bottomAnchor.constraint(
+        equalTo: bottomAnchor,
+        constant: -8
+      ),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+
+  func configure(title: String) {
+    titleLabel.text = title
+  }
+}
+
+@MainActor
+final class CompositionalPhotoGalleryViewController:
+  UIViewController
+{
+  private var photos: [Photo] = []
+  private var dataSource:
+    UICollectionViewDiffableDataSource<
+      GallerySection,
+      GalleryItemID
+    >!
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGalleryLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    configureCollectionView()
+    configureDataSource()
+    show(Photo.samples)
+  }
+
+  private func configureCollectionView() {
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func configureDataSource() {
+    let cellRegistration = UICollectionView.CellRegistration<
+      PhotoCell,
+      GalleryItemID
+    > { [weak self] cell, _, itemID in
+      guard let photo = self?.photos.first(
+        where: { $0.id == itemID.photoID }
+      ) else {
+        return
+      }
+      cell.configure(with: photo)
+    }
+
+    dataSource = UICollectionViewDiffableDataSource(
+      collectionView: collectionView
+    ) { collectionView, indexPath, itemID in
+      collectionView.dequeueConfiguredReusableCell(
+        using: cellRegistration,
+        for: indexPath,
+        item: itemID
+      )
+    }
+
+    let headerRegistration =
+      UICollectionView.SupplementaryRegistration<
+        CompositionalGalleryHeaderView
+      >(
+        elementKind:
+          UICollectionView.elementKindSectionHeader
+      ) { [weak self] header, _, indexPath in
+        guard let section =
+          self?.dataSource.sectionIdentifier(
+            for: indexPath.section
+          )
+        else {
+          return
+        }
+        header.configure(title: section.title)
+      }
+
+    dataSource.supplementaryViewProvider = {
+      collectionView,
+      _,
+      indexPath in
+
+      collectionView.dequeueConfiguredReusableSupplementary(
+        using: headerRegistration,
+        for: indexPath
+      )
+    }
+  }
+
+  private func show(_ newPhotos: [Photo]) {
+    photos = newPhotos
+
+    var snapshot = NSDiffableDataSourceSnapshot<
+      GallerySection,
+      GalleryItemID
+    >()
+    snapshot.appendSections([.featured, .library])
+    snapshot.appendItems(
+      newPhotos.prefix(3).map {
+        GalleryItemID.featured($0.id)
+      },
+      toSection: .featured
+    )
+    snapshot.appendItems(
+      newPhotos.map {
+        GalleryItemID.library($0.id)
+      },
+      toSection: .library
+    )
+    dataSource.apply(
+      snapshot,
+      animatingDifferences: false
+    )
+  }
+}
+```
+
+</details>
 
 ## 참고 자료
 

--- a/docs/guide/uikit/collection-views/examples/custom-layout.md
+++ b/docs/guide/uikit/collection-views/examples/custom-layout.md
@@ -251,6 +251,269 @@ Content size와 화면 영역·특정 item에 대한 layout attributes를 제공
 
 Custom layout과 다른 layout 사이를 gesture로 전환하려면 [`UICollectionViewTransitionLayout` 예제](./transition-layout)를 읽어 보세요.
 
+## 전체 최종 코드
+
+아래 코드는 태그 셀, 배열 기반 Data Source, 너비 delegate, attributes cache를 사용하는 Custom Layout을 모두 합친 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+protocol TagCloudLayoutDelegate: AnyObject {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    widthForItemAt indexPath: IndexPath
+  ) -> CGFloat
+}
+
+final class TagCloudLayout: UICollectionViewLayout {
+  weak var delegate: (any TagCloudLayoutDelegate)?
+  var itemHeight: CGFloat = 44
+  var horizontalSpacing: CGFloat = 8
+  var verticalSpacing: CGFloat = 10
+  var sectionInset = UIEdgeInsets(
+    top: 16,
+    left: 16,
+    bottom: 16,
+    right: 16
+  )
+
+  private var cachedAttributes: [
+    UICollectionViewLayoutAttributes
+  ] = []
+  private var contentHeight: CGFloat = 0
+
+  override func prepare() {
+    super.prepare()
+    guard let collectionView else {
+      return
+    }
+
+    cachedAttributes.removeAll(keepingCapacity: true)
+    let availableMaxX =
+      collectionView.bounds.width
+      - collectionView.adjustedContentInset.left
+      - collectionView.adjustedContentInset.right
+      - sectionInset.right
+    let maximumWidth = max(
+      availableMaxX - sectionInset.left,
+      1
+    )
+    var x = sectionInset.left
+    var y = sectionInset.top
+
+    for section in 0..<collectionView.numberOfSections {
+      for item in 0..<collectionView.numberOfItems(
+        inSection: section
+      ) {
+        let indexPath = IndexPath(
+          item: item,
+          section: section
+        )
+        let requestedWidth = delegate?.collectionView(
+          collectionView,
+          widthForItemAt: indexPath
+        ) ?? 80
+        let width = min(
+          max(requestedWidth, 1),
+          maximumWidth
+        )
+
+        if x + width > availableMaxX,
+          x > sectionInset.left
+        {
+          x = sectionInset.left
+          y += itemHeight + verticalSpacing
+        }
+
+        let attributes = UICollectionViewLayoutAttributes(
+          forCellWith: indexPath
+        )
+        attributes.frame = CGRect(
+          x: x,
+          y: y,
+          width: width,
+          height: itemHeight
+        )
+        cachedAttributes.append(attributes)
+        x += width + horizontalSpacing
+      }
+
+      x = sectionInset.left
+      y += itemHeight + sectionInset.bottom
+    }
+    contentHeight = y
+  }
+
+  override var collectionViewContentSize: CGSize {
+    guard let collectionView else {
+      return .zero
+    }
+    return CGSize(
+      width: collectionView.bounds.width,
+      height: max(contentHeight, collectionView.bounds.height)
+    )
+  }
+
+  override func layoutAttributesForElements(
+    in rect: CGRect
+  ) -> [UICollectionViewLayoutAttributes]? {
+    cachedAttributes.filter {
+      $0.frame.intersects(rect)
+    }
+  }
+
+  override func layoutAttributesForItem(
+    at indexPath: IndexPath
+  ) -> UICollectionViewLayoutAttributes? {
+    cachedAttributes.first {
+      $0.indexPath == indexPath
+    }
+  }
+
+  override func shouldInvalidateLayout(
+    forBoundsChange newBounds: CGRect
+  ) -> Bool {
+    guard let collectionView else {
+      return false
+    }
+    return newBounds.width != collectionView.bounds.width
+  }
+}
+
+final class TagCell: UICollectionViewCell {
+  static let reuseIdentifier = "TagCell"
+  private let label = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    label.translatesAutoresizingMaskIntoConstraints = false
+    contentView.addSubview(label)
+    contentView.backgroundColor = .secondarySystemBackground
+    contentView.layer.cornerRadius = 12
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(
+        equalTo: contentView.leadingAnchor,
+        constant: 16
+      ),
+      label.trailingAnchor.constraint(
+        equalTo: contentView.trailingAnchor,
+        constant: -16
+      ),
+      label.centerYAnchor.constraint(
+        equalTo: contentView.centerYAnchor
+      ),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+
+  func configure(title: String) {
+    label.text = title
+  }
+}
+
+@MainActor
+final class TagCloudViewController: UIViewController {
+  private let tags = [
+    "Swift",
+    "UIKit",
+    "Collection View",
+    "Diffable Data Source",
+    "Custom Layout",
+  ]
+
+  private lazy var collectionView: UICollectionView = {
+    let layout = TagCloudLayout()
+    layout.delegate = self
+    return UICollectionView(
+      frame: .zero,
+      collectionViewLayout: layout
+    )
+  }()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.register(
+      TagCell.self,
+      forCellWithReuseIdentifier: TagCell.reuseIdentifier
+    )
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  override func traitCollectionDidChange(
+    _ previousTraitCollection: UITraitCollection?
+  ) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    collectionView.collectionViewLayout.invalidateLayout()
+  }
+}
+
+extension TagCloudViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    tags.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: TagCell.reuseIdentifier,
+      for: indexPath
+    ) as? TagCell else {
+      preconditionFailure("TagCell 등록을 확인하세요.")
+    }
+    cell.configure(title: tags[indexPath.item])
+    return cell
+  }
+}
+
+extension TagCloudViewController: TagCloudLayoutDelegate {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    widthForItemAt indexPath: IndexPath
+  ) -> CGFloat {
+    let font = UIFont.preferredFont(forTextStyle: .body)
+    let textWidth = (tags[indexPath.item] as NSString).size(
+      withAttributes: [.font: font]
+    ).width
+    return ceil(textWidth) + 32
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewLayout](https://developer.apple.com/documentation/uikit/uicollectionviewlayout)

--- a/docs/guide/uikit/collection-views/examples/data-source-prefetching.md
+++ b/docs/guide/uikit/collection-views/examples/data-source-prefetching.md
@@ -204,6 +204,263 @@ func configureThumbnail(
 
 `IndexPath`는 현재 위치라서 삽입·삭제·정렬 뒤 다른 모델을 가리킬 수 있어요. 안정적인 모델 ID를 task와 cache의 key로 사용하면 item이 이동해도 같은 요청과 결과를 찾을 수 있어요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용하는 전통적인 Data Source에 ID 기반 이미지 cache와 prefetch를 붙인 최종본이에요. `imageURLsByID`에는 서버 응답으로 얻은 실제 URL을 주입하세요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+final class PrefetchPhotoCell: UICollectionViewCell {
+  static let reuseIdentifier = "PrefetchPhotoCell"
+
+  private let thumbnailView = UIImageView()
+  private let titleLabel = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    thumbnailView.contentMode = .scaleAspectFill
+    thumbnailView.clipsToBounds = true
+    titleLabel.font = .preferredFont(forTextStyle: .headline)
+
+    let stack = UIStackView(
+      arrangedSubviews: [thumbnailView, titleLabel]
+    )
+    stack.axis = .vertical
+    stack.spacing = 8
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    contentView.addSubview(stack)
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(
+        equalTo: contentView.topAnchor,
+        constant: 12
+      ),
+      stack.leadingAnchor.constraint(
+        equalTo: contentView.leadingAnchor,
+        constant: 12
+      ),
+      stack.trailingAnchor.constraint(
+        equalTo: contentView.trailingAnchor,
+        constant: -12
+      ),
+      stack.bottomAnchor.constraint(
+        equalTo: contentView.bottomAnchor,
+        constant: -12
+      ),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+
+  func configure(photo: Photo, thumbnail: UIImage?) {
+    titleLabel.text = photo.title
+    thumbnailView.image =
+      thumbnail ?? UIImage(systemName: "photo")
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    thumbnailView.image = nil
+    titleLabel.text = nil
+  }
+}
+
+@MainActor
+final class PhotoThumbnailStore {
+  private let cache = NSCache<NSUUID, UIImage>()
+  private var tasks: [Photo.ID: Task<Void, Never>] = [:]
+  var onImagePrepared: ((Photo.ID) -> Void)?
+
+  func cachedImage(for id: Photo.ID) -> UIImage? {
+    cache.object(forKey: id as NSUUID)
+  }
+
+  func prepare(id: Photo.ID, url: URL) {
+    guard cachedImage(for: id) == nil, tasks[id] == nil else {
+      return
+    }
+
+    tasks[id] = Task { [weak self] in
+      guard let self else {
+        return
+      }
+      defer {
+        tasks[id] = nil
+      }
+
+      do {
+        let (data, _) = try await URLSession.shared.data(
+          from: url
+        )
+        try Task.checkCancellation()
+        if let image = UIImage(data: data) {
+          cache.setObject(image, forKey: id as NSUUID)
+          onImagePrepared?(id)
+        }
+      } catch is CancellationError {
+        // 화면에서 멀어진 정상적인 취소 흐름이에요.
+      } catch {
+        print("썸네일 준비 실패: \(error)")
+      }
+    }
+  }
+
+  func cancel(id: Photo.ID) {
+    tasks[id]?.cancel()
+  }
+}
+
+@MainActor
+final class PrefetchingPhotoGridViewController:
+  UIViewController
+{
+  private var photos = Photo.samples
+  private var imageURLsByID: [Photo.ID: URL] = [:]
+  private let thumbnailStore = PhotoThumbnailStore()
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.prefetchDataSource = self
+    collectionView.register(
+      PrefetchPhotoCell.self,
+      forCellWithReuseIdentifier:
+        PrefetchPhotoCell.reuseIdentifier
+    )
+    thumbnailStore.onImagePrepared = { [weak self] id in
+      guard
+        let self,
+        let index = photos.firstIndex(
+          where: { $0.id == id }
+        )
+      else {
+        return
+      }
+
+      let indexPath = IndexPath(item: index, section: 0)
+      if collectionView.indexPathsForVisibleItems.contains(
+        indexPath
+      ) {
+        collectionView.reloadItems(at: [indexPath])
+      }
+    }
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func makeGridLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.itemSize = CGSize(width: 160, height: 160)
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 12
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    return layout
+  }
+
+  private func prepareThumbnail(at indexPath: IndexPath) {
+    guard photos.indices.contains(indexPath.item) else {
+      return
+    }
+
+    let id = photos[indexPath.item].id
+    guard let url = imageURLsByID[id] else {
+      return
+    }
+    thumbnailStore.prepare(id: id, url: url)
+  }
+}
+
+extension PrefetchingPhotoGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PrefetchPhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PrefetchPhotoCell else {
+      preconditionFailure("PrefetchPhotoCell 등록을 확인하세요.")
+    }
+
+    let photo = photos[indexPath.item]
+    cell.configure(
+      photo: photo,
+      thumbnail: thumbnailStore.cachedImage(for: photo.id)
+    )
+    prepareThumbnail(at: indexPath)
+    return cell
+  }
+}
+
+extension PrefetchingPhotoGridViewController:
+  UICollectionViewDataSourcePrefetching
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    prefetchItemsAt indexPaths: [IndexPath]
+  ) {
+    indexPaths.forEach(prepareThumbnail)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cancelPrefetchingForItemsAt indexPaths: [IndexPath]
+  ) {
+    for indexPath in indexPaths {
+      guard photos.indices.contains(indexPath.item) else {
+        continue
+      }
+      thumbnailStore.cancel(id: photos[indexPath.item].id)
+    }
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewDataSourcePrefetching](https://developer.apple.com/documentation/uikit/uicollectionviewdatasourceprefetching)

--- a/docs/guide/uikit/collection-views/examples/data-source.md
+++ b/docs/guide/uikit/collection-views/examples/data-source.md
@@ -270,6 +270,146 @@ Collection View는 update 전후 data source가 보고한 item 개수와 삽입�
 
 원격 이미지가 있다면 [`UICollectionViewDataSourcePrefetching` 예제](./data-source-prefetching)에서 곧 보일 item의 작업을 미리 준비해 보세요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 초기 표시, 선택, 삽입, 삭제, 재배치를 한 화면에 합친 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+@MainActor
+final class ClassicPhotoGridViewController: UIViewController {
+  private var photos = Photo.samples
+  var onSelectPhoto: ((Photo.ID) -> Void)?
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    view.backgroundColor = .systemBackground
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.delegate = self
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func makeGridLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 12
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    layout.itemSize = CGSize(width: 160, height: 160)
+    return layout
+  }
+
+  func append(_ photo: Photo) {
+    let indexPath = IndexPath(item: photos.count, section: 0)
+    photos.append(photo)
+    collectionView.insertItems(at: [indexPath])
+  }
+
+  func deletePhoto(id: Photo.ID) {
+    guard let index = photos.firstIndex(
+      where: { $0.id == id }
+    ) else {
+      return
+    }
+
+    photos.remove(at: index)
+    collectionView.deleteItems(
+      at: [IndexPath(item: index, section: 0)]
+    )
+  }
+}
+
+extension ClassicPhotoGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    canMoveItemAt indexPath: IndexPath
+  ) -> Bool {
+    true
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    moveItemAt sourceIndexPath: IndexPath,
+    to destinationIndexPath: IndexPath
+  ) {
+    let photo = photos.remove(at: sourceIndexPath.item)
+    photos.insert(photo, at: destinationIndexPath.item)
+  }
+}
+
+extension ClassicPhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    onSelectPhoto?(photos[indexPath.item].id)
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdatasource)

--- a/docs/guide/uikit/collection-views/examples/diffable-data-source.md
+++ b/docs/guide/uikit/collection-views/examples/diffable-data-source.md
@@ -11,15 +11,15 @@ description: 'UICollectionViewDiffableDataSource와 Cell Registration을 연결�
 
 ## 먼저 알아둘 용어
 
-| 용어          | 쉬운 뜻                                                                        |
-| ------------- | ------------------------------------------------------------------------------ |
-| identifier    | item이 이동해도 같은 데이터임을 구분하는 `Hashable` 값이에요.                  |
-| snapshot      | 특정 시점의 section과 item 순서를 나타내는 값이에요.                           |
-| cell provider | item identifier를 받아 구성된 셀을 반환하는 closure예요.                       |
-| backing store | identifier로 실제 최신 모델을 찾는 저장소예요. 이 예제에서는 `photosByID`예요. |
-| reconfigure   | item 정체성과 셀을 유지하면서 표시 내용을 다시 구성하는 갱신이에요.            |
+| 용어          | 쉬운 뜻                                                                                 |
+| ------------- | --------------------------------------------------------------------------------------- |
+| identifier    | item이 이동해도 같은 데이터임을 구분하는 `Hashable` 값이에요.                           |
+| snapshot      | 특정 시점의 section과 item 순서를 나타내는 값이에요.                                    |
+| cell provider | item identifier를 받아 구성된 셀을 반환하는 closure예요.                                |
+| backing store | 화면에 표시할 실제 최신 모델을 보관하는 저장소예요. 이 예제에서는 `[Photo]` 배열이에요. |
+| reconfigure   | item 정체성과 셀을 유지하면서 표시 내용을 다시 구성하는 갱신이에요.                     |
 
-## 모델 저장소와 화면 순서를 분리해요
+## 모델과 화면 순서를 한 배열에서 관리해요
 
 ```swift
 @MainActor
@@ -28,8 +28,7 @@ final class DiffablePhotoGridViewController: UIViewController {
     case main
   }
 
-  private var photosByID: [Photo.ID: Photo] = [:]
-  private var photoIDs: [Photo.ID] = []
+  private var photos: [Photo] = []
 
   private var dataSource:
     UICollectionViewDiffableDataSource<Section, Photo.ID>!
@@ -49,7 +48,34 @@ final class DiffablePhotoGridViewController: UIViewController {
 }
 ```
 
-`photosByID`는 ID로 최신 모델을 찾고, `photoIDs`는 화면에 보여 줄 순서를 보관해요. 제목이나 즐겨찾기 여부가 바뀌어도 `Photo.ID`는 유지돼요.
+`photos` 배열이 모델 내용과 화면 순서를 함께 나타내는 단일 진실 공급원이에요. Snapshot에는 배열 자체가 아니라 `photos.map(\.id)`로 얻은 안정적인 ID만 넣어요. 제목이나 즐겨찾기 여부가 바뀌어도 `Photo.ID`는 유지돼요.
+
+ID로 모델을 찾을 때는 작은 helper를 사용해요.
+
+```swift
+private func index(of id: Photo.ID) -> Int? {
+  photos.firstIndex { $0.id == id }
+}
+
+private func photo(for id: Photo.ID) -> Photo? {
+  guard let index = index(of: id) else {
+    return nil
+  }
+  return photos[index]
+}
+```
+
+### Dictionary와 ID 배열을 따로 두지 않는 이유
+
+`[Photo.ID: Photo]`는 ID 조회가 평균 O(1)이고 `[Photo.ID]`는 화면 순서를 표현하기 좋아요. 하지만 삽입·삭제·이동 때 두 저장소를 항상 함께 수정해야 하므로 한쪽만 바뀌는 버그가 생길 수 있어요.
+
+| 방식                               | 장점                                   | 비용                                               |
+| ---------------------------------- | -------------------------------------- | -------------------------------------------------- |
+| 단일 `[Photo]`                     | 원본이 하나라 갱신 순서가 단순해요.    | ID 조회가 O(n)이에요.                              |
+| Dictionary + 순서 배열             | ID 조회가 평균 O(1)이에요.             | 두 가변 저장소의 삽입·삭제·이동을 동기화해야 해요. |
+| 배열 + 필요할 때 계산한 Dictionary | 원본은 하나고 일괄 조회도 빠르게 해요. | Index를 다시 만드는 비용과 시점을 관리해야 해요.   |
+
+사진 수가 작고 학습이 목적인 이 예제에서는 배열 하나가 더 적합해요. 수천 개 모델을 반복 조회해 실제 병목이 확인되면, 배열을 원본으로 유지한 채 읽기 전용 ID index를 계산하거나 순서와 조회를 함께 책임지는 별도 store 타입을 도입하세요.
 
 ## Flow Layout을 준비해요
 
@@ -112,7 +138,7 @@ extension DiffablePhotoGridViewController {
       PhotoCell,
       Photo.ID
     > { [weak self] cell, _, photoID in
-      guard let photo = self?.photosByID[photoID] else {
+      guard let photo = self?.photo(for: photoID) else {
         return
       }
 
@@ -141,13 +167,10 @@ Cell Registration은 셀 타입과 구성 코드를 묶어요. `dequeueConfigure
 ```swift
 extension DiffablePhotoGridViewController {
   private func show(
-    _ photos: [Photo],
+    _ newPhotos: [Photo],
     animatingDifferences: Bool = true
   ) {
-    photosByID = Dictionary(
-      uniqueKeysWithValues: photos.map { ($0.id, $0) }
-    )
-    photoIDs = photos.map(\.id)
+    photos = newPhotos
 
     applyCurrentSnapshot(
       animatingDifferences: animatingDifferences
@@ -160,7 +183,10 @@ extension DiffablePhotoGridViewController {
     var snapshot =
       NSDiffableDataSourceSnapshot<Section, Photo.ID>()
     snapshot.appendSections([.main])
-    snapshot.appendItems(photoIDs, toSection: .main)
+    snapshot.appendItems(
+      photos.map(\.id),
+      toSection: .main
+    )
 
     dataSource.apply(
       snapshot,
@@ -177,18 +203,16 @@ extension DiffablePhotoGridViewController {
 ```swift
 extension DiffablePhotoGridViewController {
   func append(_ photo: Photo) {
-    guard photosByID[photo.id] == nil else {
+    guard index(of: photo.id) == nil else {
       return
     }
 
-    photosByID[photo.id] = photo
-    photoIDs.append(photo.id)
+    photos.append(photo)
     applyCurrentSnapshot()
   }
 
   func deletePhoto(id: Photo.ID) {
-    photosByID[id] = nil
-    photoIDs.removeAll { $0 == id }
+    photos.removeAll { $0.id == id }
     applyCurrentSnapshot()
   }
 }
@@ -201,11 +225,11 @@ extension DiffablePhotoGridViewController {
 ```swift
 extension DiffablePhotoGridViewController {
   func toggleFavorite(id: Photo.ID) {
-    guard photosByID[id] != nil else {
+    guard let index = index(of: id) else {
       return
     }
 
-    photosByID[id]?.isFavorite.toggle()
+    photos[index].isFavorite.toggle()
 
     var snapshot = dataSource.snapshot()
     guard snapshot.indexOfItem(id) != nil else {
@@ -256,17 +280,15 @@ extension DiffablePhotoGridViewController {
     before destinationID: Photo.ID
   ) {
     guard
-      let sourceIndex = photoIDs.firstIndex(of: id),
-      let destinationIndex = photoIDs.firstIndex(
-        of: destinationID
-      )
+      let sourceIndex = index(of: id),
+      let destinationIndex = index(of: destinationID)
     else {
       return
     }
 
-    photoIDs.remove(at: sourceIndex)
-    photoIDs.insert(
-      id,
+    let photo = photos.remove(at: sourceIndex)
+    photos.insert(
+      photo,
       at: sourceIndex < destinationIndex
         ? destinationIndex - 1
         : destinationIndex
@@ -294,8 +316,8 @@ extension DiffablePhotoGridViewController {
 | ----------------------------------- | ------------------------------------------------------------------------ |
 | snapshot 적용 중 중복 예외가 나요.  | section과 item identifier가 각각 유일한지 확인해요.                      |
 | 내용 변경 뒤 선택이 사라져요.       | 바뀌는 모델 전체가 아니라 `Photo.ID`를 identifier로 사용했는지 확인해요. |
-| 셀 provider에서 모델을 찾지 못해요. | snapshot을 적용하기 전에 `photosByID`를 최신 상태로 갱신했는지 확인해요. |
-| 삭제한 item이 다시 나타나요.        | `photosByID`와 `photoIDs` 양쪽에서 제거했는지 확인해요.                  |
+| 셀 provider에서 모델을 찾지 못해요. | snapshot의 ID가 현재 `photos` 배열에도 존재하는지 확인해요.              |
+| 삭제한 item이 다시 나타나요.        | `photos`에서 제거한 뒤 배열 기준으로 새 snapshot을 적용했는지 봐요.      |
 | 셀이 전혀 표시되지 않아요.          | `configureDataSource()` 뒤 초기 snapshot을 적용했는지 확인해요.          |
 
 ## 면접에서 이어질 수 있는 질문
@@ -314,6 +336,198 @@ extension DiffablePhotoGridViewController {
 - 곧 보일 이미지 작업을 미리 시작하려면 [`UICollectionViewDataSourcePrefetching` 예제](./data-source-prefetching)를 읽어 보세요.
 - section마다 다른 배치를 만들려면 [`UICollectionViewCompositionalLayout` 예제](./compositional-layout)로 이동하세요.
 - 새로고침과 prefetch는 [실무 확장 예제](./practical-recipes)에서 이어서 구현해요.
+
+## 전체 최종 코드
+
+아래 최종본은 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 단일 `[Photo]` 배열, Cell Registration, snapshot, 삽입·삭제·내용 변경·이동을 모두 연결해요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+@MainActor
+final class DiffablePhotoGridViewController: UIViewController {
+  private enum Section {
+    case main
+  }
+
+  private var photos: [Photo] = []
+  private var dataSource:
+    UICollectionViewDiffableDataSource<Section, Photo.ID>!
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    configureCollectionView()
+    configureDataSource()
+    show(Photo.samples, animatingDifferences: false)
+  }
+
+  private func index(of id: Photo.ID) -> Int? {
+    photos.firstIndex { $0.id == id }
+  }
+
+  private func photo(for id: Photo.ID) -> Photo? {
+    guard let index = index(of: id) else {
+      return nil
+    }
+    return photos[index]
+  }
+
+  private func makeGridLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 12
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    layout.itemSize = CGSize(width: 160, height: 160)
+    return layout
+  }
+
+  private func configureCollectionView() {
+    view.backgroundColor = .systemBackground
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.delegate = self
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func configureDataSource() {
+    let registration = UICollectionView.CellRegistration<
+      PhotoCell,
+      Photo.ID
+    > { [weak self] cell, _, photoID in
+      guard let photo = self?.photo(for: photoID) else {
+        return
+      }
+      cell.configure(with: photo)
+    }
+
+    dataSource = UICollectionViewDiffableDataSource(
+      collectionView: collectionView
+    ) { collectionView, indexPath, photoID in
+      collectionView.dequeueConfiguredReusableCell(
+        using: registration,
+        for: indexPath,
+        item: photoID
+      )
+    }
+  }
+
+  private func show(
+    _ newPhotos: [Photo],
+    animatingDifferences: Bool = true
+  ) {
+    photos = newPhotos
+    applyCurrentSnapshot(
+      animatingDifferences: animatingDifferences
+    )
+  }
+
+  private func applyCurrentSnapshot(
+    animatingDifferences: Bool = true
+  ) {
+    var snapshot =
+      NSDiffableDataSourceSnapshot<Section, Photo.ID>()
+    snapshot.appendSections([.main])
+    snapshot.appendItems(photos.map(\.id), toSection: .main)
+    dataSource.apply(
+      snapshot,
+      animatingDifferences: animatingDifferences
+    )
+  }
+
+  func append(_ photo: Photo) {
+    guard index(of: photo.id) == nil else {
+      return
+    }
+    photos.append(photo)
+    applyCurrentSnapshot()
+  }
+
+  func deletePhoto(id: Photo.ID) {
+    photos.removeAll { $0.id == id }
+    applyCurrentSnapshot()
+  }
+
+  func toggleFavorite(id: Photo.ID) {
+    guard let index = index(of: id) else {
+      return
+    }
+    photos[index].isFavorite.toggle()
+
+    var snapshot = dataSource.snapshot()
+    guard snapshot.indexOfItem(id) != nil else {
+      return
+    }
+    snapshot.reconfigureItems([id])
+    dataSource.apply(snapshot, animatingDifferences: true)
+  }
+
+  func movePhoto(
+    id: Photo.ID,
+    before destinationID: Photo.ID
+  ) {
+    guard
+      let sourceIndex = index(of: id),
+      let destinationIndex = index(of: destinationID)
+    else {
+      return
+    }
+
+    let photo = photos.remove(at: sourceIndex)
+    let insertionIndex = sourceIndex < destinationIndex
+      ? destinationIndex - 1
+      : destinationIndex
+    photos.insert(photo, at: insertionIndex)
+    applyCurrentSnapshot()
+  }
+}
+
+extension DiffablePhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    guard let id = dataSource.itemIdentifier(
+      for: indexPath
+    ) else {
+      return
+    }
+    toggleFavorite(id: id)
+  }
+}
+```
+
+</details>
 
 ## 참고 자료
 

--- a/docs/guide/uikit/collection-views/examples/drag-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/drag-delegate.md
@@ -196,6 +196,176 @@ func collectionView(
 
 Drag item을 만들었다면 [`UICollectionViewDropDelegate` 예제](./drop-delegate)에서 내부 재배치와 외부 데이터 삽입을 구현해 보세요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 단일·다중 선택 drag, session item 추가, 외부 전달용 provider와 내부 전달용 ID, preview를 연결한 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+@MainActor
+final class DraggablePhotoGridViewController:
+  UIViewController
+{
+  private var photos = Photo.samples
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.allowsMultipleSelection = true
+    collectionView.dataSource = self
+    collectionView.dragDelegate = self
+    collectionView.dragInteractionEnabled = true
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func makeGridLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.itemSize = CGSize(width: 160, height: 160)
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 12
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    return layout
+  }
+
+  private func makeDragItem(for photo: Photo) -> UIDragItem {
+    let provider = NSItemProvider(
+      object: photo.title as NSString
+    )
+    let item = UIDragItem(itemProvider: provider)
+    item.localObject = photo.id
+    return item
+  }
+}
+
+extension DraggablePhotoGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+}
+
+extension DraggablePhotoGridViewController:
+  UICollectionViewDragDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    itemsForBeginning session: UIDragSession,
+    at indexPath: IndexPath
+  ) -> [UIDragItem] {
+    let selected =
+      collectionView.indexPathsForSelectedItems ?? []
+    let sourceIndexPaths = selected.contains(indexPath)
+      ? selected
+      : [indexPath]
+
+    return sourceIndexPaths.compactMap { path in
+      guard photos.indices.contains(path.item) else {
+        return nil
+      }
+      let photo = photos[path.item]
+      return photo.title.isEmpty
+        ? nil
+        : makeDragItem(for: photo)
+    }
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    itemsForAddingTo session: UIDragSession,
+    at indexPath: IndexPath,
+    point: CGPoint
+  ) -> [UIDragItem] {
+    guard photos.indices.contains(indexPath.item) else {
+      return []
+    }
+
+    let photo = photos[indexPath.item]
+    let existingIDs = Set(
+      session.items.compactMap {
+        $0.localObject as? Photo.ID
+      }
+    )
+    return existingIDs.contains(photo.id)
+      ? []
+      : [makeDragItem(for: photo)]
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    dragPreviewParametersForItemAt indexPath: IndexPath
+  ) -> UIDragPreviewParameters? {
+    guard let cell = collectionView.cellForItem(
+      at: indexPath
+    ) else {
+      return nil
+    }
+
+    let parameters = UIDragPreviewParameters()
+    parameters.visiblePath = UIBezierPath(
+      roundedRect: cell.bounds,
+      cornerRadius: 14
+    )
+    parameters.backgroundColor = .clear
+    return parameters
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewDragDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdragdelegate)

--- a/docs/guide/uikit/collection-views/examples/drop-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/drop-delegate.md
@@ -233,6 +233,243 @@ private func loadExternalItem(
 
 `session.localDragSession`과 `UIDragItem.localObject`를 사용할 수 있으면 같은 앱 내부 흐름으로 처리할 수 있어요. 외부 데이터는 `NSItemProvider`가 제공하는 등록 타입을 검사하고 비동기로 로드해 새 모델을 만들어요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 drag 시작, 내부 재배치, 외부 문자열 drop과 placeholder 처리를 한 화면에 합친 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+@MainActor
+final class DropPhotoGridViewController: UIViewController {
+  private var photos = Photo.samples
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.dragDelegate = self
+    collectionView.dropDelegate = self
+    collectionView.dragInteractionEnabled = true
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func makeGridLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.itemSize = CGSize(width: 160, height: 160)
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 12
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    return layout
+  }
+
+  private func resolvedDestination(
+    from coordinator: UICollectionViewDropCoordinator
+  ) -> IndexPath {
+    let item = min(
+      coordinator.destinationIndexPath?.item ?? photos.count,
+      photos.count
+    )
+    return IndexPath(item: item, section: 0)
+  }
+
+  private func loadExternalItem(
+    _ item: UICollectionViewDropItem,
+    destination: IndexPath,
+    coordinator: UICollectionViewDropCoordinator
+  ) {
+    let placeholder = UICollectionViewDropPlaceholder(
+      insertionIndexPath: destination,
+      reuseIdentifier: PhotoCell.reuseIdentifier
+    )
+    let context = coordinator.drop(
+      item.dragItem,
+      to: placeholder
+    )
+
+    item.dragItem.itemProvider.loadObject(
+      ofClass: NSString.self
+    ) { [weak self] object, error in
+      DispatchQueue.main.async {
+        guard
+          let self,
+          error == nil,
+          let title = object as? String
+        else {
+          context.deletePlaceholder()
+          return
+        }
+
+        let photo = Photo(
+          id: UUID(),
+          title: title,
+          symbolName: "photo.fill",
+          isFavorite: false
+        )
+        context.commitInsertion { indexPath in
+          self.photos.insert(photo, at: indexPath.item)
+        }
+      }
+    }
+  }
+}
+
+extension DropPhotoGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+}
+
+extension DropPhotoGridViewController:
+  UICollectionViewDragDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    itemsForBeginning session: UIDragSession,
+    at indexPath: IndexPath
+  ) -> [UIDragItem] {
+    guard photos.indices.contains(indexPath.item) else {
+      return []
+    }
+
+    let photo = photos[indexPath.item]
+    let provider = NSItemProvider(
+      object: photo.title as NSString
+    )
+    let item = UIDragItem(itemProvider: provider)
+    item.localObject = photo.id
+    return [item]
+  }
+}
+
+extension DropPhotoGridViewController:
+  UICollectionViewDropDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    canHandle session: UIDropSession
+  ) -> Bool {
+    session.localDragSession != nil
+      || session.canLoadObjects(ofClass: NSString.self)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    dropSessionDidUpdate session: UIDropSession,
+    withDestinationIndexPath destinationIndexPath: IndexPath?
+  ) -> UICollectionViewDropProposal {
+    UICollectionViewDropProposal(
+      operation:
+        session.localDragSession == nil ? .copy : .move,
+      intent: .insertAtDestinationIndexPath
+    )
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    performDropWith coordinator: UICollectionViewDropCoordinator
+  ) {
+    var destination = resolvedDestination(from: coordinator)
+
+    for item in coordinator.items {
+      guard
+        let source = item.sourceIndexPath,
+        let id = item.dragItem.localObject as? Photo.ID,
+        let sourceIndex = photos.firstIndex(
+          where: { $0.id == id }
+        )
+      else {
+        loadExternalItem(
+          item,
+          destination: destination,
+          coordinator: coordinator
+        )
+        destination = IndexPath(
+          item: destination.item + 1,
+          section: destination.section
+        )
+        continue
+      }
+
+      let photo = photos.remove(at: sourceIndex)
+      let adjustedItem = sourceIndex < destination.item
+        ? destination.item - 1
+        : destination.item
+      let target = min(max(adjustedItem, 0), photos.count)
+      photos.insert(photo, at: target)
+
+      let targetIndexPath = IndexPath(
+        item: target,
+        section: 0
+      )
+      collectionView.moveItem(
+        at: source,
+        to: targetIndexPath
+      )
+      coordinator.drop(
+        item.dragItem,
+        toItemAt: targetIndexPath
+      )
+    }
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewDropDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdropdelegate)

--- a/docs/guide/uikit/collection-views/examples/flow-layout-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/flow-layout-delegate.md
@@ -189,6 +189,226 @@ Delegate 값은 해당 항목의 Flow Layout 기본 프로퍼티보다 우선해
 
 아니요. 고정된 크기라면 `UICollectionViewFlowLayout.itemSize`를 설정하는 편이 더 단순해요. 화면 너비나 section, 모델에 따라 값이 달라질 때 delegate가 유용해요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 화면 너비에 따른 열 계산, section 여백과 간격, header·footer 제공을 합친 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+final class GallerySupplementaryView:
+  UICollectionReusableView
+{
+  static let reuseIdentifier = "GallerySupplementaryView"
+  private let label = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    label.font = .preferredFont(forTextStyle: .headline)
+    label.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(label)
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(
+        equalTo: leadingAnchor,
+        constant: 16
+      ),
+      label.centerYAnchor.constraint(equalTo: centerYAnchor),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+
+  func configure(text: String) {
+    label.text = text
+  }
+}
+
+@MainActor
+final class ResponsiveDelegateGridViewController:
+  UIViewController
+{
+  private var photos = Photo.samples
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: UICollectionViewFlowLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.delegate = self
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+    collectionView.register(
+      GallerySupplementaryView.self,
+      forSupplementaryViewOfKind:
+        UICollectionView.elementKindSectionHeader,
+      withReuseIdentifier:
+        GallerySupplementaryView.reuseIdentifier
+    )
+    collectionView.register(
+      GallerySupplementaryView.self,
+      forSupplementaryViewOfKind:
+        UICollectionView.elementKindSectionFooter,
+      withReuseIdentifier:
+        GallerySupplementaryView.reuseIdentifier
+    )
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+}
+
+extension ResponsiveDelegateGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    viewForSupplementaryElementOfKind kind: String,
+    at indexPath: IndexPath
+  ) -> UICollectionReusableView {
+    let view = collectionView.dequeueReusableSupplementaryView(
+      ofKind: kind,
+      withReuseIdentifier:
+        GallerySupplementaryView.reuseIdentifier,
+      for: indexPath
+    )
+    guard let supplementaryView =
+      view as? GallerySupplementaryView
+    else {
+      return view
+    }
+
+    supplementaryView.configure(
+      text: kind == UICollectionView.elementKindSectionHeader
+        ? "사진"
+        : "총 \(photos.count)장"
+    )
+    return supplementaryView
+  }
+}
+
+extension ResponsiveDelegateGridViewController:
+  UICollectionViewDelegateFlowLayout
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
+    let inset: CGFloat = 16
+    let spacing: CGFloat = 12
+    let minimumWidth: CGFloat = 150
+    let availableWidth =
+      collectionView.bounds.width
+      - collectionView.adjustedContentInset.left
+      - collectionView.adjustedContentInset.right
+      - inset * 2
+    let columns = max(
+      1,
+      Int(
+        (availableWidth + spacing)
+          / (minimumWidth + spacing)
+      )
+    )
+    let width = floor(
+      (availableWidth - spacing * CGFloat(columns - 1))
+        / CGFloat(columns)
+    )
+    return CGSize(width: width, height: width + 48)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    insetForSectionAt section: Int
+  ) -> UIEdgeInsets {
+    UIEdgeInsets(top: 16, left: 16, bottom: 24, right: 16)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    minimumLineSpacingForSectionAt section: Int
+  ) -> CGFloat {
+    16
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    minimumInteritemSpacingForSectionAt section: Int
+  ) -> CGFloat {
+    12
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    referenceSizeForHeaderInSection section: Int
+  ) -> CGSize {
+    CGSize(width: collectionView.bounds.width, height: 52)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    referenceSizeForFooterInSection section: Int
+  ) -> CGSize {
+    CGSize(width: collectionView.bounds.width, height: 32)
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewDelegateFlowLayout](https://developer.apple.com/documentation/uikit/uicollectionviewdelegateflowlayout)

--- a/docs/guide/uikit/collection-views/examples/flow-layout.md
+++ b/docs/guide/uikit/collection-views/examples/flow-layout.md
@@ -310,6 +310,187 @@ Flow Layout 화면의 선택·하이라이트·메뉴는 [전통적인 `UICollec
 
 Item 크기와 section 간격을 delegate 역할에 집중해 다시 살펴보려면 [`UICollectionViewDelegateFlowLayout` 예제](./flow-layout-delegate)를 읽어 보세요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 반응형 열 계산, 고정 header, 회전 시 invalidation을 한 화면에 합친 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+final class FlowGalleryHeaderView: UICollectionReusableView {
+  static let reuseIdentifier = "FlowGalleryHeaderView"
+  private let titleLabel = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    titleLabel.font = .preferredFont(forTextStyle: .title2)
+    titleLabel.text = "모든 사진"
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    addSubview(titleLabel)
+    NSLayoutConstraint.activate([
+      titleLabel.leadingAnchor.constraint(
+        equalTo: leadingAnchor,
+        constant: 16
+      ),
+      titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 사용하지 않아요.")
+  }
+}
+
+@MainActor
+final class FlowPhotoGridViewController: UIViewController {
+  private var photos = Photo.samples
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeFlowLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.delegate = self
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+    collectionView.register(
+      FlowGalleryHeaderView.self,
+      forSupplementaryViewOfKind:
+        UICollectionView.elementKindSectionHeader,
+      withReuseIdentifier:
+        FlowGalleryHeaderView.reuseIdentifier
+    )
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  override func viewWillTransition(
+    to size: CGSize,
+    with coordinator: UIViewControllerTransitionCoordinator
+  ) {
+    super.viewWillTransition(to: size, with: coordinator)
+    coordinator.animate { [weak self] _ in
+      self?.collectionView.collectionViewLayout
+        .invalidateLayout()
+    }
+  }
+
+  private func makeFlowLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.scrollDirection = .vertical
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 16
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    layout.headerReferenceSize = CGSize(width: 0, height: 52)
+    layout.sectionHeadersPinToVisibleBounds = true
+    return layout
+  }
+}
+
+extension FlowPhotoGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    viewForSupplementaryElementOfKind kind: String,
+    at indexPath: IndexPath
+  ) -> UICollectionReusableView {
+    collectionView.dequeueReusableSupplementaryView(
+      ofKind: kind,
+      withReuseIdentifier:
+        FlowGalleryHeaderView.reuseIdentifier,
+      for: indexPath
+    )
+  }
+}
+
+extension FlowPhotoGridViewController:
+  UICollectionViewDelegateFlowLayout
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
+    let inset: CGFloat = 16
+    let spacing: CGFloat = 12
+    let minimumWidth: CGFloat = 150
+    let availableWidth =
+      collectionView.bounds.width
+      - collectionView.adjustedContentInset.left
+      - collectionView.adjustedContentInset.right
+      - inset * 2
+    let columns = max(
+      1,
+      Int(
+        (availableWidth + spacing)
+          / (minimumWidth + spacing)
+      )
+    )
+    let width = floor(
+      (availableWidth - spacing * CGFloat(columns - 1))
+        / CGFloat(columns)
+    )
+    return CGSize(width: width, height: width)
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewFlowLayout](https://developer.apple.com/documentation/uikit/uicollectionviewflowlayout)

--- a/docs/guide/uikit/collection-views/examples/list-layout.md
+++ b/docs/guide/uikit/collection-views/examples/list-layout.md
@@ -271,6 +271,191 @@ Section provider index는 현재 snapshot의 section 순서로 해석해요. 위
 
 아니요. 단순한 기존 표라면 `UITableView`도 충분해요. 같은 화면에서 목록과 카드·격자를 조합하거나 Diffable Collection View 구성 방식을 통일할 때 List Layout의 이점이 커져요.
 
+## 전체 최종 코드
+
+아래 코드는 List Layout, List Cell Registration, accessory, Diffable snapshot, swipe action을 하나의 설정 화면에 연결한 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+private enum SettingsSection: Hashable {
+  case account
+  case display
+}
+
+private enum SettingsItem: Hashable {
+  case profile
+  case notifications
+  case darkMode
+
+  var title: String {
+    switch self {
+    case .profile:
+      return "프로필"
+    case .notifications:
+      return "알림"
+    case .darkMode:
+      return "화면 모드"
+    }
+  }
+
+  var symbolName: String {
+    switch self {
+    case .profile:
+      return "person.crop.circle"
+    case .notifications:
+      return "bell"
+    case .darkMode:
+      return "circle.lefthalf.filled"
+    }
+  }
+}
+
+@MainActor
+final class SettingsListViewController: UIViewController {
+  private var resetItems: Set<SettingsItem> = []
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeListLayout()
+  )
+
+  private lazy var cellRegistration =
+    UICollectionView.CellRegistration<
+      UICollectionViewListCell,
+      SettingsItem
+    > { [weak self] cell, _, item in
+      var content = cell.defaultContentConfiguration()
+      content.text = item.title
+      content.secondaryText =
+        self?.resetItems.contains(item) == true
+          ? "기본값"
+          : nil
+      content.image = UIImage(systemName: item.symbolName)
+      cell.contentConfiguration = content
+
+      switch item {
+      case .profile:
+        cell.accessories = [.disclosureIndicator()]
+      case .notifications:
+        cell.accessories = [
+          .label(text: "켜짐"),
+          .disclosureIndicator(),
+        ]
+      case .darkMode:
+        cell.accessories = [.checkmark()]
+      }
+    }
+
+  private lazy var dataSource =
+    UICollectionViewDiffableDataSource<
+      SettingsSection,
+      SettingsItem
+    >(
+      collectionView: collectionView
+    ) { [weak self] collectionView, indexPath, item in
+      guard let self else {
+        return nil
+      }
+      return collectionView.dequeueConfiguredReusableCell(
+        using: cellRegistration,
+        for: indexPath,
+        item: item
+      )
+    }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemGroupedBackground
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+
+    applyInitialSnapshot()
+  }
+
+  private func makeListLayout()
+    -> UICollectionViewCompositionalLayout
+  {
+    var configuration = UICollectionLayoutListConfiguration(
+      appearance: .insetGrouped
+    )
+    configuration.showsSeparators = true
+    configuration.trailingSwipeActionsConfigurationProvider = {
+      [weak self] indexPath in
+      guard
+        let self,
+        let item = dataSource.itemIdentifier(
+          for: indexPath
+        )
+      else {
+        return nil
+      }
+
+      let reset = UIContextualAction(
+        style: .normal,
+        title: "초기화"
+      ) { [weak self] _, _, completion in
+        self?.reset(item)
+        completion(true)
+      }
+      reset.backgroundColor = .systemOrange
+      return UISwipeActionsConfiguration(actions: [reset])
+    }
+
+    return UICollectionViewCompositionalLayout.list(
+      using: configuration
+    )
+  }
+
+  private func applyInitialSnapshot() {
+    var snapshot = NSDiffableDataSourceSnapshot<
+      SettingsSection,
+      SettingsItem
+    >()
+    snapshot.appendSections([.account, .display])
+    snapshot.appendItems(
+      [.profile, .notifications],
+      toSection: .account
+    )
+    snapshot.appendItems(
+      [.darkMode],
+      toSection: .display
+    )
+    dataSource.apply(
+      snapshot,
+      animatingDifferences: false
+    )
+  }
+
+  private func reset(_ item: SettingsItem) {
+    resetItems.insert(item)
+    var snapshot = dataSource.snapshot()
+    snapshot.reconfigureItems([item])
+    dataSource.apply(snapshot, animatingDifferences: true)
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewCompositionalLayout](https://developer.apple.com/documentation/uikit/uicollectionviewcompositionallayout)

--- a/docs/guide/uikit/collection-views/examples/modern-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/modern-delegate.md
@@ -13,13 +13,13 @@ description: 'Diffable Data Source 기반 UICollectionView에서 delegate의 Ind
 
 ## 먼저 알아둘 용어
 
-| 용어            | 쉬운 뜻                                                                         |
-| --------------- | ------------------------------------------------------------------------------- |
-| item identifier | item이 이동해도 같은 데이터임을 나타내는 안정적인 `Hashable` 값이에요.          |
-| snapshot        | 현재 화면의 section과 item 순서를 표현한 값이에요.                              |
-| reconfigure     | 기존 item의 정체성과 셀 상태를 유지하면서 표시 내용만 다시 구성하는 갱신이에요. |
-| backing store   | identifier로 실제 최신 모델을 찾는 저장소예요. 이 예제에서는 `photosByID`예요.  |
-| delegate        | Collection View의 선택·표시·메뉴 같은 상호작용을 전달받는 객체예요.             |
+| 용어            | 쉬운 뜻                                                                                |
+| --------------- | -------------------------------------------------------------------------------------- |
+| item identifier | item이 이동해도 같은 데이터임을 나타내는 안정적인 `Hashable` 값이에요.                 |
+| snapshot        | 현재 화면의 section과 item 순서를 표현한 값이에요.                                     |
+| reconfigure     | 기존 item의 정체성과 셀 상태를 유지하면서 표시 내용만 다시 구성하는 갱신이에요.        |
+| backing store   | 화면에 표시할 실제 최신 모델을 보관하는 저장소예요. 이 예제에서는 `photos` 배열이에요. |
+| delegate        | Collection View의 선택·표시·메뉴 같은 상호작용을 전달받는 객체예요.                    |
 
 ## Delegate 연결은 전통적인 방식과 같아요
 
@@ -57,7 +57,7 @@ extension DiffablePhotoGridViewController:
   ) -> Bool {
     guard
       let id = photoID(at: indexPath),
-      let photo = photosByID[id]
+      let photo = photo(for: id)
     else {
       return false
     }
@@ -67,7 +67,7 @@ extension DiffablePhotoGridViewController:
 }
 ```
 
-Snapshot에는 ID가 있지만 backing store에서 모델을 찾지 못한다면 아직 두 상태가 동기화되지 않은 거예요. 선택을 허용하지 않고 모델과 snapshot 갱신 순서를 먼저 확인하세요.
+Snapshot에는 ID가 있지만 `photos` 배열에서 모델을 찾지 못한다면 배열을 바꾼 뒤 새 snapshot을 적용하는 순서가 지켜지지 않은 거예요. 선택을 허용하지 않고 모델과 snapshot 갱신 순서를 먼저 확인하세요.
 
 ## 선택으로 모델을 바꾸고 item만 다시 구성해요
 
@@ -88,11 +88,11 @@ func collectionView(
 
 ```swift
 private func toggleFavorite(id: Photo.ID) {
-  guard photosByID[id] != nil else {
+  guard let index = index(of: id) else {
     return
   }
 
-  photosByID[id]?.isFavorite.toggle()
+  photos[index].isFavorite.toggle()
 
   var snapshot = dataSource.snapshot()
   guard snapshot.indexOfItem(id) != nil else {
@@ -311,6 +311,250 @@ Snapshot 안의 화면 identifier는 각각 유일해야 해요. 화면 역할�
 ## 다음 예제로 이동해요
 
 Delegate 상호작용을 연결했다면 [`UICollectionViewCompositionalLayout` 예제](./compositional-layout)에서 추천 카드와 반응형 격자를 한 화면에 구성해 보세요.
+
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 단일 `[Photo]` 배열, Diffable Data Source, 선택·다중 선택·노출·Context Menu를 모두 연결한 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+@MainActor
+final class ModernInteractivePhotoGridViewController:
+  UIViewController
+{
+  private enum Section {
+    case main
+  }
+
+  private var photos = Photo.samples
+  private var selectedPhotoIDs: Set<Photo.ID> = []
+  private var exposedPhotoIDs: Set<Photo.ID> = []
+  private var dataSource:
+    UICollectionViewDiffableDataSource<Section, Photo.ID>!
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    configureCollectionView()
+    configureDataSource()
+    applySnapshot(animatingDifferences: false)
+  }
+
+  private func makeGridLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.itemSize = CGSize(width: 160, height: 160)
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 12
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    return layout
+  }
+
+  private func configureCollectionView() {
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.allowsMultipleSelection = true
+    collectionView.delegate = self
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func configureDataSource() {
+    let registration = UICollectionView.CellRegistration<
+      PhotoCell,
+      Photo.ID
+    > { [weak self] cell, _, id in
+      guard let photo = self?.photo(for: id) else {
+        return
+      }
+      cell.configure(with: photo)
+    }
+
+    dataSource = UICollectionViewDiffableDataSource(
+      collectionView: collectionView
+    ) { collectionView, indexPath, id in
+      collectionView.dequeueConfiguredReusableCell(
+        using: registration,
+        for: indexPath,
+        item: id
+      )
+    }
+  }
+
+  private func index(of id: Photo.ID) -> Int? {
+    photos.firstIndex { $0.id == id }
+  }
+
+  private func photo(for id: Photo.ID) -> Photo? {
+    guard let index = index(of: id) else {
+      return nil
+    }
+    return photos[index]
+  }
+
+  private func photoID(at indexPath: IndexPath) -> Photo.ID? {
+    dataSource.itemIdentifier(for: indexPath)
+  }
+
+  private func applySnapshot(
+    animatingDifferences: Bool = true
+  ) {
+    var snapshot =
+      NSDiffableDataSourceSnapshot<Section, Photo.ID>()
+    snapshot.appendSections([.main])
+    snapshot.appendItems(photos.map(\.id))
+    dataSource.apply(
+      snapshot,
+      animatingDifferences: animatingDifferences
+    ) { [weak self] in
+      self?.restoreSelection()
+    }
+  }
+
+  private func toggleFavorite(id: Photo.ID) {
+    guard let index = index(of: id) else {
+      return
+    }
+    photos[index].isFavorite.toggle()
+
+    var snapshot = dataSource.snapshot()
+    guard snapshot.indexOfItem(id) != nil else {
+      return
+    }
+    snapshot.reconfigureItems([id])
+    dataSource.apply(snapshot, animatingDifferences: true)
+  }
+
+  private func deletePhoto(id: Photo.ID) {
+    photos.removeAll { $0.id == id }
+    selectedPhotoIDs.remove(id)
+    applySnapshot()
+  }
+
+  private func restoreSelection() {
+    selectedPhotoIDs = selectedPhotoIDs.filter {
+      dataSource.indexPath(for: $0) != nil
+    }
+
+    for id in selectedPhotoIDs {
+      guard let indexPath = dataSource.indexPath(for: id) else {
+        continue
+      }
+      collectionView.selectItem(
+        at: indexPath,
+        animated: false,
+        scrollPosition: []
+      )
+    }
+  }
+}
+
+extension ModernInteractivePhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    shouldSelectItemAt indexPath: IndexPath
+  ) -> Bool {
+    guard
+      let id = photoID(at: indexPath),
+      let photo = photo(for: id)
+    else {
+      return false
+    }
+    return !photo.title.isEmpty
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    guard let id = photoID(at: indexPath) else {
+      return
+    }
+    selectedPhotoIDs.insert(id)
+    toggleFavorite(id: id)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didDeselectItemAt indexPath: IndexPath
+  ) {
+    guard let id = photoID(at: indexPath) else {
+      return
+    }
+    selectedPhotoIDs.remove(id)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    willDisplay cell: UICollectionViewCell,
+    forItemAt indexPath: IndexPath
+  ) {
+    guard let id = photoID(at: indexPath) else {
+      return
+    }
+    if exposedPhotoIDs.insert(id).inserted {
+      print("첫 사진 노출: \(id)")
+    }
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    contextMenuConfigurationForItemAt indexPath: IndexPath,
+    point: CGPoint
+  ) -> UIContextMenuConfiguration? {
+    guard let id = photoID(at: indexPath) else {
+      return nil
+    }
+
+    return UIContextMenuConfiguration(
+      identifier: id as NSUUID,
+      previewProvider: nil
+    ) { [weak self] _ in
+      let favorite = UIAction(title: "즐겨찾기 전환") { _ in
+        self?.toggleFavorite(id: id)
+      }
+      let delete = UIAction(
+        title: "삭제",
+        attributes: .destructive
+      ) { _ in
+        self?.deletePhoto(id: id)
+      }
+      return UIMenu(children: [favorite, delete])
+    }
+  }
+}
+```
+
+</details>
 
 ## 참고 자료
 

--- a/docs/guide/uikit/collection-views/examples/practical-recipes.md
+++ b/docs/guide/uikit/collection-views/examples/practical-recipes.md
@@ -36,7 +36,7 @@ private lazy var emptyLabel: UILabel = {
 
 private func updateEmptyState() {
   collectionView.backgroundView =
-    photoIDs.isEmpty ? emptyLabel : nil
+    photos.isEmpty ? emptyLabel : nil
 }
 ```
 
@@ -218,7 +218,7 @@ func collectionView(
   guard
     !isLoadingNextPage,
     hasNextPage,
-    indexPath.item >= max(0, photoIDs.count - 5)
+    indexPath.item >= max(0, photos.count - 5)
   else {
     return
   }
@@ -244,12 +244,12 @@ private func loadNextPage() {
       let page = try await self.photoRepository.fetchNextPage()
       self.hasNextPage = page.hasNextPage
 
-      for photo in page.photos {
-        self.photosByID[photo.id] = photo
-        if !self.photoIDs.contains(photo.id) {
-          self.photoIDs.append(photo.id)
+      var knownIDs = Set(self.photos.map(\.id))
+      self.photos.append(
+        contentsOf: page.photos.filter {
+          knownIDs.insert($0.id).inserted
         }
-      }
+      )
       self.applyCurrentSnapshot()
     } catch {
       self.presentPaginationError(error)
@@ -322,13 +322,20 @@ private func configureReordering() {
   dataSource.reorderingHandlers.didReorder = {
     [weak self] transaction in
 
-    self?.photoIDs =
-      transaction.finalSnapshot.itemIdentifiers
+    guard let self else {
+      return
+    }
+
+    let photosByID = Dictionary(
+      uniqueKeysWithValues: photos.map { ($0.id, $0) }
+    )
+    photos = transaction.finalSnapshot.itemIdentifiers
+      .compactMap { photosByID[$0] }
   }
 }
 ```
 
-Snapshot만 바뀌고 `photoIDs`를 갱신하지 않으면 다음 데이터 갱신 때 이전 순서로 돌아가요. 영구 저장이 필요하면 새 ID 순서를 repository에 전달하고 실패 시 복구 정책을 정하세요.
+Snapshot만 바뀌고 `photos` 배열 순서를 갱신하지 않으면 다음 데이터 갱신 때 이전 순서로 돌아가요. 여기서 `photosByID`는 재정렬 순간에만 만드는 읽기용 index이며, 별도의 가변 데이터 원본이 아니에요. 영구 저장이 필요하면 새 ID 순서를 repository에 전달하고 실패 시 복구 정책을 정하세요.
 
 여러 section을 사용한다면 `transaction.finalSnapshot.itemIdentifiers(inSection:)`로 section별 순서를 가져와 각 backing store에 반영해요.
 

--- a/docs/guide/uikit/collection-views/examples/traditional-delegate.md
+++ b/docs/guide/uikit/collection-views/examples/traditional-delegate.md
@@ -288,6 +288,219 @@ Highlight는 사용자가 손가락을 누르고 있는 동안의 일시적인 �
 
 상호작용을 연결했다면 [`UICollectionViewFlowLayout` 예제](./flow-layout)에서 같은 전통적인 화면의 셀 크기와 간격을 반응형으로 구성해 보세요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용해 전통적인 Data Source와 선택·하이라이트·노출·다중 선택·Context Menu를 한 화면에 연결한 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+@MainActor
+final class ClassicInteractivePhotoGridViewController:
+  UIViewController
+{
+  private var photos = Photo.samples
+  private var selectedPhotoIDs: Set<Photo.ID> = []
+  private var exposedPhotoIDs: Set<Photo.ID> = []
+  var onSelectPhoto: ((Photo.ID) -> Void)?
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeGridLayout()
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.allowsMultipleSelection = true
+    collectionView.dataSource = self
+    collectionView.delegate = self
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+  }
+
+  private func makeGridLayout() -> UICollectionViewFlowLayout {
+    let layout = UICollectionViewFlowLayout()
+    layout.itemSize = CGSize(width: 160, height: 160)
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 12
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    return layout
+  }
+
+  private func toggleFavorite(id: Photo.ID) {
+    guard let index = photos.firstIndex(
+      where: { $0.id == id }
+    ) else {
+      return
+    }
+
+    photos[index].isFavorite.toggle()
+    collectionView.reloadItems(
+      at: [IndexPath(item: index, section: 0)]
+    )
+  }
+
+  private func deletePhoto(id: Photo.ID) {
+    guard let index = photos.firstIndex(
+      where: { $0.id == id }
+    ) else {
+      return
+    }
+
+    photos.remove(at: index)
+    selectedPhotoIDs.remove(id)
+    collectionView.deleteItems(
+      at: [IndexPath(item: index, section: 0)]
+    )
+  }
+}
+
+extension ClassicInteractivePhotoGridViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+}
+
+extension ClassicInteractivePhotoGridViewController:
+  UICollectionViewDelegate
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    shouldSelectItemAt indexPath: IndexPath
+  ) -> Bool {
+    !photos[indexPath.item].title.isEmpty
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    let id = photos[indexPath.item].id
+    selectedPhotoIDs.insert(id)
+    onSelectPhoto?(id)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didDeselectItemAt indexPath: IndexPath
+  ) {
+    selectedPhotoIDs.remove(photos[indexPath.item].id)
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didHighlightItemAt indexPath: IndexPath
+  ) {
+    UIView.animate(withDuration: 0.12) {
+      collectionView.cellForItem(at: indexPath)?
+        .transform = CGAffineTransform(
+          scaleX: 0.96,
+          y: 0.96
+        )
+    }
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didUnhighlightItemAt indexPath: IndexPath
+  ) {
+    UIView.animate(withDuration: 0.12) {
+      collectionView.cellForItem(at: indexPath)?
+        .transform = .identity
+    }
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    willDisplay cell: UICollectionViewCell,
+    forItemAt indexPath: IndexPath
+  ) {
+    let id = photos[indexPath.item].id
+    if exposedPhotoIDs.insert(id).inserted {
+      print("첫 사진 노출: \(id)")
+    }
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    contextMenuConfigurationForItemAt indexPath: IndexPath,
+    point: CGPoint
+  ) -> UIContextMenuConfiguration? {
+    let id = photos[indexPath.item].id
+
+    return UIContextMenuConfiguration(
+      identifier: id as NSUUID,
+      previewProvider: nil
+    ) { [weak self] _ in
+      let favorite = UIAction(
+        title: "즐겨찾기 전환",
+        image: UIImage(systemName: "heart")
+      ) { _ in
+        self?.toggleFavorite(id: id)
+      }
+      let delete = UIAction(
+        title: "삭제",
+        image: UIImage(systemName: "trash"),
+        attributes: .destructive
+      ) { _ in
+        self?.deletePhoto(id: id)
+      }
+      return UIMenu(children: [favorite, delete])
+    }
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewDelegate](https://developer.apple.com/documentation/uikit/uicollectionviewdelegate)

--- a/docs/guide/uikit/collection-views/examples/transition-layout.md
+++ b/docs/guide/uikit/collection-views/examples/transition-layout.md
@@ -220,6 +220,208 @@ Finish하면 목표 layout이 최종 `collectionViewLayout`이 되고, cancel하
 
 아니요. 현재 layout과 목표 layout 사이의 중간 attributes를 제공하는 임시 layout이에요. 전환을 완료하면 목표 layout이 설치되고, 취소하면 이전 layout으로 돌아가요.
 
+## 전체 최종 코드
+
+아래 코드는 [공통 `Photo`와 `PhotoCell`](./index)을 사용하는 배열 기반 Data Source에 격자·목록 layout, 버튼 전환, pan gesture 기반 interactive transition을 연결한 최종본이에요.
+
+<details>
+<summary>전체 코드 펼쳐보기</summary>
+
+```swift
+import UIKit
+
+@MainActor
+final class LayoutTransitionViewController: UIViewController {
+  private var photos = Photo.samples
+  private var showsGrid = true
+  private var transitionLayout:
+    UICollectionViewTransitionLayout?
+  private var transitionShouldFinish = false
+
+  private lazy var gridLayout: UICollectionViewFlowLayout = {
+    let layout = UICollectionViewFlowLayout()
+    layout.itemSize = CGSize(width: 160, height: 208)
+    layout.minimumInteritemSpacing = 12
+    layout.minimumLineSpacing = 16
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    return layout
+  }()
+
+  private lazy var listLayout: UICollectionViewFlowLayout = {
+    let layout = UICollectionViewFlowLayout()
+    layout.itemSize = CGSize(width: 320, height: 88)
+    layout.minimumLineSpacing = 8
+    layout.sectionInset = UIEdgeInsets(
+      top: 16,
+      left: 16,
+      bottom: 16,
+      right: 16
+    )
+    return layout
+  }()
+
+  private lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: gridLayout
+  )
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    collectionView.backgroundColor = .systemBackground
+    collectionView.dataSource = self
+    collectionView.register(
+      PhotoCell.self,
+      forCellWithReuseIdentifier: PhotoCell.reuseIdentifier
+    )
+    view.addSubview(collectionView)
+    NSLayoutConstraint.activate([
+      collectionView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      collectionView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      collectionView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      collectionView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+    ])
+
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "전환",
+      style: .plain,
+      target: self,
+      action: #selector(toggleLayout)
+    )
+    let pan = UIPanGestureRecognizer(
+      target: self,
+      action: #selector(handleLayoutPan(_:))
+    )
+    collectionView.addGestureRecognizer(pan)
+  }
+
+  @objc
+  private func toggleLayout() {
+    guard transitionLayout == nil else {
+      return
+    }
+    showsGrid.toggle()
+    collectionView.setCollectionViewLayout(
+      showsGrid ? gridLayout : listLayout,
+      animated: true
+    )
+  }
+
+  @objc
+  private func handleLayoutPan(
+    _ gesture: UIPanGestureRecognizer
+  ) {
+    switch gesture.state {
+    case .began:
+      beginLayoutTransition()
+    case .changed:
+      updateLayoutTransition(with: gesture)
+    case .ended:
+      endLayoutTransition(cancelled: false)
+    case .cancelled, .failed:
+      endLayoutTransition(cancelled: true)
+    default:
+      break
+    }
+  }
+
+  private func beginLayoutTransition() {
+    guard transitionLayout == nil else {
+      return
+    }
+
+    let target = showsGrid ? listLayout : gridLayout
+    transitionLayout = collectionView
+      .startInteractiveTransition(
+        to: target
+      ) { [weak self] completed, finished in
+        guard let self else {
+          return
+        }
+        if completed && finished {
+          showsGrid.toggle()
+        }
+        transitionLayout = nil
+        transitionShouldFinish = false
+      }
+  }
+
+  private func updateLayoutTransition(
+    with gesture: UIPanGestureRecognizer
+  ) {
+    guard let transitionLayout else {
+      return
+    }
+
+    let translation = gesture.translation(in: collectionView)
+    let distance = max(collectionView.bounds.width, 1)
+    let progress = min(
+      max(abs(translation.x) / distance, 0),
+      1
+    )
+    transitionLayout.transitionProgress = progress
+    transitionLayout.invalidateLayout()
+
+    let velocity = gesture.velocity(in: collectionView).x
+    transitionShouldFinish =
+      progress > 0.5 || abs(velocity) > 700
+  }
+
+  private func endLayoutTransition(cancelled: Bool) {
+    guard transitionLayout != nil else {
+      return
+    }
+
+    if !cancelled && transitionShouldFinish {
+      collectionView.finishInteractiveTransition()
+    } else {
+      collectionView.cancelInteractiveTransition()
+    }
+  }
+}
+
+extension LayoutTransitionViewController:
+  UICollectionViewDataSource
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: PhotoCell.reuseIdentifier,
+      for: indexPath
+    ) as? PhotoCell else {
+      preconditionFailure("PhotoCell 등록을 확인하세요.")
+    }
+    cell.configure(with: photos[indexPath.item])
+    return cell
+  }
+}
+```
+
+</details>
+
 ## 참고 자료
 
 - [Apple Developer Documentation — UICollectionViewTransitionLayout](https://developer.apple.com/documentation/uikit/uicollectionviewtransitionlayout)


### PR DESCRIPTION
## Summary

UICollectionView 예제의 Data Source, Delegate, Layout 하위 문서마다 단계별 구현을 한 번에 확인할 수 있는 접이식 `전체 최종 코드`를 추가합니다.

Diffable Data Source 예제는 `photosByID`와 `photoIDs` 두 가변 저장소 대신 단일 `[Photo]` 배열을 모델과 화면 순서의 원본으로 사용하도록 단순화했습니다.

## Changes

- Data Source 3개, Delegate 5개, Layout 5개 문서에 페이지별 전체 최종 코드를 추가했습니다.
- 긴 최종 코드는 `<details>`로 접어 단계별 설명을 읽을 때 문서 탐색을 방해하지 않게 했습니다.
- Diffable Data Source의 삽입·삭제·내용 갱신·이동·선택을 단일 `[Photo]` 배열 기준으로 정리했습니다.
- Modern Delegate와 Compositional Layout도 같은 단일 배열 기준으로 맞췄습니다.
- 실무 확장 예제의 재배치는 필요할 때만 읽기용 ID dictionary를 계산하도록 변경했습니다.
- 단일 배열과 dictionary + 순서 배열의 조회 성능·동기화 비용을 비교하고, 별도 index를 도입할 조건을 설명했습니다.
- Prefetch 최종본은 다운로드 완료 후 현재 보이는 셀을 실제 cache 이미지로 다시 구성하도록 연결했습니다.

## Testing

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run docs:check-collection-views`
- [x] `npm run build`
- [x] `git diff --check`
- [x] 13개 전체 최종 코드 블록을 iOS 15 Simulator SDK로 개별 Swift 타입 검사

## Related Issues

Closes #13

## Notes

- 학습 예제에서는 단일 진실 공급원과 갱신 흐름의 명확성을 우선했습니다.
- 데이터가 매우 크고 ID 선형 탐색이 실제 병목으로 측정되면 `[Photo]`를 원본으로 유지한 읽기용 index나 순서와 조회를 함께 책임지는 별도 store 타입을 고려할 수 있습니다.