### PR TITLE
[#18] Swift 제네릭과 some·any 입문 문서를 추가한다

### DIFF
--- a/docs/guide/swift/_meta.json
+++ b/docs/guide/swift/_meta.json
@@ -8,5 +8,20 @@
     "type": "file",
     "name": "closures",
     "label": "클로저"
+  },
+  {
+    "type": "file",
+    "name": "generics",
+    "label": "제네릭"
+  },
+  {
+    "type": "file",
+    "name": "opaque-types",
+    "label": "some과 불투명 타입"
+  },
+  {
+    "type": "file",
+    "name": "existential-types",
+    "label": "any와 실존 타입"
   }
 ]

--- a/docs/guide/swift/existential-types.md
+++ b/docs/guide/swift/existential-types.md
@@ -1,0 +1,692 @@
+---
+title: Swift로 이해하는 any와 실존 타입
+description: Swift의 any가 여러 프로토콜 준수 타입을 실존 상자에 저장하는 원리와 타입 소거, 연관 타입 제약, 제네릭·some과의 선택 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 any와 실존 타입
+
+> **면접 답변 한 줄 요약:** `any Protocol`은 프로토콜을 따르는 서로 다른 구체 타입을 하나의 실존 상자에 저장하고 실행 중 교체할 수 있도록 바깥에서 구체 타입 정체성을 지우는 대신, 프로토콜이 보장하는 공통 기능만 사용하게 하는 Swift의 타입 소거 문법이에요.
+
+책과 영상은 서로 다른 타입이지만 카탈로그 화면에서는 같은 목록에 표시해야 할 수 있어요. 제네릭 배열 `Shelf<Book>`은 책의 구체 타입 정보를 안전하게 유지하지만 `Video`를 함께 넣을 수 없어요. 불투명 타입 `some CatalogItem`도 하나의 숨겨진 기반 타입을 유지하므로 실행 중 다른 타입으로 바꿀 수 없어요.
+
+이처럼 **서로 다른 구체 타입을 같은 프로퍼티나 배열에 저장하고 실행 중 선택해야 하는 문제**를 `any Protocol`로 해결할 수 있어요. `any`는 편리하지만 구체 타입 정보를 지우는 선택이므로, 사용할 수 있는 연산과 런타임 비용도 함께 이해해야 해요.
+
+이 문서에서는 카탈로그 항목을 섞어 저장하는 문제에서 출발해 실존 상자의 의미, 프로토콜 멤버 접근 제한, 연관 타입이 있는 프로토콜, 암시적으로 열린 실존 타입까지 설명해요. 타입 정보를 유지하는 방법은 [제네릭](./generics), 하나의 구현 타입만 숨기는 방법은 [`some`과 불투명 타입](./opaque-types) 문서에서 먼저 확인할 수 있어요.
+
+## 먼저 알아둘 실존 타입 용어
+
+| 용어                      | 쉬운 뜻                                                                                                                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 프로토콜                  | 여러 타입이 공통으로 제공해야 할 프로퍼티와 메서드를 선언한 약속이에요.                                                                                                        |
+| 구체 타입                 | 값의 실제 구조와 구현이 정해진 타입이에요. `Book`과 `Video`가 한 예예요.                                                                                                       |
+| 정적 타입                 | 컴파일러가 코드를 검사할 때 알고 있는 타입이에요. `any CatalogItem` 변수의 정적 타입은 실존 타입이에요.                                                                        |
+| 동적 타입                 | 실행 중 실존 상자 안에 실제로 들어 있는 값의 구체 타입이에요. 같은 변수라도 어느 순간에는 `Book`, 나중에는 `Video`일 수 있어요.                                                |
+| 실존 타입                 | “프로토콜을 따르는 어떤 구체 타입이 존재한다”는 값을 담는 타입이에요. 영어로 existential type 또는 Swift 공식 문서에서 boxed protocol type이라고 해요.                         |
+| 실존 값                   | `any Protocol` 타입의 변수나 프로퍼티에 저장된 값이에요.                                                                                                                       |
+| 실존 상자                 | 구체 값을 프로토콜 타입으로 다루기 위해 값과 타입·준수 정보를 함께 감싼 개념적인 저장 구조예요. 실제 메모리 배치는 값과 최적화 상황에 따라 달라질 수 있어요.                   |
+| 타입 소거                 | 바깥 코드에서 구체 타입 정체성을 직접 사용하지 못하게 숨기고 공통 인터페이스만 남기는 방식이에요. 영어로 type erasure라고 해요.                                                |
+| boxing                    | 구체 값을 실존 타입의 저장 형식으로 감싸고 필요할 때 간접 접근하는 과정이에요. 추가 간접 참조와 경우에 따른 저장 비용이 생길 수 있어요.                                        |
+| `Self` 요구사항           | 프로토콜을 따르는 실제 자기 타입과 연결된 요구사항이에요. `Equatable`의 `==`는 두 인자가 같은 `Self` 타입이어야 해요.                                                          |
+| 연관 타입                 | 프로토콜을 따르는 구체 타입이 정하는 내부 타입 자리예요. `CatalogSource.Item`이 한 예예요.                                                                                     |
+| 암시적으로 열린 실존 타입 | 제네릭 함수에 실존 값을 전달할 때 컴파일러가 상자 안의 숨겨진 구체 타입에 임시 이름을 붙여 타입 매개변수로 다루는 기능이에요. 영어로 implicitly opened existential이라고 해요. |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- 제네릭 저장소가 서로 다른 타입을 섞지 못하는 이유
+- `any Protocol` 변수가 구체 타입을 저장하고 교체하는 방법
+- 실존 상자가 개념적으로 보관하는 정보와 비용
+- 프로토콜 요구사항만 바로 사용할 수 있는 이유
+- `Self`와 연관 타입 때문에 일부 연산이 제한되는 경우
+- 실존 값을 제네릭 함수에 전달할 때 일어나는 암시적 열기
+- primary associated type으로 실존 값의 연관 타입을 제약하는 방법
+- `Any`, `some`, 제네릭과 `any`의 차이
+
+## 하나의 구체 타입을 보존하는 배열에는 다른 타입을 넣을 수 없어요
+
+먼저 카탈로그 항목을 정의해 볼게요.
+
+```swift
+protocol CatalogItem: Equatable {
+  var id: Int { get }
+  var title: String { get }
+}
+
+struct Book: CatalogItem {
+  let id: Int
+  let title: String
+  let author: String
+}
+
+struct Video: CatalogItem {
+  let id: Int
+  let title: String
+  let duration: Int
+}
+```
+
+`[Book]`은 원소의 구체 타입이 `Book`으로 정해진 제네릭 배열이에요.
+
+```swift
+var books: [Book] = [
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  ),
+]
+```
+
+이 배열에 `Video`를 추가할 수 없어요.
+
+```swift
+// 오류: [Book]에는 Video를 넣을 수 없어요.
+books.append(
+  Video(
+    id: 2,
+    title: "Swift 동시성",
+    duration: 35
+  )
+)
+```
+
+이 제한은 제네릭의 장점이에요. `books[0]`은 항상 `Book`이므로 캐스팅 없이 `author`에 접근할 수 있어요.
+
+하지만 홈 화면에서 책과 영상을 하나의 추천 목록에 섞어 표시해야 한다면 원소의 구체 타입을 하나로 고정한 `[Book]`만으로 요구사항을 표현할 수 없어요.
+
+## any Protocol은 여러 준수 타입을 같은 저장소에 담아요
+
+프로토콜 이름 앞에 `any`를 붙이면 실존 타입을 만들 수 있어요.
+
+```swift
+let item: any CatalogItem =
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+```
+
+정적 타입은 `any CatalogItem`이고, 현재 상자 안의 동적 타입은 `Book`이에요. `CatalogItem`의 요구사항을 사용할 수 있어요.
+
+```swift
+print(item.id)
+print(item.title)
+```
+
+변수라면 나중에 다른 준수 타입을 대입할 수 있어요.
+
+```swift
+var selectedItem: any CatalogItem =
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+
+selectedItem = Video(
+  id: 2,
+  title: "Swift 동시성",
+  duration: 35
+)
+```
+
+첫 번째 값의 동적 타입은 `Book`, 두 번째 값의 동적 타입은 `Video`예요. 둘 다 `CatalogItem`을 따르므로 같은 `any CatalogItem` 변수에 들어갈 수 있어요.
+
+## 이종 배열은 각 원소가 다른 동적 타입을 가질 수 있어요
+
+`[any CatalogItem]`을 사용하면 책과 영상을 같은 배열에 저장할 수 있어요.
+
+```swift
+let items: [any CatalogItem] = [
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  ),
+  Video(
+    id: 2,
+    title: "Swift 동시성",
+    duration: 35
+  ),
+]
+```
+
+배열의 정적 원소 타입은 하나인 `any CatalogItem`이에요. 각 실존 상자 안의 동적 타입은 서로 달라도 돼요.
+
+```text
+[any CatalogItem]
+├─ 상자 0 → Book
+└─ 상자 1 → Video
+```
+
+반복문에서는 공통 프로토콜 요구사항을 사용할 수 있어요.
+
+```swift
+for item in items {
+  print("\(item.id): \(item.title)")
+}
+```
+
+반면 `Book.author`나 `Video.duration`은 `CatalogItem`이 보장하지 않으므로 바로 접근할 수 없어요.
+
+```swift
+// 오류: any CatalogItem에는 author 요구사항이 없어요.
+print(items[0].author)
+```
+
+필요하다면 실행 중 타입을 확인해 downcast할 수 있어요.
+
+```swift
+if let book = items[0] as? Book {
+  print(book.author)
+}
+```
+
+캐스팅이 곳곳에서 반복된다면 공통으로 필요한 기능이 프로토콜 요구사항에서 빠졌거나, 서로 다른 타입을 한 배열에 넣는 설계가 적절한지 다시 확인해야 해요.
+
+## 실존 상자는 값과 타입 사용 정보를 함께 보관해요
+
+`any CatalogItem`을 개념적으로 다음 정보가 들어 있는 상자로 생각할 수 있어요.
+
+```text
+┌─────────────────────────────┐
+│ any CatalogItem 실존 상자   │
+├─────────────────────────────┤
+│ 저장된 값                   │ → Book 값
+│ 실제 구체 타입 정보         │ → Book
+│ 프로토콜 요구사항 구현 정보 │ → Book의 CatalogItem 구현
+└─────────────────────────────┘
+```
+
+프로토콜 요구사항 구현 정보는 특정 구체 타입의 메서드와 프로퍼티를 어떻게 호출할지 연결해요. Swift 구현에서는 이를 witness table과 같은 용어로 설명할 수 있지만, 입문 단계에서는 **상자가 실제 타입과 약속 구현을 함께 알고 있다**고 이해하면 돼요.
+
+실제 값이 상자 내부의 고정 공간에 들어갈지, 별도 저장소를 사용할지, 어떤 호출이 최적화될지는 값의 크기와 컴파일러 판단에 따라 달라질 수 있어요. “모든 `any` 값은 반드시 힙에 할당된다”라고 단정하면 안 돼요.
+
+다만 실존 타입은 구체 타입을 직접 다루는 코드와 비교해 필요할 때 추가 간접 참조와 boxing 비용이 생길 수 있어요. Swift 공식 [Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/types/#Boxed-Protocol-Type) 문서도 boxed protocol type의 간접 접근과 런타임 비용을 설명해요.
+
+성능 비용만으로 `any`를 피할 필요는 없어요. 서로 다른 타입을 저장하는 요구사항이 먼저이고, 실제 병목은 측정으로 확인해야 해요.
+
+## any를 쓰면 프로토콜이 보장한 인터페이스만 남아요
+
+실존 값의 바깥에서는 동적 타입이 `Book`인지 `Video`인지 정적으로 확정할 수 없어요. 따라서 모든 준수 타입이 제공하기로 약속한 멤버만 바로 사용할 수 있어요.
+
+```swift
+func summary(
+  of item: any CatalogItem
+) -> String {
+  "\(item.id): \(item.title)"
+}
+```
+
+`id`와 `title`은 `CatalogItem` 요구사항이므로 안전해요.
+
+```swift
+// 사용할 수 없어요.
+// item.author
+// item.duration
+```
+
+프로토콜 extension의 멤버도 요구사항과 타입 관계에 따라 사용할 수 있어요.
+
+```swift
+extension CatalogItem {
+  var displayTitle: String {
+    "#\(id) \(title)"
+  }
+}
+
+print(item.displayTitle)
+```
+
+API를 `any Protocol`로 받으면 구체 타입별 전용 기능보다 프로토콜 인터페이스가 중심이 돼요. 이 경계가 의도한 추상화인지 확인해야 해요.
+
+## Self를 사용하는 요구사항은 타입이 지워지면 제한될 수 있어요
+
+`CatalogItem`은 `Equatable`을 따르므로 구체 타입끼리는 `==`로 비교할 수 있어요.
+
+```swift
+let firstBook = Book(
+  id: 1,
+  title: "Swift 기초",
+  author: "Blob"
+)
+
+let secondBook = Book(
+  id: 1,
+  title: "Swift 기초",
+  author: "Blob"
+)
+
+print(firstBook == secondBook)
+// true
+```
+
+`Equatable`의 비교는 양쪽 값이 같은 `Self` 타입이어야 해요. 그러나 두 `any CatalogItem` 상자 안에는 서로 다른 동적 타입이 들어 있을 수 있어요.
+
+```swift
+let first: any CatalogItem = firstBook
+let second: any CatalogItem =
+  Video(
+    id: 2,
+    title: "Swift 동시성",
+    duration: 35
+  )
+
+// 오류: 두 상자 안의 구체 타입이 같다는 보장이 없어요.
+// print(first == second)
+```
+
+`any CatalogItem`이 `Equatable` 제약을 가진 값을 담을 수 있다는 사실과, 실존 값 두 개에 `==`를 바로 적용할 수 있다는 것은 다른 문제예요. 비교 연산에는 양쪽의 숨겨진 `Self`가 같다는 보장이 필요해요.
+
+요구사항에 맞는 해결 방법을 선택해야 해요.
+
+- 카탈로그에서 동일 항목인지 판단하려면 공통 `id`를 비교해요.
+- 같은 구체 타입의 전체 값 비교가 필요하면 안전하게 downcast한 뒤 비교해요.
+- 비교할 두 값이 같은 타입이어야 하는 API라면 제네릭 매개변수를 사용해요.
+- 여러 타입을 아우르는 별도 동등성 규칙이 필요하면 프로토콜 요구사항이나 type eraser에 그 규칙을 명시해요.
+
+```swift
+func hasSameID(
+  _ first: any CatalogItem,
+  _ second: any CatalogItem
+) -> Bool {
+  first.id == second.id
+}
+```
+
+`id` 비교는 `Equatable`의 전체 값 비교와 의미가 다르므로 함수 이름에서 의도를 드러내야 해요.
+
+## Any와 any Protocol은 지우는 범위가 달라요
+
+`Any`는 함수, 튜플을 포함해 거의 모든 Swift 값을 담을 수 있어요.
+
+```swift
+let mixedValues: [Any] = [
+  1,
+  "Swift",
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  ),
+]
+```
+
+공통 프로토콜 약속이 없으므로 값을 사용하려면 타입을 확인하고 캐스팅해야 해요.
+
+```swift
+if let book = mixedValues[2] as? Book {
+  print(book.title)
+}
+```
+
+`any CatalogItem`은 `CatalogItem`을 따르는 값만 받을 수 있고 요구사항에 바로 접근할 수 있어요.
+
+```swift
+let catalogValues: [any CatalogItem] = [
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  ),
+  Video(
+    id: 2,
+    title: "Swift 동시성",
+    duration: 35
+  ),
+]
+
+print(catalogValues[0].title)
+```
+
+| 타입              | 담을 수 있는 값           | 바로 사용할 수 있는 인터페이스               |
+| ----------------- | ------------------------- | -------------------------------------------- |
+| `Any`             | 거의 모든 Swift 값        | 공통 사용자 정의 인터페이스가 없어요.        |
+| `AnyObject`       | 모든 클래스 인스턴스      | 구체 멤버는 캐스팅이나 동적 기능이 필요해요. |
+| `any CatalogItem` | `CatalogItem`을 따르는 값 | `CatalogItem` 요구사항을 사용할 수 있어요.   |
+
+공통 약속이 있다면 `Any`보다 `any Protocol`이 더 많은 타입 안전성과 의도를 제공해요.
+
+## 반환 타입의 any는 경로마다 다른 준수 타입을 허용해요
+
+함수 실행 결과가 조건에 따라 다른 구체 타입이어야 한다면 `any` 반환을 사용할 수 있어요.
+
+```swift
+func dynamicItem(
+  prefersVideo: Bool
+) -> any CatalogItem {
+  if prefersVideo {
+    return Video(
+      id: 2,
+      title: "Swift 동시성",
+      duration: 35
+    )
+  }
+
+  return Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+}
+```
+
+두 반환값 모두 `CatalogItem`을 따르므로 각각 실존 상자에 담겨 반환돼요.
+
+```swift
+let first = dynamicItem(
+  prefersVideo: false
+)
+// 동적 타입: Book
+
+let second = dynamicItem(
+  prefersVideo: true
+)
+// 동적 타입: Video
+```
+
+같은 코드를 `-> some CatalogItem`으로 바꾸면 반환 경로의 기반 타입이 달라 컴파일되지 않아요. `some`은 하나의 숨겨진 타입, `any`는 서로 다른 타입이 들어갈 수 있는 상자라는 차이가 드러나는 예예요.
+
+반환 타입이 항상 `Book`인데 단지 구현 이름만 숨기려는 목적이라면 `any`보다 `some`이 더 강한 타입 정체성 계약을 제공해요.
+
+## 연관 타입이 있는 프로토콜도 실존 타입으로 사용할 수 있어요
+
+카탈로그 소스가 어떤 항목을 불러오는지 연관 타입으로 표현해 볼게요.
+
+```swift
+protocol CatalogSource {
+  associatedtype Item: CatalogItem
+
+  func load() -> [Item]
+}
+
+struct BookSource: CatalogSource {
+  func load() -> [Book] {
+    [
+      Book(
+        id: 1,
+        title: "Swift 기초",
+        author: "Blob"
+      ),
+    ]
+  }
+}
+```
+
+현대 Swift에서는 연관 타입이 있는 프로토콜도 `any CatalogSource` 형태로 실존 값에 사용할 수 있어요.
+
+```swift
+let source: any CatalogSource =
+  BookSource()
+```
+
+다만 `source`의 `Item`이 무엇인지 바깥 타입에 명시하지 않았어요. 반환 위치처럼 안전하게 타입을 지울 수 있는 멤버는 사용할 수 있지만, 연관 타입이 입력 위치에 등장하는 메서드는 구체 관계를 모르면 제한될 수 있어요.
+
+연관 타입의 상한이 `CatalogItem`이므로 `load()` 결과를 통해 항목의 공통 인터페이스를 사용할 수 있지만, 호출자가 정확히 `[Book]`을 기대한다면 제약 없는 `any CatalogSource`는 정보가 부족해요.
+
+## primary associated type으로 실존 값의 내부 타입을 제약해요
+
+자주 제약할 연관 타입을 primary associated type으로 표시해요.
+
+```swift
+protocol CatalogSource<Item> {
+  associatedtype Item: CatalogItem
+
+  func load() -> [Item]
+}
+```
+
+이제 구체 소스 타입은 서로 달라도 모두 `Book`을 불러온다는 조건을 표현할 수 있어요.
+
+```swift
+struct CachedBookSource:
+  CatalogSource {
+  let books: [Book]
+
+  func load() -> [Book] {
+    books
+  }
+}
+
+let bookSources:
+  [any CatalogSource<Book>] = [
+    BookSource(),
+    CachedBookSource(books: []),
+  ]
+```
+
+배열의 각 원소는 `BookSource`, `CachedBookSource`처럼 서로 다른 동적 타입일 수 있어요. 하지만 모든 실존 값의 `Item == Book`이라는 관계는 유지돼요.
+
+```swift
+let allBooks: [Book] =
+  bookSources.flatMap {
+    $0.load()
+  }
+```
+
+이 형태를 **제약된 실존 타입(constrained existential type)**이라고 해요. [SE-0353](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0353-constrained-existential-types.md)은 primary associated type에 동일 타입 요구사항을 적용한 `any Collection<String>` 같은 문법을 도입했어요.
+
+구체 구현 타입은 중요하지 않지만 처리하는 데이터 타입은 중요할 때 유용해요.
+
+```text
+소스의 구체 타입: 달라도 돼요.
+소스가 반환하는 Item: 모두 Book이어야 해요.
+```
+
+## 실존 값은 제네릭 함수에 전달할 때 임시로 열릴 수 있어요
+
+제네릭 함수는 원래 구체 타입 매개변수를 받아요.
+
+```swift
+func describe<Item: CatalogItem>(
+  _ item: Item
+) -> String {
+  "\(item.id): \(item.title)"
+}
+```
+
+`any CatalogItem` 값을 전달해도 현대 Swift에서는 많은 경우 컴파일돼요.
+
+```swift
+let erased: any CatalogItem =
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+
+let text = describe(erased)
+```
+
+컴파일러가 실존 상자를 **암시적으로 열어** 그 안의 숨겨진 동적 타입에 임시 이름을 붙이고 `Item`으로 사용하기 때문이에요.
+
+```text
+any CatalogItem 상자
+        │ 열기
+        ▼
+숨겨진 구체 타입 τ
+        │
+        └─ describe<τ>(...)
+```
+
+이는 `any CatalogItem` 실존 타입 자체가 일반적인 의미에서 `CatalogItem`을 따르는 새로운 구체 타입이 되었다는 뜻이 아니에요. 특정 호출이 안전한 범위에서 상자 안의 타입을 잠시 제네릭 매개변수로 다루는 기능이에요.
+
+Swift Evolution의 [SE-0352](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0352-implicit-open-existentials.md)는 이 동작을 암시적으로 열린 실존 타입으로 설명해요.
+
+제네릭 타입 매개변수가 반환 타입이나 다른 값과 복잡하게 연결되면 실존 타입을 열어도 관계를 바깥으로 안전하게 표현할 수 없는 경우가 있어요. 컴파일 오류가 난다면 다음을 확인해요.
+
+- 타입 매개변수가 반환 타입 안에 그대로 노출되는가
+- 두 실존 값의 숨겨진 타입이 같아야 하는가
+- 연관 타입이 입력 위치에 사용되는가
+- `any P<Associated>`처럼 필요한 관계를 제약할 수 있는가
+
+## any Protocol이 프로토콜을 따른다고 단순화하면 안 돼요
+
+다음 두 문장은 구분해야 해요.
+
+1. `any CatalogItem` 상자는 `CatalogItem`을 따르는 값을 저장할 수 있어요.
+2. `any CatalogItem`이라는 실존 타입 자체가 모든 상황에서 `CatalogItem`을 따르는 구체 타입인 것은 아니에요.
+
+두 번째 문장을 무조건 참으로 만들면 `Equatable`의 `Self`처럼 숨겨진 타입 정체성이 필요한 요구사항을 안전하게 구현할 수 없어요. 상자 A의 동적 타입이 `Book`, 상자 B의 동적 타입이 `Video`일 수 있기 때문이에요.
+
+암시적 열기 덕분에 실존 값을 제네릭 함수에 전달하는 많은 코드가 동작하지만, 이를 “`any P`가 이제 P에 준수한다”라고 외우기보다 **컴파일러가 필요할 때 상자 안의 타입을 열 수 있다**고 이해하는 편이 정확해요.
+
+## 수동 type eraser는 여전히 역할이 있을 수 있어요
+
+과거에는 연관 타입이나 `Self` 요구사항이 있는 프로토콜 값을 저장하기 위해 `AnySequence`, `AnyPublisher`처럼 `Any...` wrapper를 직접 만드는 경우가 많았어요. 현대 Swift의 `any`와 제약된 실존 타입은 단순 저장 문제를 더 직접적으로 해결할 수 있어요.
+
+하지만 수동 type eraser가 항상 불필요해진 것은 아니에요. 별도 wrapper는 다음 역할을 추가할 수 있어요.
+
+- 실존 값에서 직접 제공하지 않는 새로운 프로토콜 준수
+- 값 비교, 해싱, 복사와 같은 명시적인 의미 규칙
+- 여러 프로토콜과 콜백을 하나의 안정된 API로 묶는 기능
+- 저장 방식과 성능 특성을 직접 제어하는 기능
+- 이전 Swift 버전이나 기존 public API와의 호환
+
+`any Protocol`로 충분한 단순 저장 문제에 관성적으로 wrapper를 추가하지 말고, wrapper가 제공해야 할 추가 의미가 있는지 확인해야 해요.
+
+## 제네릭, some, any를 나란히 비교해요
+
+같은 `CatalogItem` 제약을 사용해도 타입을 정하고 보존하는 방식이 달라요.
+
+| 기준                       | 제네릭 `<Item: CatalogItem>`            | `some CatalogItem` 반환                   | `any CatalogItem`                      |
+| -------------------------- | --------------------------------------- | ----------------------------------------- | -------------------------------------- |
+| 구체 타입을 정하는 주체    | 호출자                                  | 함수·프로퍼티 구현                        | 값을 대입하는 코드                     |
+| 한 값의 타입 정체성        | 유지해요.                               | 유지하지만 이름을 숨겨요.                 | 상자 바깥에서 지워요.                  |
+| 실행 중 다른 타입으로 교체 | 같은 인스턴스·호출 관계에서는 어려워요. | 할 수 없어요.                             | 할 수 있어요.                          |
+| 이종 배열                  | 단일 타입 매개변수로는 표현하지 않아요. | 한 기반 타입만 담아요.                    | `[any P]`로 표현해요.                  |
+| `Self`·연관 타입 관계      | 가장 많이 보존해요.                     | 기반 타입을 보존해 많이 활용할 수 있어요. | 지운 정보에 따라 일부 연산이 제한돼요. |
+| 런타임 간접 접근           | 필수 의미가 아니에요.                   | 실존 boxing이 핵심 의미가 아니에요.       | 필요할 때 boxing과 간접 접근이 생겨요. |
+| 대표 사용                  | 재사용 알고리즘과 자료구조              | 구현 타입을 감춘 반환 API                 | 런타임 교체, 이종 저장, 플러그인 목록  |
+
+선택 질문을 짧게 정리하면 다음과 같아요.
+
+```text
+호출자가 구체 타입을 고르고 관계를 유지해야 하나요?
+└─ 제네릭
+
+구현이 고른 하나의 타입을 숨겨 반환해야 하나요?
+└─ some
+
+서로 다른 준수 타입을 저장하거나 실행 중 바꿔야 하나요?
+└─ any
+```
+
+## any의 비용은 요구사항과 함께 판단해요
+
+실존 타입은 다음 비용을 가질 수 있어요.
+
+- 구체 타입의 전용 API를 바로 사용할 수 없어요.
+- `Self`와 연관 타입 관계가 지워져 일부 프로토콜 멤버가 제한될 수 있어요.
+- 필요할 때 boxing 저장과 추가 간접 참조가 생겨요.
+- 컴파일러가 구체 타입을 직접 아는 제네릭 코드보다 특수화 기회가 줄 수 있어요.
+- 캐스팅이 늘어나면 런타임 실패 가능성과 분기 코드가 생겨요.
+
+반면 다음 가치를 제공해요.
+
+- 서로 다른 준수 타입을 하나의 배열과 프로퍼티에 저장해요.
+- 실행 중 구성, 사용자 선택, 플러그인 등록 결과에 따라 구현을 교체해요.
+- 공개 API에서 구체 타입을 노출하지 않아요.
+- 단순한 type eraser wrapper를 직접 작성하지 않고 프로토콜 상자를 표현해요.
+
+성능이 중요하지 않다는 뜻도, `any`가 항상 느리다는 뜻도 아니에요. 먼저 동적 이질성이 실제 요구사항인지 판단하고, 병목 경로에서는 Instruments나 벤치마크로 측정해야 해요.
+
+## any 오류는 지워진 타입 관계를 찾아봐요
+
+| 자주 만나는 상황                                     | 원인                                                                     | 확인할 부분                                                                                    |
+| ---------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| 구체 타입 전용 프로퍼티에 접근할 수 없어요.          | 실존 값의 정적 인터페이스에는 프로토콜 요구사항만 보여요.                | 공통 요구사항으로 올릴지, 안전하게 캐스팅할지, 이종 저장 자체가 필요한지 확인해요.             |
+| 두 실존 값을 `==`로 비교할 수 없어요.                | `Equatable`의 두 `Self` 타입이 같다는 보장이 없어요.                     | 공통 식별자 비교, 같은 타입 제네릭, downcast, 별도 동등성 규칙 중 목적에 맞는 방법을 선택해요. |
+| 연관 타입을 입력으로 받는 메서드를 호출할 수 없어요. | 상자 밖에서 연관 타입의 정확한 정체성을 몰라요.                          | `any Protocol<Associated>`로 제약하거나 제네릭 경계에서 처리해요.                              |
+| `any P`를 제네릭 함수에 전달한 코드가 실패해요.      | 숨겨진 타입 관계가 반환 타입이나 다른 매개변수로 빠져나갈 수 있어요.     | 타입 매개변수 관계를 단순화하거나 제약된 실존 타입, 별도 type eraser를 검토해요.               |
+| `Any` 값에서 프로토콜 멤버를 사용할 수 없어요.       | `Any`는 특정 프로토콜 약속을 보존하지 않아요.                            | 실제 요구사항이 있다면 `any Protocol`로 타입을 좁혀요.                                         |
+| 성능을 이유로 모든 any를 제네릭으로 바꾸려 해요.     | 런타임 이종 저장이라는 요구사항을 제네릭 하나로 표현하지 못할 수 있어요. | 의미를 먼저 유지하고 실제 측정에서 병목인 경계만 wrapper나 구조 변경을 검토해요.               |
+
+오류 메시지에서 `Self`, `associated type`, `cannot conform`이 보이면 어떤 구체 타입 정보가 상자 밖에서 지워졌는지 추적해 보세요.
+
+## 언제 사용해야 하나요
+
+다음 상황에서는 `any`가 잘 맞아요.
+
+- 서로 다른 프로토콜 준수 타입을 같은 배열에 저장해요.
+- 설정, 사용자 입력, 의존성 조립 결과에 따라 구현을 실행 중 교체해요.
+- 구체 타입보다 공통 프로토콜 인터페이스가 중요한 저장 경계예요.
+- 플러그인, 라우트, 명령, 렌더러처럼 타입이 다른 구현 목록을 관리해요.
+- primary associated type을 제약해 구현 타입은 달라도 처리하는 데이터 타입은 같게 유지해요.
+- 단순한 타입 소거를 위해 별도 `Any...` wrapper를 만드는 비용을 줄이고 싶어요.
+
+다음 상황에서는 다른 표현도 검토해요.
+
+- 함수 한 번의 호출에서 타입 관계를 유지하면 된다면 제네릭이 더 강한 계약을 제공해요.
+- 구현이 항상 하나의 구체 타입을 반환하고 이름만 숨기려면 `some`이 맞아요.
+- 구체 타입 전용 기능을 계속 캐스팅해서 사용한다면 프로토콜 경계가 잘못 잡혔을 수 있어요.
+- 값의 전체 동등성, 해싱, 복사 의미를 실존 값에 별도로 제공해야 한다면 명시적인 type eraser가 필요할 수 있어요.
+- 동적 이질성이 없는 단순 코드에 관성적으로 `any`를 추가하지 않아요.
+
+## any를 적용하는 순서를 정리해요
+
+1. 같은 저장소에 실제로 서로 다른 구체 타입이 들어가야 하는지 확인해요.
+2. 모든 값이 공통으로 제공해야 할 최소 동작을 프로토콜 요구사항으로 정의해요.
+3. 변수, 프로퍼티, 배열의 타입을 `any Protocol`로 선언해요.
+4. 호출부에서 구체 타입 전용 멤버를 캐스팅 없이 사용하려는 곳이 없는지 확인해요.
+5. `Self`나 연관 타입 때문에 제한되는 연산을 찾고, 제네릭 또는 primary associated type 제약으로 관계를 복구해요.
+6. 단순 `any`로 부족하다면 별도 enum이나 type eraser가 제공할 추가 의미를 정의해요.
+7. 캐스팅과 런타임 분기가 늘어나지 않는지 검토해요.
+8. 성능이 중요한 저장·호출 경계는 실제 데이터와 release 빌드로 측정해요.
+
+## 흔한 오해를 정리해요
+
+### any Protocol은 Any와 같은가요?
+
+아니요. `Any`는 거의 모든 Swift 값을 담고 공통 사용자 정의 인터페이스를 보존하지 않아요. `any Protocol`은 해당 프로토콜을 따르는 값만 담으며 프로토콜 요구사항을 바로 사용할 수 있어요.
+
+### any를 붙이면 프로토콜을 따르는 새 구체 타입이 만들어지나요?
+
+아니요. 프로토콜을 따르는 구체 값을 담는 실존 타입을 만들어요. 암시적 열기로 제네릭 함수에 전달할 수 있는 경우가 많지만, 실존 타입 자체가 모든 상황에서 그 프로토콜을 따르는 구체 타입이 된 것은 아니에요.
+
+### any 값은 항상 힙에 할당되나요?
+
+아니요. 실제 저장 방식은 값의 크기와 컴파일러·런타임 구현에 따라 달라질 수 있어요. 실존 타입은 필요할 때 boxing과 간접 접근 비용을 가질 수 있다고 이해하고, 구체적인 성능은 측정해야 해요.
+
+### 프로토콜이 Equatable을 따르면 any 값도 바로 비교할 수 있나요?
+
+항상 그렇지 않아요. `Equatable`의 `==`는 양쪽 값의 `Self` 타입이 같아야 하는데, 두 실존 상자의 동적 타입이 같다는 보장이 없어요. 비교 목적에 맞는 식별자나 별도 동등성 규칙이 필요해요.
+
+### 연관 타입이 있는 프로토콜은 any로 사용할 수 없나요?
+
+현대 Swift에서는 사용할 수 있어요. 다만 연관 타입 정체성을 모르면 일부 멤버 사용이 제한될 수 있고, primary associated type을 이용한 `any Protocol<Concrete>` 형태로 필요한 관계를 제약할 수 있어요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 실존 타입이란 무엇인가요?
+
+어떤 구체 타입이 프로토콜을 따른다는 사실만 남기고 그 값을 상자에 담아 다루는 타입이에요. `any Protocol`로 표현하며 상자 밖에서는 공통 프로토콜 인터페이스를 사용해요.
+
+### any를 사용하면 어떤 정보를 잃나요?
+
+바깥 코드에서 저장된 값의 구체 타입 정체성을 직접 사용하지 못해요. 이 때문에 구체 타입 전용 멤버와 `Self`·일부 연관 타입 관계에 의존하는 연산이 제한될 수 있어요.
+
+### 제네릭과 any는 어떻게 선택하나요?
+
+호출마다 하나의 구체 타입과 입력·출력 관계를 보존해야 하면 제네릭을 사용해요. 서로 다른 준수 타입을 한 저장소에 담거나 실행 중 교체해야 하면 `any`를 사용해요.
+
+### some과 any의 차이는 무엇인가요?
+
+`some Protocol`은 선언이 선택한 하나의 기반 타입을 숨기면서 정체성을 유지해요. `any Protocol`은 여러 기반 타입을 실행 중 담을 수 있도록 바깥에서 정체성을 지워요.
+
+### 암시적으로 열린 실존 타입은 무엇인가요?
+
+실존 값을 제네릭 함수에 전달할 때 컴파일러가 상자 안의 숨겨진 타입에 임시 이름을 붙여 타입 매개변수로 사용하는 기능이에요. 실존 타입 자체의 일반적인 프로토콜 준수를 추가하는 것과는 달라요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Opaque and Boxed Protocol Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/)
+- [The Swift Programming Language — Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/types/)
+- [The Swift Programming Language — Protocols](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/)
+- [The Swift Programming Language — Generics](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/generics/)
+- [Swift Evolution SE-0309 — Unlock Existential Types for All Protocols](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0309-unlock-existential-types-for-all-protocols.md)
+- [Swift Evolution SE-0335 — Introduce Existential any](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md)
+- [Swift Evolution SE-0352 — Implicitly Opened Existentials](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0352-implicit-open-existentials.md)
+- [Swift Evolution SE-0353 — Constrained Existential Types](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0353-constrained-existential-types.md)

--- a/docs/guide/swift/generics.md
+++ b/docs/guide/swift/generics.md
@@ -1,0 +1,725 @@
+---
+title: Swift로 이해하는 제네릭
+description: Swift 제네릭 함수와 타입, 타입 매개변수·제약·where 절·연관 타입을 단계적으로 이해하고 some·any와 선택 기준을 비교합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 제네릭
+
+> **면접 답변 한 줄 요약:** 제네릭은 호출할 때 정해지는 구체 타입을 타입 매개변수로 표현하고 필요한 제약만 선언해, 타입 안전성과 타입 사이의 관계를 유지하면서 여러 타입에 같은 알고리즘과 자료구조를 재사용하는 Swift 기능이에요.
+
+`Array<Int>`와 `Array<String>`은 원소 타입이 다르지만 같은 배열 기능을 제공해요. `Optional<Book>`과 `Optional<Video>`도 값의 타입만 다를 뿐 “값이 있거나 없다”라는 같은 구조를 사용해요. 이처럼 타입만 바뀌고 동작이 반복될 때 Swift의 제네릭을 사용할 수 있어요.
+
+제네릭을 단순히 “모든 타입을 받는 문법”으로 이해하면 중요한 부분을 놓치기 쉬워요. 제네릭은 아무 타입이나 무조건 허용하는 기능이 아니라, 호출마다 하나의 구체 타입을 정하고 그 타입이 지켜야 할 조건과 여러 위치에서 같아야 할 관계를 컴파일러가 검사하게 하는 기능이에요.
+
+이 문서에서는 카탈로그의 `Book`과 `Video`를 다루는 중복 코드에서 출발해 제네릭 함수와 타입, 타입 제약, `where` 절, 연관 타입까지 단계적으로 설명해요. 마지막에는 [불투명 타입 `some`](./opaque-types)과 [실존 타입 `any`](./existential-types)를 언제 선택할지도 비교해요.
+
+## 먼저 알아둘 제네릭 용어
+
+| 용어                    | 쉬운 뜻                                                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 타입                    | 값이 저장할 데이터와 사용할 수 있는 동작을 정한 분류예요. `Book`, `String`, `Array<Int>`가 모두 타입이에요.                                                |
+| 구체 타입               | 실제 값의 메모리 구조와 동작이 정해진 타입이에요. `Book`과 `Array<Book>`이 한 예예요.                                                                      |
+| 타입 매개변수           | 나중에 들어올 구체 타입에 붙인 자리 이름이에요. `Shelf<Item>`의 `Item`이 타입 매개변수예요.                                                                |
+| 타입 인자               | 제네릭을 실제로 사용할 때 타입 매개변수 자리에 들어가는 구체 타입이에요. `Shelf<Book>`에서 `Book`이 타입 인자예요.                                         |
+| 타입 추론               | 코드의 인자와 문맥을 보고 컴파일러가 생략된 타입을 알아내는 과정이에요.                                                                                    |
+| 타입 제약               | 타입 매개변수가 특정 클래스를 상속하거나 프로토콜을 따라야 한다는 조건이에요. `Item: Equatable`은 `Item`이 비교 가능해야 한다는 뜻이에요.                  |
+| 프로토콜                | 타입이 제공해야 할 프로퍼티와 메서드를 선언한 약속이에요. 제네릭에서는 구체 타입에 필요한 능력을 제약으로 표현할 때 자주 사용해요.                         |
+| `where` 절              | 여러 타입이나 연관 타입의 준수 조건과 동일 타입 관계를 선언하는 문법이에요.                                                                                |
+| 연관 타입               | 프로토콜을 따르는 구체 타입이 정하게 되는 타입 자리예요. `CatalogSource`가 불러올 `Item` 타입처럼 `associatedtype`으로 선언해요.                           |
+| primary associated type | 연관 타입 중 사용 위치에서 자주 제약할 타입을 프로토콜 이름 뒤의 꺾쇠괄호에 표시한 것이에요. 한국어로는 주 연관 타입이라고도 해요.                         |
+| 특수화(specialization)  | 컴파일러가 특정 타입 인자를 사용하는 제네릭 코드를 그 구체 타입에 맞춰 최적화하는 과정이에요. 항상 같은 방식으로 일어난다고 보장되는 언어 규칙은 아니에요. |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- 타입별로 반복되는 함수에서 제네릭이 해결하는 문제
+- 타입 매개변수와 타입 인자, 타입 추론의 관계
+- 제네릭 함수와 제네릭 타입을 작성하는 방법
+- 프로토콜 제약으로 사용할 수 있는 동작을 늘리는 방법
+- `where` 절로 타입 사이의 관계를 표현하는 방법
+- 프로토콜의 연관 타입과 primary associated type
+- 조건부 extension과 조건부 프로토콜 준수
+- 제네릭, `some`, `any`를 선택하는 기준
+
+## 타입만 다른 함수는 같은 구현을 반복하게 돼요
+
+카탈로그에서 책과 영상을 찾는 함수를 각각 작성해 볼게요.
+
+```swift
+struct Book: Equatable {
+  let id: Int
+  let title: String
+  let author: String
+}
+
+struct Video: Equatable {
+  let id: Int
+  let title: String
+  let duration: Int
+}
+
+func findBook(
+  _ target: Book,
+  in books: [Book]
+) -> Book? {
+  books.first { $0 == target }
+}
+
+func findVideo(
+  _ target: Video,
+  in videos: [Video]
+) -> Video? {
+  videos.first { $0 == target }
+}
+```
+
+두 함수의 알고리즘은 같아요.
+
+1. 배열의 값을 앞에서부터 확인해요.
+2. 찾는 값과 같은 첫 값을 반환해요.
+3. 같은 값이 없으면 `nil`을 반환해요.
+
+다른 부분은 `Book`과 `Video`라는 타입 이름뿐이에요. 새로운 `Podcast` 타입이 생기면 같은 함수를 또 만들 수 있지만, 이렇게 복사한 함수는 검색 규칙을 바꿀 때 모두 수정해야 해요.
+
+`Any`로 타입을 지우면 하나의 함수를 만들 수 있지만, `==`로 안전하게 비교할 수 없고 반환값을 다시 캐스팅해야 해요.
+
+```swift
+// 타입 정보가 너무 많이 사라지는 접근이에요.
+func findValue(
+  _ target: Any,
+  in values: [Any]
+) -> Any? {
+  // Any 두 값을 일반적인 == 연산자로 비교할 수 없어요.
+  nil
+}
+```
+
+필요한 것은 타입 정보를 없애는 방식이 아니에요. **호출마다 구체 타입은 달라도 입력 배열과 찾는 값, 반환값이 모두 같은 타입이라는 관계**를 보존하는 방식이 필요해요.
+
+## 타입 매개변수는 나중에 정해질 타입의 자리예요
+
+먼저 비교 기능 없이 첫 값을 반환하는 가장 작은 제네릭 함수를 만들어 볼게요.
+
+```swift
+func first<Item>(
+  in items: [Item]
+) -> Item? {
+  items.first
+}
+```
+
+`<Item>`은 `Item`이 타입 매개변수라는 뜻이에요. 함수 안에서 `Item`은 구체 타입처럼 사용할 수 있지만, 실제 타입은 호출할 때 정해져요.
+
+```swift
+let books = [
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  ),
+]
+
+let videos = [
+  Video(
+    id: 2,
+    title: "Swift 동시성",
+    duration: 35
+  ),
+]
+
+let firstBook = first(in: books)
+// Item == Book, 반환 타입은 Book?
+
+let firstVideo = first(in: videos)
+// Item == Video, 반환 타입은 Video?
+```
+
+호출부에서 `first<Book>(in:)`처럼 타입 인자를 직접 적지 않아도 돼요. 컴파일러가 `[Book]` 인자를 보고 `Item`을 `Book`으로 추론해요.
+
+여기서 `Item`은 “아무 값이나 담는 상자”가 아니에요. 한 번의 호출 안에서는 하나의 구체 타입으로 정해져요. 입력이 `[Book]`이면 반환값도 반드시 `Book?`이고, 입력이 `[Video]`이면 반환값은 `Video?`예요.
+
+## 같은 타입 매개변수는 같은 구체 타입이어야 해요
+
+타입 매개변수를 여러 위치에서 반복하면 그 위치의 타입이 같아야 한다는 관계를 표현해요.
+
+```swift
+func choose<Item>(
+  _ first: Item,
+  or second: Item,
+  useFirst: Bool
+) -> Item {
+  useFirst ? first : second
+}
+```
+
+두 인자와 반환값에 같은 `Item`을 사용했어요.
+
+```swift
+let book = Book(
+  id: 1,
+  title: "Swift 기초",
+  author: "Blob"
+)
+
+let anotherBook = Book(
+  id: 2,
+  title: "Swift 심화",
+  author: "Mango"
+)
+
+let selected = choose(
+  book,
+  or: anotherBook,
+  useFirst: true
+)
+// selected는 Book
+```
+
+서로 다른 타입을 전달하면 하나의 `Item`을 정할 수 없어 컴파일 오류가 나요.
+
+```swift
+let video = Video(
+  id: 3,
+  title: "SwiftUI",
+  duration: 40
+)
+
+// 오류: Item을 Book과 Video로 동시에 정할 수 없어요.
+let invalid = choose(
+  book,
+  or: video,
+  useFirst: true
+)
+```
+
+두 인자가 서로 다른 타입이어도 되는 함수라면 타입 매개변수를 두 개 선언해야 해요.
+
+```swift
+func makePair<First, Second>(
+  _ first: First,
+  _ second: Second
+) -> (First, Second) {
+  (first, second)
+}
+
+let pair = makePair(book, video)
+// (Book, Video)
+```
+
+제네릭 설계에서는 “몇 개의 타입을 받을 수 있는가?”보다 **어느 위치의 타입이 같아야 하고 어느 위치는 달라도 되는가?**를 먼저 생각해야 해요.
+
+## 타입 제약은 제네릭 코드가 사용할 수 있는 능력을 정해요
+
+앞의 `findBook`과 `findVideo`를 하나로 합치려면 두 값을 `==`로 비교해야 해요. 하지만 제약 없는 `Item`이 `Equatable`을 따른다는 보장은 없어요.
+
+```swift
+// 컴파일되지 않는 예예요.
+func find<Item>(
+  _ target: Item,
+  in items: [Item]
+) -> Item? {
+  items.first { $0 == target }
+  // 오류: 모든 Item이 == 연산을 제공하지는 않아요.
+}
+```
+
+`Item: Equatable` 제약을 추가하면 컴파일러가 `==` 사용을 허용해요.
+
+```swift
+func find<Item: Equatable>(
+  _ target: Item,
+  in items: [Item]
+) -> Item? {
+  items.first { $0 == target }
+}
+```
+
+이제 `Book`과 `Video`가 모두 `Equatable`을 따르므로 하나의 함수를 사용할 수 있어요.
+
+```swift
+let foundBook = find(book, in: books)
+let foundVideo = find(video, in: videos)
+```
+
+제약은 제네릭을 덜 유연하게 만드는 불필요한 제한이 아니에요. 함수 구현이 실제로 요구하는 능력을 API 계약으로 드러내요. `==`를 사용하는 함수라면 `Equatable`, 딕셔너리 키로 사용한다면 `Hashable`, 정렬한다면 `Comparable` 같은 제약이 필요해요.
+
+Swift 공식 [Generics](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/generics/) 문서도 제약을 타입 매개변수가 특정 클래스를 상속하거나 프로토콜을 따라야 한다는 요구사항으로 설명해요.
+
+## 문제 영역의 프로토콜로 필요한 동작을 표현해요
+
+카탈로그 항목이 공통으로 `id`와 `title`을 제공하게 만들 수 있어요.
+
+```swift
+protocol CatalogItem: Equatable {
+  var id: Int { get }
+  var title: String { get }
+}
+
+struct Book: CatalogItem {
+  let id: Int
+  let title: String
+  let author: String
+}
+
+struct Video: CatalogItem {
+  let id: Int
+  let title: String
+  let duration: Int
+}
+```
+
+제네릭 함수에 `CatalogItem` 제약을 사용하면 `id`, `title`, `==`를 모두 사용할 수 있어요.
+
+```swift
+func describe<Item: CatalogItem>(
+  _ item: Item
+) -> String {
+  "\(item.id): \(item.title)"
+}
+```
+
+함수 안에서는 `Book.author`나 `Video.duration`을 사용할 수 없어요. `Item`이 어떤 `CatalogItem`인지는 호출자가 정하므로, 구현은 모든 `CatalogItem`이 보장하는 프로토콜 요구사항만 사용해야 해요.
+
+```swift
+let bookDescription = describe(book)
+// "1: Swift 기초"
+
+let videoDescription = describe(video)
+// "3: SwiftUI"
+```
+
+구체 타입 정보는 사라지지 않아요. 호출마다 `Item`이 `Book` 또는 `Video`로 정해지고, 반환 타입이나 다른 제네릭 타입과의 관계에 계속 사용할 수 있어요.
+
+## 제네릭 타입은 같은 구조를 여러 원소 타입에 재사용해요
+
+함수뿐 아니라 구조체, 클래스, 열거형에도 타입 매개변수를 선언할 수 있어요. 카탈로그 항목을 보관하는 `Shelf`를 만들어 볼게요.
+
+```swift
+struct Shelf<Item> {
+  private(set) var items: [Item] = []
+
+  mutating func add(_ item: Item) {
+    items.append(item)
+  }
+
+  mutating func removeLast() -> Item? {
+    items.popLast()
+  }
+}
+```
+
+`Shelf<Book>`과 `Shelf<Video>`는 같은 구조와 메서드를 사용하지만 서로 다른 구체 타입이에요.
+
+```swift
+var bookShelf = Shelf<Book>()
+bookShelf.add(book)
+
+var videoShelf = Shelf<Video>()
+videoShelf.add(video)
+```
+
+책 선반에는 `Video`를 넣을 수 없어요.
+
+```swift
+// 오류: Shelf<Book>에는 Book만 추가할 수 있어요.
+bookShelf.add(video)
+```
+
+이 제한 덕분에 `bookShelf.removeLast()`의 반환 타입은 항상 `Book?`이라고 알 수 있어요. 값을 꺼낼 때 캐스팅할 필요도 없어요.
+
+Swift 표준 라이브러리에서도 같은 구조를 볼 수 있어요.
+
+| 제네릭 타입                | 타입 매개변수가 뜻하는 것       |
+| -------------------------- | ------------------------------- |
+| `Array<Element>`           | 배열에 저장할 원소 타입이에요.  |
+| `Dictionary<Key, Value>`   | 키 타입과 값 타입이에요.        |
+| `Optional<Wrapped>`        | 값이 있을 때 감싸는 타입이에요. |
+| `Result<Success, Failure>` | 성공 값과 실패 오류 타입이에요. |
+
+`[Book]`은 `Array<Book>`의 축약이고, `Book?`은 `Optional<Book>`의 축약이에요. Swift 코드를 작성할 때 이미 많은 제네릭 타입을 사용하고 있는 셈이에요.
+
+## 조건부 extension은 요구사항을 만족할 때만 기능을 열어요
+
+모든 `Shelf<Item>`에서 사용할 수 있는 기능은 제약 없는 extension에 작성해요.
+
+```swift
+extension Shelf {
+  var isEmpty: Bool {
+    items.isEmpty
+  }
+}
+```
+
+`Item`이 `CatalogItem`일 때만 제목 목록을 제공하려면 extension에 `where` 조건을 붙여요.
+
+```swift
+extension Shelf where Item: CatalogItem {
+  var titles: [String] {
+    items.map(\.title)
+  }
+}
+```
+
+`Shelf<Book>`과 `Shelf<Video>`에서는 `titles`를 사용할 수 있지만, `Shelf<Int>`에서는 사용할 수 없어요.
+
+```swift
+print(bookShelf.titles)
+// ["Swift 기초"]
+
+let numbers = Shelf<Int>()
+// numbers.titles는 사용할 수 없어요.
+```
+
+제네릭 타입 전체에 지나치게 강한 제약을 걸 필요는 없어요. 기본 저장 기능은 모든 `Item`에 제공하고, 제목처럼 추가 능력이 필요한 기능에만 조건을 붙일 수 있어요.
+
+## 조건부 준수는 타입 인자가 따를 때만 프로토콜을 따르게 해요
+
+`Shelf`의 두 값을 비교하려면 내부 `Item`도 비교할 수 있어야 해요.
+
+```swift
+extension Shelf: Equatable
+where Item: Equatable {}
+```
+
+컴파일러가 `[Item]`의 `Equatable` 구현을 이용해 `Shelf`의 구현을 합성해요.
+
+```swift
+let firstShelf = Shelf(
+  items: [book]
+)
+let secondShelf = Shelf(
+  items: [book]
+)
+
+print(firstShelf == secondShelf)
+// true
+```
+
+`Item`이 `Equatable`을 따르지 않으면 해당 `Shelf<Item>`도 `Equatable`을 따르지 않아요. 바깥 제네릭 타입의 능력이 타입 인자의 능력에 따라 달라지는 구조예요.
+
+## where 절은 타입 사이의 관계를 표현해요
+
+콜론 제약은 한 타입 매개변수의 기본 조건을 간단히 표현하기 좋아요.
+
+```swift
+func describe<Item: CatalogItem>(
+  _ item: Item
+) -> String
+```
+
+두 타입의 내부 타입이 같아야 하는 것처럼 더 복잡한 관계는 `where` 절로 표현해요. 먼저 카탈로그 데이터를 불러오는 프로토콜을 정의해 볼게요.
+
+```swift
+protocol CatalogSource {
+  associatedtype Item: CatalogItem
+
+  func load() -> [Item]
+}
+```
+
+두 소스가 같은 `Item`을 불러올 때만 결과를 합치고 싶어요.
+
+```swift
+func merge<
+  Left: CatalogSource,
+  Right: CatalogSource
+>(
+  _ left: Left,
+  _ right: Right
+) -> [Left.Item]
+where Left.Item == Right.Item {
+  left.load() + right.load()
+}
+```
+
+요구사항을 나눠 읽으면 다음과 같아요.
+
+1. `Left`와 `Right`는 각각 `CatalogSource`를 따라야 해요.
+2. `Left.Item`과 `Right.Item`은 같은 타입이어야 해요.
+3. 따라서 두 배열을 안전하게 합쳐 `[Left.Item]`으로 반환할 수 있어요.
+
+```swift
+struct BookSource: CatalogSource {
+  func load() -> [Book] {
+    [
+      Book(
+        id: 1,
+        title: "Swift 기초",
+        author: "Blob"
+      ),
+    ]
+  }
+}
+
+struct CachedBookSource: CatalogSource {
+  let books: [Book]
+
+  func load() -> [Book] {
+    books
+  }
+}
+
+let mergedBooks = merge(
+  BookSource(),
+  CachedBookSource(books: [])
+)
+// [Book]
+```
+
+`VideoSource`와 `BookSource`를 전달하면 `Item`이 다르므로 컴파일되지 않아요. `where` 절은 실행 중에 검사하는 조건문이 아니라, 허용할 타입 조합을 컴파일 시점에 제한하는 타입 관계예요.
+
+## 연관 타입은 프로토콜을 따르는 타입이 정하는 자리예요
+
+제네릭 타입의 타입 매개변수와 프로토콜의 연관 타입은 모두 타입의 자리를 표현하지만, 누가 어디에서 정하는지가 달라요.
+
+```swift
+struct Shelf<Item> {
+  // Shelf를 사용할 때 Item을 정해요.
+}
+
+protocol CatalogSource {
+  associatedtype Item: CatalogItem
+  // CatalogSource를 따르는 타입이 Item을 정해요.
+}
+```
+
+`BookSource`는 `load()`의 반환 타입을 `[Book]`으로 구현했기 때문에 컴파일러가 `Item == Book`이라고 추론해요.
+
+```swift
+struct BookSource: CatalogSource {
+  func load() -> [Book] {
+    []
+  }
+}
+```
+
+명시적으로 적으면 다음과 같은 의미예요.
+
+```swift
+struct ExplicitBookSource: CatalogSource {
+  typealias Item = Book
+
+  func load() -> [Book] {
+    []
+  }
+}
+```
+
+| 구분        | 타입 매개변수                                 | 연관 타입                                             |
+| ----------- | --------------------------------------------- | ----------------------------------------------------- |
+| 선언 위치   | 함수나 구체 타입의 `<...>`                    | 프로토콜 본문의 `associatedtype`                      |
+| 정하는 주체 | 제네릭 함수 호출부 또는 제네릭 타입 사용 위치 | 프로토콜을 따르는 구체 타입                           |
+| 예          | `Shelf<Book>`의 `Book`                        | `BookSource.Item == Book`                             |
+| 주된 역할   | 알고리즘과 자료구조를 여러 타입에 재사용해요. | 프로토콜 요구사항 안에서 서로 연결된 타입을 표현해요. |
+
+연관 타입이 있는 프로토콜도 제네릭 제약으로 사용할 수 있어요.
+
+```swift
+func titles<Source: CatalogSource>(
+  from source: Source
+) -> [String] {
+  source.load().map(\.title)
+}
+```
+
+`Source.Item`의 정확한 타입은 호출마다 다를 수 있지만 `CatalogItem`을 따른다는 제약 덕분에 `title`을 사용할 수 있어요.
+
+## primary associated type은 자주 쓰는 연관 타입 제약을 짧게 적어요
+
+`CatalogSource`에서 가장 중요한 연관 타입이 `Item`이라면 이를 프로토콜 이름 뒤에 표시할 수 있어요.
+
+```swift
+protocol CatalogSource<Item> {
+  associatedtype Item: CatalogItem
+
+  func load() -> [Item]
+}
+```
+
+꺾쇠괄호의 `Item`은 새로운 제네릭 타입 매개변수를 선언하는 것이 아니에요. 본문에 선언한 기존 연관 타입 `Item`을 **primary associated type**으로 지정해 사용 위치에서 쉽게 제약할 수 있게 해요.
+
+예를 들어 “구체 소스 타입은 숨기되 `Book`을 불러오는 소스”를 다음처럼 표현할 수 있어요.
+
+```swift
+func makeBookSource()
+  -> some CatalogSource<Book> {
+  BookSource()
+}
+```
+
+“서로 다른 소스 타입을 저장하되 모두 `Book`을 불러오는 값”은 다음처럼 표현해요.
+
+```swift
+let bookSources:
+  [any CatalogSource<Book>] = [
+    BookSource(),
+    CachedBookSource(books: []),
+  ]
+```
+
+`CatalogSource<Book>`은 `CatalogSource`라는 프로토콜 자체가 제네릭 타입이 되었다는 뜻이 아니에요. `Item == Book`이라는 동일 타입 요구사항을 간단히 적은 제약 문법이에요.
+
+Swift Evolution의 [SE-0346](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0346-light-weight-same-type-syntax.md)은 primary associated type을 이용해 `some Sequence<String>`처럼 자주 쓰는 동일 타입 제약을 가볍게 표현하는 문법을 도입했어요.
+
+## 제네릭은 구체 타입 정보와 관계를 보존해요
+
+제네릭 함수는 호출부가 선택한 구체 타입을 타입 매개변수에 연결해요.
+
+```text
+describe(book)
+    │
+    └─ Item == Book
+       입력: Book
+       사용 가능한 약속: CatalogItem
+       구체 타입 관계: 유지
+```
+
+함수 구현은 프로토콜 제약이 보장하는 동작만 사용하지만, 컴파일러는 호출마다 실제 `Item`이 무엇인지 알고 있어요. 이 정보로 반환 타입을 정하고 다른 타입 매개변수나 연관 타입과의 관계를 검사해요.
+
+컴파일러는 상황에 따라 특정 타입 인자에 맞는 제네릭 구현을 특수화해 호출 비용을 줄이거나 추가 최적화를 할 수 있어요. 그러나 “제네릭을 쓰면 항상 코드가 복제된다”, “항상 직접 호출보다 빠르다”처럼 구현 결과를 단정하면 안 돼요. 최적화 여부는 가시성, 빌드 설정, 모듈 경계와 컴파일러 판단에 따라 달라질 수 있어요.
+
+제네릭을 선택하는 첫 번째 이유는 성능이 아니라 **타입 안전성과 관계를 유지한 재사용**이에요. 성능이 중요한 경로는 실제 빌드에서 측정해야 해요.
+
+## 제네릭, some, any는 타입을 정하는 주체가 달라요
+
+세 문법은 모두 프로토콜과 함께 사용할 수 있지만 답하는 질문이 달라요.
+
+| 방식                    | 구체 타입을 정하는 주체       | 구체 타입 정체성 | 서로 다른 타입을 한 저장소에 혼합      | 대표 목적                               |
+| ----------------------- | ----------------------------- | ---------------- | -------------------------------------- | --------------------------------------- |
+| `<Item: CatalogItem>`   | 호출자                        | 유지             | 하나의 제네릭 값 안에서는 어려워요.    | 알고리즘과 타입 관계를 재사용해요.      |
+| `some CatalogItem` 반환 | 함수·프로퍼티 구현            | 유지하되 숨겨요. | 하나의 선언은 한 기반 타입을 사용해요. | 구현 타입을 감춘 결과를 제공해요.       |
+| `any CatalogItem`       | 값을 저장하거나 대입하는 코드 | 지워져요.        | 가능해요.                              | 실행 중 여러 준수 타입을 저장·교체해요. |
+
+제네릭 함수는 호출자가 타입을 선택해요.
+
+```swift
+func describe<Item: CatalogItem>(
+  _ item: Item
+) -> String
+```
+
+`some` 반환은 구현이 타입을 선택하고 호출자에게는 약속만 보여 줘요.
+
+```swift
+func featuredItem()
+  -> some CatalogItem {
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+}
+```
+
+`any`는 실행 중에 여러 구체 타입을 같은 변수나 배열에 담을 수 있어요.
+
+```swift
+let mixedItems: [any CatalogItem] = [
+  book,
+  video,
+]
+```
+
+제네릭의 더 짧은 매개변수 표기는 [`some` 문서](./opaque-types)에서, 타입을 지운 저장과 동적 교체는 [`any` 문서](./existential-types)에서 자세히 살펴봐요.
+
+## 제네릭 오류는 추론 정보와 제약을 확인해요
+
+| 자주 만나는 상황                               | 원인                                                            | 확인할 부분                                                                              |
+| ---------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `generic parameter could not be inferred`      | 타입 매개변수를 정할 인자나 반환 문맥이 부족해요.               | 인자 타입, 변수 타입 주석, 반환값 사용 문맥 중 어디에서 타입을 알려 줄지 확인해요.       |
+| `requires that ... conform to ...`             | 전달한 타입이 선언된 프로토콜 제약을 만족하지 않아요.           | 해당 제약이 구현에 정말 필요한지, 구체 타입이 올바르게 준수하는지 확인해요.              |
+| `conflicting arguments to generic parameter`   | 같은 타입 매개변수 자리에 서로 다른 타입이 들어왔어요.          | 같은 타입이어야 하는 관계가 맞는지, 타입 매개변수를 둘로 나눠야 하는지 확인해요.         |
+| `binary operator '==' cannot be applied`       | 타입 매개변수에 `Equatable` 보장이 없어요.                      | `T: Equatable` 또는 `where T: Equatable` 제약이 필요한지 확인해요.                       |
+| 서로 다른 두 소스의 배열을 합칠 수 없어요.     | 두 연관 타입이 같다는 보장이 없어요.                            | `where Left.Item == Right.Item` 같은 동일 타입 요구사항을 추가해요.                      |
+| 제네릭 시그니처가 지나치게 길고 읽기 어려워요. | 한 함수가 너무 많은 타입 관계와 책임을 표현하고 있을 수 있어요. | 의미 있는 타입 이름, 작은 보조 함수, primary associated type, 별도 타입 분리를 검토해요. |
+
+오류 메시지의 `T`, `Item`, `Source.Item`을 실제 호출부 타입으로 치환해 읽으면 원인을 찾기 쉬워요.
+
+```text
+Item == Book이라고 추론했는데
+두 번째 인자로 Video가 들어왔어요.
+→ 같은 Item으로 볼 수 없어요.
+```
+
+## 언제 사용해야 하나요
+
+다음 상황에서는 제네릭이 잘 맞아요.
+
+- 타입만 다르고 알고리즘이나 자료구조가 같아요.
+- 입력과 반환값, 여러 인자 사이의 동일 타입 관계를 보존해야 해요.
+- 호출자가 사용할 구체 타입을 선택하는 API예요.
+- 특정 프로토콜 능력을 가진 여러 타입에 같은 구현을 제공해요.
+- 배열 원소와 반환 타입처럼 연관된 타입 정보를 컴파일 시점에 유지해야 해요.
+- 타입 인자가 만족하는 조건에 따라 extension이나 프로토콜 준수를 제공해요.
+
+다음 상황에서는 다른 표현도 검토해요.
+
+- 실제로 한 구체 타입만 사용한다면 제네릭이 불필요한 복잡성을 만들 수 있어요.
+- 구현이 고른 반환 타입을 감추고 싶다면 `some`이 API 의도를 더 잘 표현할 수 있어요.
+- 서로 다른 준수 타입을 같은 배열이나 프로퍼티에 저장하고 실행 중 교체해야 한다면 `any`가 필요할 수 있어요.
+- 타입 매개변수와 `where` 조건이 너무 많아 함수의 책임을 설명하기 어렵다면 타입이나 기능 분리를 먼저 검토해요.
+- 성능만을 추측해 제네릭으로 바꾸지 말고 실제 병목을 측정해요.
+
+## 제네릭을 적용하는 순서를 정리해요
+
+1. 타입 이름만 다르고 구현이 같은 중복 코드를 찾어요.
+2. 호출마다 바뀌는 타입에 `Item`, `Element`, `Key`, `Value`처럼 역할이 드러나는 이름을 붙여요.
+3. 같은 타입이어야 하는 매개변수와 반환값에 같은 타입 매개변수를 사용해요.
+4. 구현이 사용하는 연산과 프로퍼티를 확인하고 필요한 프로토콜 제약만 추가해요.
+5. 연관 타입 사이의 동일 타입 관계는 `where` 절로 표현해요.
+6. 일부 기능만 추가 능력이 필요하면 조건부 extension으로 범위를 좁혀요.
+7. 호출자가 타입을 선택하는지, 구현이 숨길지, 실행 중 섞어 저장할지를 확인해 제네릭·`some`·`any`를 다시 선택해요.
+8. 여러 구체 타입과 잘못된 타입 조합을 모두 컴파일하거나 테스트해 계약이 의도와 같은지 확인해요.
+
+## 흔한 오해를 정리해요
+
+### 제네릭은 Any와 같은가요?
+
+아니요. `Any`는 다양한 값을 담기 위해 구체 타입 정보를 지우고 사용할 때 캐스팅이 필요할 수 있어요. 제네릭은 호출마다 구체 타입을 정하고 그 타입 정보를 유지하므로 입력과 반환값 사이의 관계를 컴파일러가 검사할 수 있어요.
+
+### T는 모든 타입을 뜻하나요?
+
+`T`는 한 번의 호출이나 하나의 제네릭 인스턴스에서 정해지는 하나의 구체 타입 자리예요. 제약이 없다면 여러 종류의 타입이 각각 다른 호출에서 들어올 수 있지만, 같은 호출 안에서 `T`가 동시에 `Book`과 `Video`가 되지는 않아요.
+
+### 제약이 많을수록 더 안전한가요?
+
+구현에 필요한 제약은 안전한 계약을 만들지만, 사용하지 않는 능력까지 요구하면 사용할 수 있는 타입을 불필요하게 줄여요. 함수 본문이 실제로 사용하는 동작을 기준으로 최소한의 제약을 선언해야 해요.
+
+### 프로토콜의 꺾쇠괄호는 제네릭 프로토콜을 뜻하나요?
+
+`protocol CatalogSource<Item>`의 `Item`은 제네릭 타입 매개변수를 새로 선언하는 문법이 아니에요. 본문의 연관 타입을 primary associated type으로 지정해 `some CatalogSource<Book>`이나 `any CatalogSource<Book>`처럼 동일 타입 제약을 짧게 쓰게 해요.
+
+### 제네릭을 사용하면 항상 정적 디스패치되고 더 빠른가요?
+
+구체 타입 정보가 보존되므로 컴파일러가 특수화와 인라이닝을 적용할 기회가 있지만, 최적화 결과는 보장된 한 가지 형태가 아니에요. 모듈 경계와 빌드 설정에 따라 달라질 수 있으므로 성능은 측정해야 해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 제네릭의 핵심 목적은 무엇인가요?
+
+타입만 다른 중복 구현을 하나로 만들면서도 구체 타입 정보와 타입 사이의 관계를 유지하는 것이 핵심이에요. 필요한 프로토콜 제약을 선언하면 컴파일러가 허용할 타입과 사용할 수 있는 동작을 검사해요.
+
+### 타입 매개변수와 연관 타입의 차이는 무엇인가요?
+
+타입 매개변수는 제네릭 함수 호출부나 제네릭 타입 사용 위치에서 정해져요. 연관 타입은 프로토콜에 타입 자리를 선언하고, 그 프로토콜을 따르는 구체 타입이 실제 타입을 정해요.
+
+### where 절은 언제 사용하나요?
+
+연관 타입이 특정 프로토콜을 따라야 하거나 두 타입 매개변수의 내부 타입이 같아야 하는 등 복합적인 관계를 표현할 때 사용해요. 실행 중 조건이 아니라 허용할 타입 조합을 컴파일 시점에 제한하는 문법이에요.
+
+### 조건부 준수란 무엇인가요?
+
+제네릭 타입의 타입 인자가 특정 요구사항을 만족할 때만 바깥 타입도 프로토콜을 따르게 하는 기능이에요. `Shelf`가 `Equatable`일 때만 `Shelf`도 `Equatable`을 따르게 만드는 것이 한 예예요.
+
+### 제네릭과 any의 가장 중요한 차이는 무엇인가요?
+
+제네릭은 호출마다 하나의 구체 타입을 타입 매개변수에 연결해 정체성과 관계를 유지해요. `any Protocol`은 서로 다른 준수 타입을 같은 저장소에 담기 위해 구체 타입을 실존 상자 뒤로 지워 실행 중 유연성을 얻어요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Generics](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/generics/)
+- [The Swift Programming Language — Protocols](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/)
+- [The Swift Programming Language — Opaque and Boxed Protocol Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/)
+- [Swift Evolution SE-0341 — Opaque Parameter Declarations](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0341-opaque-parameters.md)
+- [Swift Evolution SE-0346 — Lightweight Same-Type Requirements for Primary Associated Types](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0346-light-weight-same-type-syntax.md)

--- a/docs/guide/swift/opaque-types.md
+++ b/docs/guide/swift/opaque-types.md
@@ -1,0 +1,816 @@
+---
+title: Swift로 이해하는 some과 불투명 타입
+description: Swift의 some이 하나의 숨겨진 구체 타입을 유지하는 원리와 opaque result·parameter type, 반환 규칙 및 any와의 차이를 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 some과 불투명 타입
+
+> **면접 답변 한 줄 요약:** `some Protocol`은 선언의 구현이 선택한 하나의 구체 타입을 호출자에게 숨기되 컴파일러에는 그 타입의 정체성을 유지해, 프로토콜이 보장하는 기능과 정적 타입 관계를 사용하면서 구현 세부사항을 감출 수 있게 하는 불투명 타입 문법이에요.
+
+함수가 프로토콜을 따르는 값을 반환할 때 구체 타입 이름을 그대로 공개하면 호출자가 구현 세부사항에 의존할 수 있어요. 반대로 타입을 완전히 지우면 서로 다른 값을 저장할 수 있는 대신 구체 타입 사이의 관계와 일부 연산을 잃을 수 있어요.
+
+Swift의 `some`은 이 두 선택 사이에서 **구체 타입은 하나로 유지하되 이름만 숨기는 방식**을 제공해요. SwiftUI의 `var body: some View`가 대표적이지만 `some`은 SwiftUI 전용 문법이 아니며, 일반 프로토콜과 제네릭 API에서도 사용할 수 있어요.
+
+이 문서에서는 카탈로그 항목을 반환하는 함수로 불투명 반환 타입을 먼저 이해하고, `some` 매개변수, primary associated type 제약, 프로토콜 연관 타입 추론까지 살펴봐요. 제네릭 자체가 낯설다면 [제네릭](./generics) 문서를 먼저 읽으면 타입을 정하는 주체의 차이를 이해하기 쉬워요.
+
+## 먼저 알아둘 불투명 타입 용어
+
+| 용어                       | 쉬운 뜻                                                                                                                                              |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 프로토콜                   | 타입이 제공해야 할 프로퍼티와 메서드를 선언한 약속이에요.                                                                                            |
+| 구체 타입                  | 값의 실제 구조와 구현이 정해진 타입이에요. `Book`과 `Video`가 한 예예요.                                                                             |
+| 기반 타입(underlying type) | `some Protocol` 뒤에 숨겨진 실제 구체 타입이에요. 함수 본문의 반환값을 보고 컴파일러가 정해요.                                                       |
+| 불투명 타입                | 구체 타입 이름은 사용하는 코드에 숨기지만, 컴파일러가 하나의 타입 정체성을 계속 추적하는 타입이에요. 영어로 opaque type이라고 해요.                  |
+| 타입 정체성                | 두 값이 컴파일 시점에 같은 구체 타입인지 구분하는 정보예요. 같은 불투명 반환 선언의 결과는 이 정체성을 공유해요.                                     |
+| 추상화 경계                | 구현 세부사항을 감추고 외부에 필요한 약속만 보여 주는 경계예요. 함수의 반환 타입이나 모듈의 public API가 한 예예요.                                  |
+| 호출자                     | 함수나 프로퍼티를 사용하는 코드예요.                                                                                                                 |
+| 구현자                     | 함수 본문이나 프로퍼티 getter를 작성해 실제 반환 타입을 선택하는 쪽이에요.                                                                           |
+| 불투명 반환 타입           | `-> some Protocol`처럼 반환 위치에 작성해 구현이 고른 구체 타입을 숨기는 형태예요. 영어로 opaque result type이라고 해요.                             |
+| 불투명 매개변수 타입       | `value: some Protocol`처럼 매개변수 위치에 작성하는 가벼운 제네릭 표기예요. 호출자가 전달한 구체 타입을 함수 안에서 하나의 타입 매개변수처럼 다뤄요. |
+| 실존 타입                  | `any Protocol`처럼 프로토콜을 따르는 여러 구체 타입을 실행 중 담을 수 있도록 타입을 지운 상자예요. `some`과 달리 저장된 구체 타입이 바뀔 수 있어요.  |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- 구체 반환 타입을 공개할 때 생기는 결합
+- `some Protocol`이 기반 타입을 숨기고 정체성을 유지하는 방식
+- 모든 반환 경로가 같은 기반 타입이어야 하는 이유
+- 같은 불투명 선언과 서로 다른 선언의 타입 정체성
+- 제네릭 인자에 따라 달라지는 불투명 타입
+- `some` 매개변수와 명시적인 제네릭 매개변수의 관계
+- primary associated type으로 불투명 타입의 연관 타입을 제약하는 방법
+- 제네릭, `some`, `any`를 선택하는 기준
+
+## 구체 반환 타입은 구현 세부사항을 공개해요
+
+카탈로그에 표시할 항목을 정의해 볼게요.
+
+```swift
+protocol CatalogItem: Equatable {
+  var id: Int { get }
+  var title: String { get }
+}
+
+struct Book: CatalogItem {
+  let id: Int
+  let title: String
+  let author: String
+}
+
+struct Video: CatalogItem {
+  let id: Int
+  let title: String
+  let duration: Int
+}
+```
+
+추천 항목을 반환하는 가장 직접적인 함수는 `Book`을 반환 타입으로 적어요.
+
+```swift
+func featuredItem() -> Book {
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+}
+```
+
+이 시그니처는 정확하지만 두 가지 사실을 외부에 공개해요.
+
+1. 결과가 `CatalogItem`이라는 API 약속
+2. 현재 구현이 결과를 `Book`으로 만든다는 세부사항
+
+호출자는 `author`에 접근하거나 결과를 `Book`만 받는 다른 API에 전달할 수 있어요.
+
+```swift
+let featured = featuredItem()
+print(featured.author)
+```
+
+나중에 구현을 `FeaturedBook`이라는 전용 타입이나 여러 값을 조합한 제네릭 타입으로 바꾸면 함수 본문만 바뀌는 것이 아니에요. 공개된 반환 타입에 의존한 호출 코드도 영향을 받아요.
+
+호출자에게 필요한 약속이 `id`와 `title`뿐이라면 구체 타입 이름을 API에 공개하지 않는 편이 변경 범위를 줄일 수 있어요.
+
+## some은 하나의 구체 타입을 숨겨 반환해요
+
+반환 타입을 `some CatalogItem`으로 바꿔 볼게요.
+
+```swift
+func featuredItem()
+  -> some CatalogItem {
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+}
+```
+
+이 선언을 두 관점으로 읽어야 해요.
+
+- 호출자에게는 “결과가 `CatalogItem`을 따른다”라고 보여요.
+- 구현과 컴파일러에는 “기반 타입은 항상 `Book`이다”라는 사실이 남아 있어요.
+
+호출자는 프로토콜이 보장하는 멤버를 사용할 수 있어요.
+
+```swift
+let featured = featuredItem()
+
+print(featured.id)
+print(featured.title)
+```
+
+하지만 정적 타입 시스템에서 결과를 `Book`이라고 가정할 수는 없어요.
+
+```swift
+// 오류: 호출자에게 기반 타입 Book은 공개되지 않아요.
+let book: Book = featuredItem()
+```
+
+불투명 타입은 구체 타입을 `Any`처럼 없애는 것이 아니에요. 타입 이름에 접근하지 못하게 추상화 경계를 만들 뿐, 컴파일러는 같은 불투명 타입인지 계속 구분해요.
+
+Swift 공식 [Opaque and Boxed Protocol Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/) 문서도 불투명 타입은 구현 타입을 숨기지만 타입 정체성을 보존한다고 설명해요.
+
+## 반환 경로마다 같은 기반 타입을 사용해야 해요
+
+`some CatalogItem`은 “조건마다 아무 `CatalogItem`이나 반환해도 된다”는 뜻이 아니에요. 하나의 선언에는 하나의 기반 타입이 있어야 해요.
+
+다음 함수는 두 반환 경로의 타입이 모두 `Book`이므로 유효해요.
+
+```swift
+func recommendedBook(
+  isBeginner: Bool
+) -> some CatalogItem {
+  if isBeginner {
+    return Book(
+      id: 1,
+      title: "Swift 기초",
+      author: "Blob"
+    )
+  }
+
+  return Book(
+    id: 2,
+    title: "Swift 심화",
+    author: "Mango"
+  )
+}
+```
+
+반면 `Book`과 `Video`를 조건에 따라 직접 반환하면 컴파일되지 않아요.
+
+```swift
+// 컴파일되지 않는 예예요.
+func recommendedItem(
+  prefersVideo: Bool
+) -> some CatalogItem {
+  if prefersVideo {
+    return Video(
+      id: 2,
+      title: "Swift 동시성",
+      duration: 35
+    )
+  }
+
+  return Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+  // 오류: 기반 타입을 Video와 Book 중 하나로 정할 수 없어요.
+}
+```
+
+프로토콜 준수 여부만 보면 두 타입 모두 조건을 만족해요. 하지만 불투명 반환 타입은 준수 여부뿐 아니라 하나의 타입 정체성을 약속하므로 모든 반환 경로의 기반 타입이 같아야 해요.
+
+## 서로 다른 경우를 하나의 구체 타입으로 감쌀 수 있어요
+
+조건에 따라 책이나 영상을 표현해야 하지만 불투명 타입의 정체성을 유지하고 싶다면, 두 경우를 하나의 열거형으로 감쌀 수 있어요.
+
+```swift
+enum FeaturedItem: CatalogItem {
+  case book(Book)
+  case video(Video)
+
+  var id: Int {
+    switch self {
+    case let .book(book):
+      book.id
+    case let .video(video):
+      video.id
+    }
+  }
+
+  var title: String {
+    switch self {
+    case let .book(book):
+      book.title
+    case let .video(video):
+      video.title
+    }
+  }
+}
+```
+
+이제 반환 경로의 기반 타입은 항상 `FeaturedItem`이에요.
+
+```swift
+func recommendedItem(
+  prefersVideo: Bool
+) -> some CatalogItem {
+  if prefersVideo {
+    return FeaturedItem.video(
+      Video(
+        id: 2,
+        title: "Swift 동시성",
+        duration: 35
+      )
+    )
+  }
+
+  return FeaturedItem.book(
+    Book(
+      id: 1,
+      title: "Swift 기초",
+      author: "Blob"
+    )
+  )
+}
+```
+
+열거형은 가능한 경우가 닫혀 있고 각 경우의 동작을 직접 제어할 때 잘 맞아요. 새 준수 타입을 실행 중 자유롭게 저장하고 교체해야 한다면 [`any CatalogItem`](./existential-types)이 더 직접적인 표현일 수 있어요.
+
+## 같은 선언의 결과는 같은 불투명 타입이에요
+
+같은 함수의 서로 다른 호출 결과는 같은 불투명 타입 정체성을 공유해요.
+
+```swift
+let first = featuredItem()
+let second = featuredItem()
+
+print(first == second)
+```
+
+`CatalogItem`이 `Equatable`을 따르고 두 값이 같은 불투명 타입이므로 `==`를 사용할 수 있어요. 호출자는 기반 타입이 `Book`이라는 사실은 모르지만, 두 결과가 같은 타입이라는 사실은 알아요.
+
+배열에도 함께 담을 수 있어요.
+
+```swift
+let featuredItems = [
+  featuredItem(),
+  featuredItem(),
+]
+```
+
+각 값의 타입 이름은 숨겨져 있지만 배열의 원소 타입은 `featuredItem()`이 만든 하나의 불투명 반환 타입으로 정해져요.
+
+## 서로 다른 선언의 불투명 타입은 별개예요
+
+두 함수가 우연히 같은 `Book`을 반환해도 각각의 `some CatalogItem`은 별개의 불투명 타입이에요.
+
+```swift
+func featuredItem()
+  -> some CatalogItem {
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+}
+
+func latestItem()
+  -> some CatalogItem {
+  Book(
+    id: 2,
+    title: "Swift 심화",
+    author: "Mango"
+  )
+}
+```
+
+다음 대입은 허용되지 않아요.
+
+```swift
+var item = featuredItem()
+
+// 오류: latestItem()은 다른 불투명 타입이에요.
+item = latestItem()
+```
+
+호출자가 두 함수의 기반 타입을 `Book`이라고 가정할 수 있다면 구현 타입을 숨긴 의미가 없어져요. Swift는 불투명 타입을 선언별로 구분해 각 API의 추상화 경계를 지켜요.
+
+여러 API가 반드시 같은 반환 타입을 공유해야 한다면 다음 중 하나를 검토해요.
+
+- 구체 반환 타입을 공개해요.
+- 공통 wrapper나 열거형을 반환해요.
+- 하나의 함수나 타입의 멤버로 결과 생성을 모아요.
+- 런타임 교체가 목적이라면 `any Protocol`을 사용해요.
+
+## 제네릭 인자가 다르면 불투명 결과도 달라질 수 있어요
+
+불투명 반환 타입의 기반 타입은 바깥 제네릭 인자에 의존할 수 있어요.
+
+```swift
+func duplicate<Item>(
+  _ item: Item
+) -> some Collection {
+  [item, item]
+}
+```
+
+구현의 기반 타입은 `[Item]`이에요.
+
+```swift
+let numbers = duplicate(3)
+// 기반 타입은 [Int]
+
+let words = duplicate("Swift")
+// 기반 타입은 [String]
+```
+
+같은 함수 이름을 호출했지만 `Item`이 다르므로 두 결과의 불투명 타입도 달라요.
+
+```swift
+var values = duplicate(3)
+
+// 오류: duplicate(String)의 결과는
+// duplicate(Int)의 결과와 다른 불투명 타입이에요.
+values = duplicate("Swift")
+```
+
+하나의 제네릭 인자 조합 안에서는 기반 타입이 일관되지만, 다른 타입 인자 조합까지 같은 타입일 필요는 없어요.
+
+## some 반환은 구현이 타입을 선택하는 역방향 제네릭이에요
+
+일반 제네릭 매개변수에서는 호출자가 타입을 선택해요.
+
+```swift
+func describe<Item: CatalogItem>(
+  _ item: Item
+) -> String {
+  item.title
+}
+```
+
+```text
+호출자: Book을 전달할게요.
+함수: Item이 무엇인지 추상적으로 다룰게요.
+```
+
+불투명 반환 타입에서는 구현이 타입을 선택해요.
+
+```swift
+func featuredItem()
+  -> some CatalogItem {
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+}
+```
+
+```text
+함수: 기반 타입은 내가 Book으로 정할게요.
+호출자: 이름은 모르지만 CatalogItem으로 사용할게요.
+```
+
+이 때문에 불투명 반환 타입을 **역방향 제네릭(reverse generic)**이라는 관점으로 설명하기도 해요. [SE-0244](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0244-opaque-result-types.md)는 일반 제네릭은 호출자가 타입을 선택하고, 불투명 반환은 구현이 타입을 선택한다고 설명해요.
+
+| 방향                  | 타입을 선택하는 쪽 | 타입을 추상적으로 보는 쪽 |
+| --------------------- | ------------------ | ------------------------- |
+| 제네릭 매개변수 `<T>` | 호출자             | 함수 구현                 |
+| 불투명 반환 `some P`  | 함수 구현          | 호출자                    |
+
+이 모델은 반환 위치의 `some`을 이해할 때 유용해요. 매개변수 위치의 `some`은 다음 섹션처럼 일반 제네릭의 가벼운 표기이므로 타입을 선택하는 방향이 달라요.
+
+## some 매개변수는 이름 없는 제네릭 매개변수예요
+
+매개변수 타입에도 `some`을 사용할 수 있어요.
+
+```swift
+func printTitle(
+  _ item: some CatalogItem
+) {
+  print(item.title)
+}
+```
+
+이 함수는 다음 제네릭 함수의 가벼운 표기예요.
+
+```swift
+func printTitle<Item: CatalogItem>(
+  _ item: Item
+) {
+  print(item.title)
+}
+```
+
+두 경우 모두 호출자가 구체 타입을 선택해요.
+
+```swift
+printTitle(
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+)
+
+printTitle(
+  Video(
+    id: 2,
+    title: "Swift 동시성",
+    duration: 35
+  )
+)
+```
+
+`some` 매개변수는 제약이 단순하고 함수 본문이나 반환 타입에서 타입 매개변수의 이름을 다시 사용할 필요가 없을 때 읽기 쉬워요.
+
+## 여러 some 매개변수는 각각 독립된 타입이에요
+
+다음 함수의 두 `some CatalogItem`은 서로 다른 이름 없는 타입 매개변수예요.
+
+```swift
+func printPair(
+  _ first: some CatalogItem,
+  _ second: some CatalogItem
+) {
+  print(first.title)
+  print(second.title)
+}
+```
+
+따라서 `Book`과 `Video`를 함께 전달할 수 있어요.
+
+```swift
+printPair(
+  Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  ),
+  Video(
+    id: 2,
+    title: "Swift 동시성",
+    duration: 35
+  )
+)
+```
+
+두 인자가 반드시 같은 구체 타입이어야 한다면 이름 있는 타입 매개변수를 사용해야 해요.
+
+```swift
+func areEqual<Item: CatalogItem>(
+  _ first: Item,
+  _ second: Item
+) -> Bool {
+  first == second
+}
+```
+
+같은 `Item`을 두 위치에 사용했으므로 `Book`과 `Video`를 섞어 전달할 수 없어요. 타입 사이의 관계를 반복해서 표현해야 한다면 `<Item>` 형태가 더 정확해요.
+
+Swift Evolution의 [SE-0341](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0341-opaque-parameters.md)은 `some P` 매개변수를 이름이 필요 없는 제네릭 매개변수의 가벼운 문법으로 도입했어요.
+
+## some 매개변수와 some 반환은 같은 단어지만 방향이 달라요
+
+다음 시그니처에는 `some`이 두 번 등장해요.
+
+```swift
+func copyTitle(
+  from item: some CatalogItem
+) -> some CatalogItem {
+  Book(
+    id: item.id,
+    title: item.title,
+    author: "Unknown"
+  )
+}
+```
+
+각 위치를 따로 읽어야 해요.
+
+| 위치                        | 구체 타입 선택 주체 | 이 예제의 타입                          |
+| --------------------------- | ------------------- | --------------------------------------- |
+| 매개변수 `some CatalogItem` | 호출자              | 호출마다 `Book`, `Video` 등이 가능해요. |
+| 반환 `some CatalogItem`     | 함수 구현           | 기반 타입은 항상 `Book`이에요.          |
+
+매개변수로 들어온 타입과 반환 타입은 자동으로 같은 타입이 아니에요. 같은 타입을 그대로 반환한다는 관계가 필요하면 이름 있는 제네릭을 사용해요.
+
+```swift
+func identity<Item: CatalogItem>(
+  _ item: Item
+) -> Item {
+  item
+}
+```
+
+`identity(_:)`는 입력이 `Video`이면 반환도 `Video`, 입력이 `Book`이면 반환도 `Book`이라는 관계를 시그니처에 표현해요.
+
+## primary associated type으로 숨겨진 타입의 일부 관계를 공개해요
+
+불투명 타입은 기반 타입 이름을 숨기지만, 호출자가 꼭 알아야 할 연관 타입 관계까지 숨길 필요는 없어요.
+
+카탈로그 소스의 `Item`을 primary associated type으로 선언해 볼게요.
+
+```swift
+protocol CatalogSource<Item> {
+  associatedtype Item: CatalogItem
+
+  func load() -> [Item]
+}
+
+struct BookSource: CatalogSource {
+  func load() -> [Book] {
+    [
+      Book(
+        id: 1,
+        title: "Swift 기초",
+        author: "Blob"
+      ),
+    ]
+  }
+}
+```
+
+구체 소스 타입은 숨기면서 `Item == Book`이라는 관계를 공개할 수 있어요.
+
+```swift
+func makeBookSource()
+  -> some CatalogSource<Book> {
+  BookSource()
+}
+
+let source = makeBookSource()
+let books: [Book] = source.load()
+```
+
+호출자는 결과가 `BookSource`라는 사실은 모르지만 `load()`가 `[Book]`을 반환한다는 사실은 알아요. 불투명 타입이 타입 정체성과 연관 타입 정보를 보존하기 때문에 가능해요.
+
+`some CatalogSource`만 적으면 `Item`의 정확한 타입을 API에 명시하지 않아요.
+
+```swift
+func makeSource()
+  -> some CatalogSource {
+  BookSource()
+}
+```
+
+함수 사용에 필요한 관계를 기준으로 제약을 공개해야 해요. 호출자가 `Book` 전용 API에 결과를 연결해야 한다면 `some CatalogSource<Book>`이 더 유용한 계약이에요.
+
+## 프로토콜 연관 타입을 some 구현으로 추론할 수 있어요
+
+프로토콜이 결과 타입을 연관 타입으로 요구할 때, 준수 타입의 구현에서 `some`을 사용할 수 있어요.
+
+```swift
+protocol FeaturedProviding {
+  associatedtype Featured: CatalogItem
+
+  func featured() -> Featured
+}
+
+struct HomeProvider: FeaturedProviding {
+  func featured()
+    -> some CatalogItem {
+    Book(
+      id: 1,
+      title: "Swift 기초",
+      author: "Blob"
+    )
+  }
+}
+```
+
+컴파일러는 `HomeProvider.Featured`를 `featured()`의 불투명 반환 타입으로 추론해요. 외부에는 구체 기반 타입 이름을 공개하지 않으면서 `HomeProvider` 안에서는 항상 같은 `Featured` 타입을 제공해요.
+
+프로토콜 요구사항 자체에 `some` 반환을 직접 적기보다, 연관 타입으로 관계를 선언하고 준수 타입의 구현에서 `some`으로 구체 타입을 숨기는 구조가 명확해요.
+
+## 프로퍼티에서도 불투명 타입을 사용할 수 있어요
+
+계산 프로퍼티의 반환 타입을 숨길 수 있어요.
+
+```swift
+var previewItem: some CatalogItem {
+  Book(
+    id: 0,
+    title: "미리보기",
+    author: "Preview"
+  )
+}
+```
+
+초깃값이 있는 저장 프로퍼티나 지역 상수에서도 기반 타입을 추론할 수 있어요.
+
+```swift
+let sampleItem: some CatalogItem =
+  Book(
+    id: 0,
+    title: "샘플",
+    author: "Preview"
+  )
+```
+
+`sampleItem`의 기반 타입은 초깃값의 `Book`으로 정해지지만, 정적 타입 시스템에서 `sampleItem`의 타입을 `Book`과 같다고 취급하지는 않아요.
+
+```swift
+var hiddenItem: some CatalogItem =
+  Book(
+    id: 0,
+    title: "샘플",
+    author: "Preview"
+  )
+
+// 오류: 불투명 타입을 정적으로 Book과
+// 같은 타입이라고 가정할 수 없어요.
+hiddenItem = Book(
+  id: 1,
+  title: "Swift 기초",
+  author: "Blob"
+)
+```
+
+값을 바꿔야 한다면 같은 불투명 반환 선언의 결과를 사용해 타입 정체성을 맞출 수 있어요.
+
+```swift
+func makeSample(
+  id: Int
+) -> some CatalogItem {
+  Book(
+    id: id,
+    title: "샘플 \(id)",
+    author: "Preview"
+  )
+}
+
+var editableItem = makeSample(id: 0)
+editableItem = makeSample(id: 1)
+
+// 두 값은 같은 makeSample 선언의
+// 불투명 반환 타입이에요.
+```
+
+실행 중 `Book`과 `Video`처럼 다른 준수 타입으로 바꿔야 한다면 `var editableItem: any CatalogItem`이 목적에 맞아요.
+
+## SwiftUI의 some View도 같은 규칙을 사용해요
+
+SwiftUI는 Apple 플랫폼에서 화면을 선언형으로 구성하는 프레임워크예요. `View` 프로토콜의 `body`는 연관 타입을 사용하고, 구현에서는 흔히 `some View`를 반환해요.
+
+```swift
+import SwiftUI
+
+struct ProfileView: View {
+  var body: some View {
+    VStack {
+      Text("프로필")
+      Text("Swift 학습자")
+    }
+  }
+}
+```
+
+`VStack<Text...>`처럼 조합 과정에서 만들어지는 구체 타입 이름은 길고 구현 구조를 그대로 드러낼 수 있어요. `some View`는 그 이름을 숨기면서 기반 타입 정체성은 유지해 SwiftUI가 타입 정보를 이용할 수 있게 해요.
+
+조건에 따라 서로 다른 View를 반환하는 코드가 동작하는 경우에는 Result Builder가 조건별 View를 하나의 공통 구체 wrapper 타입으로 조합하는 등 추가 규칙이 개입할 수 있어요. 이를 “`some`은 서로 다른 반환 타입을 허용한다”라고 일반화하면 안 돼요. 일반 함수의 반환 경로는 여전히 같은 기반 타입을 사용해야 해요.
+
+## some과 any는 타입 정체성 보존 여부가 달라요
+
+두 문법 모두 구체 타입 이름을 숨기지만 제공하는 계약은 달라요.
+
+| 기준                       | `some CatalogItem`               | `any CatalogItem`                                |
+| -------------------------- | -------------------------------- | ------------------------------------------------ |
+| 의미                       | 숨겨진 하나의 구체 타입이에요.   | 준수 타입을 담을 수 있는 실존 상자예요.          |
+| 타입 선택                  | 선언 구현이 선택해요.            | 값을 대입하는 코드가 실행 중 선택할 수 있어요.   |
+| 타입 정체성                | 유지해요.                        | 상자 밖에서는 지워져요.                          |
+| 서로 다른 타입으로 교체    | 할 수 없어요.                    | 할 수 있어요.                                    |
+| 같은 함수의 여러 결과      | 같은 불투명 타입이에요.          | 각 값의 동적 타입이 다를 수 있어요.              |
+| `Self`·연관 타입 기반 연산 | 더 많은 관계를 보존할 수 있어요. | 지워진 정보 때문에 일부 연산이 제한될 수 있어요. |
+| 대표 사용                  | 구현 타입을 숨긴 반환값이에요.   | 이종 배열, 저장 프로퍼티, 런타임 교체예요.       |
+
+조건마다 `Book` 또는 `Video`를 자유롭게 반환하고 호출자가 둘을 같은 타입으로 저장해야 한다면 `any`를 사용할 수 있어요.
+
+```swift
+func dynamicItem(
+  prefersVideo: Bool
+) -> any CatalogItem {
+  if prefersVideo {
+    return Video(
+      id: 2,
+      title: "Swift 동시성",
+      duration: 35
+    )
+  }
+
+  return Book(
+    id: 1,
+    title: "Swift 기초",
+    author: "Blob"
+  )
+}
+```
+
+유연성을 얻는 대신 결과의 구체 타입 정체성은 실존 상자 뒤로 지워져요. 자세한 저장 방식과 제약은 [`any`와 실존 타입](./existential-types) 문서에서 설명해요.
+
+## some 오류는 기반 타입과 선택 방향을 확인해요
+
+| 자주 만나는 상황                                           | 원인                                                               | 확인할 부분                                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| 반환 경로마다 다른 타입이라는 오류가 나요.                 | 하나의 불투명 반환 선언에서 기반 타입이 `Book`과 `Video`로 갈려요. | 하나의 enum·wrapper로 감싸거나, 런타임 유연성이 필요하면 `any`를 검토해요. |
+| `some` 결과를 구체 타입 변수에 대입할 수 없어요.           | 호출자에게 기반 타입 이름이 숨겨져 있어요.                         | 프로토콜 요구사항만 사용할지, 구체 타입을 공개해야 하는 API인지 확인해요.  |
+| 같은 구체 타입을 반환하는 두 함수 결과를 대입할 수 없어요. | 서로 다른 선언의 불투명 타입은 별개예요.                           | 공통 구체 타입·wrapper를 공개하거나 결과 생성 API를 하나로 모아요.         |
+| 두 `some` 매개변수가 같은 타입일 것으로 기대했어요.        | 각 `some` 매개변수는 독립된 이름 없는 제네릭 매개변수예요.         | 같은 타입 관계가 필요하면 `<Item>`을 선언해 두 위치에 반복해서 사용해요.   |
+| `some Source`의 원소 타입을 사용할 수 없어요.              | 연관 타입 관계를 시그니처에 충분히 공개하지 않았어요.              | primary associated type으로 `some Source<Book>`처럼 제약해요.              |
+| 실행 중 다른 타입을 대입할 수 없어요.                      | `some` 변수의 기반 타입은 초기화 시점에 하나로 고정돼요.           | 동적 교체가 요구사항이면 `any Protocol`을 사용해요.                        |
+
+오류를 볼 때 `some`을 “아무 타입”으로 읽지 말고 다음 문장으로 바꿔 읽어 보세요.
+
+```text
+이 선언이 선택한,
+이름은 숨겨져 있지만 정확히 하나인 구체 타입
+```
+
+## 언제 사용해야 하나요
+
+다음 상황에서는 불투명 반환 타입이 잘 맞아요.
+
+- 호출자가 구체 구현 타입보다 프로토콜 약속에 의존해야 해요.
+- 구현 타입 이름이 길거나 제네릭 조합 구조를 그대로 드러내요.
+- 기반 타입을 나중에 바꿀 수 있는 API 추상화 경계를 만들고 싶어요.
+- 같은 선언의 결과끼리 타입 정체성과 연관 타입 관계를 유지해야 해요.
+- 프로토콜 연관 타입 구현을 제공하면서 구체 타입 이름은 숨기고 싶어요.
+- SwiftUI처럼 컴파일러가 구체 타입 정보를 활용할 수 있게 유지하고 싶어요.
+
+다음 상황에서는 다른 표현도 검토해요.
+
+- 호출자가 구체 타입의 전용 API를 사용해야 한다면 구체 타입을 반환하는 편이 명확해요.
+- 반환 경로마다 서로 다른 준수 타입을 자유롭게 선택해야 한다면 `any`나 공통 wrapper가 필요해요.
+- 여러 함수의 결과가 반드시 같은 공개 타입이어야 한다면 각각의 `some`은 맞지 않을 수 있어요.
+- 매개변수와 반환값이 같은 타입이라는 관계를 표현해야 한다면 이름 있는 제네릭을 사용해요.
+- 단지 반환 타입 이름을 짧게 만들려는 목적이라면 어떤 추상화 계약을 제공하는지 먼저 확인해요.
+
+## some을 적용하는 순서를 정리해요
+
+1. 호출자가 실제로 필요한 프로토콜 요구사항을 정해요.
+2. 구체 반환 타입을 공개했을 때 호출자가 의도하지 않은 구현 세부사항에 의존하는지 확인해요.
+3. 모든 반환 경로가 같은 기반 타입을 만드는지 확인해요.
+4. 함수나 프로퍼티 반환 타입을 `some Protocol`로 바꾸고 호출부가 필요한 기능을 사용할 수 있는지 검사해요.
+5. 연관 타입 정보가 필요하면 primary associated type 제약을 추가해요.
+6. 여러 `some` 매개변수 사이에 같은 타입 관계가 필요한지 확인하고, 필요하면 이름 있는 제네릭으로 바꿔요.
+7. 실행 중 다른 준수 타입을 저장하거나 교체해야 한다면 `any`와 비교해요.
+8. 여러 호출, 조건 경로, 모듈 경계에서 타입 관계와 컴파일 결과를 검증해요.
+
+## 흔한 오해를 정리해요
+
+### some Protocol은 Protocol을 따르는 아무 타입이나 뜻하나요?
+
+아니요. 한 선언의 구현이 선택한 정확히 하나의 구체 타입을 뜻해요. 이름은 호출자에게 숨겨지지만 모든 반환 경로에서 같은 기반 타입을 사용해야 해요.
+
+### some과 any는 성능만 다른가요?
+
+핵심 차이는 의미와 타입 정체성이에요. `some`은 하나의 숨겨진 타입을 유지하고, `any`는 실행 중 서로 다른 준수 타입을 담도록 타입을 지워요. 성능 차이는 이 의미 차이에서 따라오는 결과 중 하나이며 실제 영향은 측정해야 해요.
+
+### 같은 Book을 반환하면 서로 다른 some 함수의 결과도 같은 타입인가요?
+
+정적 타입 시스템에서는 아니에요. 서로 다른 선언의 불투명 반환 타입은 각각 고유하므로 기반 구현이 우연히 같아도 직접 대입할 수 없어요.
+
+### 매개변수의 some도 구현이 타입을 선택하나요?
+
+아니요. 매개변수 위치의 `some`은 이름 없는 제네릭 매개변수의 가벼운 표기라 호출자가 타입을 선택해요. 반환 위치의 `some`은 구현이 기반 타입을 선택해요.
+
+### some을 사용하면 런타임 boxing이 전혀 없나요?
+
+`some` 자체는 실존 상자처럼 구체 타입을 지우는 의미가 아니며 컴파일러가 기반 타입 정체성을 유지해요. 하지만 전체 프로그램의 실제 메모리 배치와 최적화 결과는 다른 추상화, 모듈 경계, 빌드 설정의 영향도 받으므로 “할당이 절대 없다”라고 단정하면 안 돼요.
+
+## 면접에서 이어질 수 있는 질문
+
+### some이 불투명 타입이라고 불리는 이유는 무엇인가요?
+
+호출자에게는 기반 구체 타입의 이름이 보이지 않기 때문이에요. 다만 컴파일러는 그 타입 정체성을 유지하므로 같은 선언의 결과와 연관 타입 관계를 정적으로 검사할 수 있어요.
+
+### some 반환 타입은 왜 모든 경로에서 같은 타입이어야 하나요?
+
+하나의 함수 선언이 하나의 불투명 타입 정체성을 제공하기 때문이에요. 반환 경로마다 기반 타입이 다르면 호출자가 받은 값의 정적 타입을 하나로 정할 수 없어요.
+
+### some 매개변수와 제네릭 매개변수의 차이는 무엇인가요?
+
+`item: some Protocol`은 단순한 제약에서 이름을 생략한 제네릭 매개변수 문법이에요. 타입 이름을 반환 타입이나 다른 매개변수에 반복해 관계를 표현해야 한다면 `<Item: Protocol>` 형태가 필요해요.
+
+### some과 any 중 무엇을 반환해야 하나요?
+
+구현 타입을 숨기되 항상 하나의 기반 타입과 타입 관계를 유지하려면 `some`이 맞아요. 반환 경로의 타입이 실행 중 달라져야 하거나 결과를 서로 교체 가능한 실존 값으로 제공하려면 `any`를 검토해요.
+
+### 불투명 타입이 API 설계에 주는 이점은 무엇인가요?
+
+호출자에게 필요한 프로토콜 약속만 공개하고 구체 구현 타입 이름은 감출 수 있어요. 호출자가 세부 타입에 의존하지 않으므로 구현을 변경할 여지가 생기면서도 타입 정체성과 연관 타입 정보는 유지할 수 있어요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Opaque and Boxed Protocol Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/opaquetypes/)
+- [The Swift Programming Language — Generics](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/generics/)
+- [The Swift Programming Language — Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/types/)
+- [Swift Evolution SE-0244 — Opaque Result Types](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0244-opaque-result-types.md)
+- [Swift Evolution SE-0341 — Opaque Parameter Declarations](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0341-opaque-parameters.md)
+- [Swift Evolution SE-0346 — Lightweight Same-Type Requirements for Primary Associated Types](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0346-light-weight-same-type-syntax.md)


### PR DESCRIPTION
## Summary

Swift 제네릭과 `some`, `any`를 각각 단계적으로 학습할 수 있는 입문 문서 세 개를 추가합니다.

## Changes

- 제네릭 함수와 타입, 타입 제약, `where` 절, 조건부 확장·준수, 연관 타입을 예제와 함께 설명합니다.
- `some`의 불투명 반환 타입과 매개변수 문법, 반환 경로 규칙, primary associated type 활용법을 정리합니다.
- `any` 실존 타입의 저장 방식과 타입 소거, 암시적으로 열린 실존 타입, 제네릭·`some`과의 선택 기준을 설명합니다.
- 각 문서에 흔한 오류, 적용 순서, FAQ, 면접 질문과 Swift 공식 참고 자료를 포함합니다.
- Swift 사이드바에 제네릭, `some`, `any` 문서를 순서대로 연결합니다.

## Testing

- Swift 6.3으로 대표 예제와 경계 사례를 컴파일하고 실행했습니다.
- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run docs:check-collection-views`
- 개발 서버와 빌드 산출물에서 페이지 경로, 제목, SEO 설명, 사이드바 노출을 확인했습니다.

## Related Issues

Closes #18
