### PR TITLE
[#17] Swift Result Builder·매크로·Property Wrapper와 Combine·RxSwift 가이드를 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -12,6 +12,12 @@
     "position": "left"
   },
   {
+    "text": "Combine",
+    "link": "/guide/combine/index",
+    "activeMatch": "/guide/combine/",
+    "position": "left"
+  },
+  {
     "text": "디자인 패턴",
     "link": "/guide/design-patterns/dependency-injection",
     "activeMatch": "/guide/design-patterns/",

--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -18,6 +18,12 @@
     "position": "left"
   },
   {
+    "text": "RxSwift",
+    "link": "/guide/rxswift/index",
+    "activeMatch": "/guide/rxswift/",
+    "position": "left"
+  },
+  {
     "text": "디자인 패턴",
     "link": "/guide/design-patterns/dependency-injection",
     "activeMatch": "/guide/design-patterns/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -11,6 +11,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "combine",
+    "label": "Combine"
+  },
+  {
+    "type": "dir-section-header",
     "name": "design-patterns",
     "label": "디자인 패턴"
   }

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -16,6 +16,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "rxswift",
+    "label": "RxSwift"
+  },
+  {
+    "type": "dir-section-header",
     "name": "design-patterns",
     "label": "디자인 패턴"
   }

--- a/docs/guide/combine/_meta.json
+++ b/docs/guide/combine/_meta.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "custom-link",
+    "label": "Combine 시작하기",
+    "link": "/guide/combine/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "모든 연산자",
+    "collapsible": true,
+    "collapsed": false,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "변환과 필터링",
+        "link": "/guide/combine/operators-map-filter"
+      },
+      {
+        "type": "custom-link",
+        "label": "축약과 조건 판정",
+        "link": "/guide/combine/operators-reduce-match"
+      },
+      {
+        "type": "custom-link",
+        "label": "시퀀스와 요소 선택",
+        "link": "/guide/combine/operators-sequence-selection"
+      },
+      {
+        "type": "custom-link",
+        "label": "Publisher 결합",
+        "link": "/guide/combine/operators-combine"
+      },
+      {
+        "type": "custom-link",
+        "label": "평탄화와 오류 처리",
+        "link": "/guide/combine/operators-flatten-error"
+      },
+      {
+        "type": "custom-link",
+        "label": "시간·버퍼·스케줄러",
+        "link": "/guide/combine/operators-time-buffer"
+      },
+      {
+        "type": "custom-link",
+        "label": "연결·구독·디버깅",
+        "link": "/guide/combine/operators-lifecycle"
+      }
+    ]
+  }
+]

--- a/docs/guide/combine/index.md
+++ b/docs/guide/combine/index.md
@@ -1,0 +1,239 @@
+---
+title: Swift로 시작하는 Combine
+description: Publisher와 Subscriber의 연결부터 Subject, 취소, 오류, 스케줄러까지 Combine 파이프라인의 핵심과 모든 연산자의 학습 순서를 설명합니다.
+---
+
+# Swift로 시작하는 Combine
+
+> **면접 답변 한 줄 요약:** Combine은 `Publisher`가 시간에 따라 보내는 값과 완료 이벤트를 연산자로 변환하고, `Subscriber`가 수요를 요청해 소비하도록 연결하는 Apple의 반응형 프로그래밍 프레임워크예요.
+
+버튼 탭, 검색어 변경, 네트워크 응답은 모두 **언제 도착할지 모르는 값**이에요. 각각을 콜백과 상태 변수로 처리하면 취소, 오류, 실행 위치가 여러 곳으로 흩어지기 쉬워요. Combine은 값이 출발하는 곳부터 화면에 반영되는 곳까지 하나의 파이프라인으로 표현해요.
+
+이 섹션은 기본 Swift 문법을 알지만 Combine은 처음 접하는 독자를 대상으로 해요. 먼저 Publisher와 Subscriber가 연결되는 과정을 익힌 뒤, Apple의 `Publisher` API에 공개된 모든 연산자를 목적별로 찾아볼 수 있어요.
+
+## 먼저 알아둘 Combine 용어
+
+| 용어                                 | 쉬운 뜻                                                                                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 반응형 프로그래밍                    | 값이 바뀌거나 사건이 생겼을 때 미리 연결한 처리 흐름이 반응하도록 만드는 방식이에요.                                                      |
+| `Publisher`                          | 0개 이상의 값과 마지막 완료 이벤트를 시간에 따라 보내는 타입이에요. 보내는 값은 `Output`, 보낼 수 있는 오류는 `Failure`로 표현해요.       |
+| `Subscriber`                         | Publisher에 연결되어 구독을 받고, 필요한 값의 개수를 요청한 뒤 값과 완료를 처리하는 타입이에요.                                           |
+| 연산자(operator)                     | 위쪽 Publisher를 입력으로 받아 값, 오류, 시간, 연결 방식을 바꾼 새 Publisher나 Subscriber를 만드는 메서드예요.                            |
+| 업스트림·다운스트림                  | 값이 출발하는 쪽을 업스트림, 연산자를 지나 값을 받는 쪽을 다운스트림이라고 해요.                                                          |
+| 구독(subscription)                   | Publisher와 Subscriber 사이의 연결이에요. Subscriber는 구독을 통해 값을 요청하거나 연결을 취소해요.                                       |
+| 수요(demand)와 역압력(back pressure) | Subscriber가 지금 처리할 수 있는 값의 개수를 Publisher에 알리는 흐름 제어 방식이에요.                                                     |
+| `Subject`                            | 외부 코드가 `send(_:)`로 값을 직접 넣을 수 있으면서 Publisher와 Subscriber 역할을 모두 하는 타입이에요.                                   |
+| 스케줄러(scheduler)                  | 지연 시간과 작업 실행 위치를 정하는 추상화예요. `RunLoop`, `DispatchQueue`, `OperationQueue` 등이 Combine 스케줄러로 쓰여요.              |
+| `AnyCancellable`                     | 구독을 취소할 수 있는 토큰이에요. 해제될 때 자동으로 취소되므로 파이프라인을 유지하려면 프로퍼티나 `Set<AnyCancellable>`에 보관해야 해요. |
+
+이 문서에서는 다음 순서로 Combine을 배워요.
+
+1. Publisher가 값과 완료를 보내는 규칙을 이해해요.
+2. 연산자를 연결해 값과 오류를 처리해요.
+3. `sink`가 만든 구독을 보관하고 취소해요.
+4. Subject와 `@Published`로 상태 변화를 노출해요.
+5. 모든 연산자를 목적에 따라 골라요.
+6. Combine과 Swift Concurrency의 역할을 구분해요.
+
+## Publisher는 값과 완료를 보내요
+
+Publisher는 `Output` 타입의 값을 여러 번 보낼 수 있고, 마지막에는 아래 완료 이벤트 중 하나를 최대 한 번 보내요.
+
+```swift
+Subscribers.Completion<Failure>.finished
+Subscribers.Completion<Failure>.failure(error)
+```
+
+완료한 뒤에는 값이나 다른 완료를 더 보내지 않아요. 실패할 수 없는 Publisher는 `Failure == Never`를 사용해요. 이 두 타입이 파이프라인 전체에서 맞아야 다음 연산자와 Subscriber를 연결할 수 있어요.
+
+가장 작은 Publisher는 컬렉션의 `publisher` 프로퍼티로 만들 수 있어요.
+
+```swift
+import Combine
+
+let numbers = [1, 2, 3, 4, 5].publisher
+```
+
+이 Publisher의 `Output`은 `Int`, `Failure`는 `Never`예요. 아직 값이 출력되지는 않아요. Combine 파이프라인은 보통 Subscriber가 연결되어 구독이 시작될 때 업스트림에 값을 요청해요.
+
+## 연산자는 새 Publisher를 반환해요
+
+짝수만 골라 문자열로 바꿔 볼게요.
+
+```swift
+let cancellable = [1, 2, 3, 4, 5].publisher
+  .filter { $0.isMultiple(of: 2) }
+  .map { "값: \($0)" }
+  .sink { value in
+    print(value)
+  }
+
+// 값: 2
+// 값: 4
+```
+
+호출 순서는 위에서 아래지만 연결은 아래의 `sink`에서 시작해요.
+
+```text
+[Int].publisher → filter → map → sink
+     업스트림                    다운스트림
+```
+
+`filter`는 원래 Publisher를 직접 바꾸지 않고 `Publishers.Filter`라는 새 Publisher를 만들어요. `map`도 그 결과를 감싼 새 Publisher를 만들고, 마지막 `sink`가 Subscriber와 취소 토큰을 만들어요. 그래서 각 단계의 입력과 출력을 왼쪽에서 오른쪽으로 읽으면 파이프라인을 이해하기 쉬워요.
+
+## 구독을 보관해야 값이 계속 와요
+
+`sink`와 `assign(to:on:)`은 `AnyCancellable`을 반환해요. 토큰을 보관하지 않으면 표현식이 끝난 직후 해제되면서 구독도 취소될 수 있어요.
+
+```swift
+import Combine
+
+final class SearchViewModel {
+  @Published var query = ""
+  @Published private(set) var normalizedQuery = ""
+
+  private var cancellables = Set<AnyCancellable>()
+
+  init() {
+    $query
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .removeDuplicates()
+      .sink { [weak self] query in
+        self?.normalizedQuery = query
+      }
+      .store(in: &cancellables)
+  }
+}
+```
+
+`store(in:)`은 `Cancellable`의 편의 메서드로 토큰을 집합에 넣어요. `SearchViewModel`이 해제되면 집합과 토큰도 해제되어 구독이 취소돼요. 클로저가 `self`를 강하게 잡고, `self`가 토큰을 보관하면 참조 순환이 생길 수 있으므로 소유 기간을 확인해야 해요.
+
+## Publisher를 만드는 방법을 구분해요
+
+연산자를 적용하려면 먼저 값이 출발할 Publisher가 필요해요.
+
+| Publisher·API              | 언제 사용하나요                                                                                                                                |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Just`                     | 실패 없이 값 하나를 즉시 보내고 끝낼 때 사용해요.                                                                                              |
+| `Future`                   | 나중에 성공 값 하나나 실패 하나를 전달할 때 사용해요. 생성 시 작업 클로저가 실행되고 결과를 저장하므로 구독 시 시작하려면 `Deferred`로 감싸요. |
+| `Deferred`                 | Subscriber가 붙을 때마다 내부 Publisher를 새로 만들고 싶을 때 사용해요.                                                                        |
+| `Empty`                    | 값 없이 바로 끝내거나 끝나지 않는 Publisher가 필요할 때 사용해요.                                                                              |
+| `Fail`                     | 값 없이 지정한 오류로 끝낼 때 사용해요.                                                                                                        |
+| `Record`                   | 미리 기록한 값들과 완료를 재생할 때 사용해요.                                                                                                  |
+| `Sequence.publisher`       | 배열이나 범위 같은 `Sequence`의 값을 차례로 보낼 때 사용해요.                                                                                  |
+| `PassthroughSubject`       | 새 Subscriber에게 과거 값은 주지 않고 이후 `send(_:)` 값만 전달해요.                                                                           |
+| `CurrentValueSubject`      | 현재 값을 저장하고 새 Subscriber에게 그 값을 먼저 전달해요.                                                                                    |
+| `@Published`의 `$property` | 클래스 프로퍼티가 바뀌는 흐름을 `Published.Publisher`로 노출해요.                                                                              |
+| Foundation Publisher       | `URLSession`, `NotificationCenter`, `Timer`, KVO 같은 시스템 사건을 Combine으로 연결해요.                                                      |
+
+Subject는 기존 delegate나 콜백을 Combine 파이프라인에 넣는 경계에서는 유용해요. 그러나 어디서나 값을 보낼 수 있으므로 상태 변경 경로가 감춰질 수 있어요. 단순한 상태는 `@Published`처럼 소유자가 분명한 API부터 고려하세요.
+
+## 오류 타입을 맞춰야 연결할 수 있어요
+
+Combine은 오류 타입도 제네릭으로 추적해요.
+
+```swift
+import Combine
+
+enum SearchError: Error {
+  case emptyQuery
+}
+
+func validate(_ query: String) -> AnyPublisher<String, SearchError> {
+  Just(query)
+    .setFailureType(to: SearchError.self)
+    .tryMap { query in
+      guard !query.isEmpty else {
+        throw SearchError.emptyQuery
+      }
+      return query
+    }
+    .mapError { error in
+      error as? SearchError ?? .emptyQuery
+    }
+    .eraseToAnyPublisher()
+}
+```
+
+`setFailureType`은 실패하지 않는 `Never` Publisher에 오류 타입만 맞춰요. `tryMap`처럼 던질 수 있는 클로저를 받는 연산자는 `Failure`를 `any Error`로 넓혀요. 필요한 구체 오류로 다시 제한하려면 `mapError`를 사용해요.
+
+## 모든 연산자를 목적별로 찾아봐요
+
+아래 표는 Xcode 26.4 SDK의 Combine 모듈과 Apple의 `Publisher` DocC 목차를 대조한 인벤토리예요. 같은 이름의 오버로드는 한 항목에서 차이를 함께 설명해요. `receive(subscriber:)`와 `connect()`는 프로토콜 요구사항이므로 연결 문서에서 별도로 다루고, `values`는 메서드가 아닌 비동기 브리지지만 함께 설명해요.
+
+| 목적                  | 연산자                                                                                                                          | 문서                                                 |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| 값 변환               | `map`, `tryMap`, `mapError`, `replaceNil`, `scan`, `tryScan`, `setFailureType`                                                  | [변환과 필터링](./operators-map-filter)              |
+| 값 필터링             | `filter`, `tryFilter`, `compactMap`, `tryCompactMap`, `removeDuplicates`, `tryRemoveDuplicates`, `replaceEmpty`, `replaceError` | [변환과 필터링](./operators-map-filter)              |
+| 모으기와 축약         | `collect`, `ignoreOutput`, `reduce`, `tryReduce`, `count`, `min`, `tryMin`, `max`, `tryMax`                                     | [축약과 조건 판정](./operators-reduce-match)         |
+| 조건 판정             | `contains`, `tryContains`, `allSatisfy`, `tryAllSatisfy`                                                                        | [축약과 조건 판정](./operators-reduce-match)         |
+| 앞뒤 연결과 구간 선택 | `append`, `prepend`, `drop`, `tryDrop`, `dropFirst`, `prefix`, `tryPrefix`, `first`, `tryFirst`, `last`, `tryLast`, `output`    | [시퀀스와 요소 선택](./operators-sequence-selection) |
+| 여러 Publisher 결합   | `combineLatest`, `merge`, `zip`                                                                                                 | [Publisher 결합](./operators-combine)                |
+| 내부 Publisher 평탄화 | `flatMap`, `switchToLatest`                                                                                                     | [평탄화와 오류 처리](./operators-flatten-error)      |
+| 오류 처리             | `assertNoFailure`, `catch`, `tryCatch`, `retry`                                                                                 | [평탄화와 오류 처리](./operators-flatten-error)      |
+| 시간과 흐름 제어      | `measureInterval`, `debounce`, `delay`, `throttle`, `timeout`, `buffer`, `subscribe(on:)`, `receive(on:)`                       | [시간·버퍼·스케줄러](./operators-time-buffer)        |
+| 코딩과 타입 감추기    | `encode`, `decode`, `eraseToAnyPublisher`                                                                                       | [연결·구독·디버깅](./operators-lifecycle)            |
+| 공유와 연결           | `share`, `multicast`, `makeConnectable`, `autoconnect`                                                                          | [연결·구독·디버깅](./operators-lifecycle)            |
+| 구독과 관찰           | `sink`, `assign`, `subscribe`, `handleEvents`, `print`, `breakpoint`, `breakpointOnError`, `values`                             | [연결·구독·디버깅](./operators-lifecycle)            |
+
+## Combine과 Swift Concurrency를 구분해요
+
+둘 다 비동기 값을 다루지만 출발점이 달라요.
+
+| 질문           | Combine                                                         | Swift Concurrency                                                    |
+| -------------- | --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| 값의 형태      | 여러 Publisher를 연산자로 조합하는 반응형 파이프라인            | 한 번의 결과는 `async`, 여러 결과는 `AsyncSequence`로 표현           |
+| 취소           | `AnyCancellable` 또는 `Subscription`을 취소                     | `Task` 취소와 협력적 취소 확인                                       |
+| 오류 타입      | `Publisher<Output, Failure>`가 구체 오류 타입을 추적            | 일반적인 `throws`는 호출부에서 구체 오류 타입을 항상 보존하지는 않음 |
+| 시간 기반 연산 | `debounce`, `throttle`, `combineLatest` 같은 연산자를 기본 제공 | 필요한 동작을 `AsyncSequence` 알고리즘이나 별도 구현으로 구성        |
+| 연결           | `publisher.values`로 `AsyncSequence`처럼 순회                   | `AsyncPublisher`를 통해 Publisher의 값을 소비                        |
+
+여러 UI 입력을 합치고 시간 기반 제어가 많은 기존 Apple 플랫폼 코드라면 Combine이 자연스러워요. 한 번의 요청을 순서대로 읽는 로직은 `async`/`await`가 더 단순할 수 있어요. 둘 중 하나만 고집하기보다 값의 수명과 필요한 연산을 기준으로 선택하세요.
+
+## 언제 사용해야 하나요
+
+Combine이 잘 맞는 경우는 다음과 같아요.
+
+- 검색어, 네트워크 상태, 선택 값처럼 여러 비동기 상태를 계속 결합해야 해요.
+- 중복 제거, 지연, 재시도, 취소 같은 규칙을 하나의 흐름으로 읽고 싶어요.
+- UIKit·AppKit의 기존 이벤트나 Foundation Publisher를 연결해야 해요.
+- 이미 Combine 기반 API와 코드가 많은 프로젝트를 유지해요.
+
+반대로 단일 네트워크 요청 하나를 기다리는 코드는 `async`/`await`가 더 짧고 읽기 쉬울 수 있어요. 연산자를 많이 연결했다고 자동으로 좋은 구조가 되는 것은 아니에요. 파이프라인이 화면 상태 변경, 네트워크 정책, 데이터 변환을 모두 떠안으면 작은 이름 있는 메서드나 별도 타입으로 경계를 나누세요.
+
+## 적용 순서를 정리해요
+
+1. 값이 어디에서 시작되고 몇 번 도착하는지 정해요.
+2. `Output`과 `Failure` 타입을 확인해요.
+3. 변환, 필터링, 결합, 시간 제어를 각각 한 단계씩 연결해요.
+4. UI를 바꾼다면 `receive(on:)`으로 전달 위치를 명확히 해요.
+5. `sink`, `assign`, `values` 중 소비 방법을 선택해요.
+6. 취소 토큰의 소유자와 수명을 정해요.
+7. `handleEvents`나 테스트용 Subject로 값·완료·취소 경로를 검증해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Publisher와 Subscriber 사이에 Subscription이 왜 필요한가요?
+
+Subscription은 값의 요청과 취소를 담당하는 연결 객체예요. Subscriber가 처리 가능한 수요를 전달할 수 있어 빠른 Publisher가 소비자를 무제한 밀어붙이는 문제를 제어하고, 더 필요하지 않을 때 업스트림 작업을 취소할 수 있어요.
+
+### `PassthroughSubject`와 `CurrentValueSubject`는 무엇이 다른가요?
+
+`PassthroughSubject`는 구독 이후에 들어온 값만 전달하고 현재 값을 저장하지 않아요. `CurrentValueSubject`는 현재 값 하나를 보관하며 새 Subscriber에게 그 값을 즉시 전달하므로 상태를 표현할 때 적합해요.
+
+### `AnyCancellable`을 왜 프로퍼티에 보관하나요?
+
+`AnyCancellable`은 해제될 때 구독을 취소해요. 비동기 파이프라인이 객체의 수명 동안 유지되어야 한다면 같은 수명을 가진 프로퍼티나 집합에 토큰을 보관해야 해요.
+
+### Combine과 `AsyncSequence`를 함께 쓸 수 있나요?
+
+가능해요. Publisher의 `values` 프로퍼티를 `for await` 또는 `for try await`로 순회할 수 있어요. 다만 무한 Publisher를 순회하는 Task의 취소와 소유 수명도 함께 설계해야 해요.
+
+## 참고 자료
+
+- [Combine](https://developer.apple.com/documentation/combine)
+- [Publisher](https://developer.apple.com/documentation/combine/publisher)
+- [Receiving and Handling Events with Combine](https://developer.apple.com/documentation/combine/receiving-and-handling-events-with-combine)
+- [Processing Published Elements with Subscribers](https://developer.apple.com/documentation/combine/processing-published-elements-with-subscribers)
+- [Subject](https://developer.apple.com/documentation/combine/subject)
+- [Using Combine for Your App’s Asynchronous Code](https://developer.apple.com/documentation/combine/using-combine-for-your-app-s-asynchronous-code)

--- a/docs/guide/combine/operators-combine.md
+++ b/docs/guide/combine/operators-combine.md
@@ -1,0 +1,221 @@
+---
+title: Combine 연산자 — Publisher 결합
+description: combineLatest, merge, zip의 값 짝짓기 방식과 완료 조건을 비교하고 여러 Publisher를 안전하게 결합하는 방법을 Swift 예제로 설명합니다.
+---
+
+# Combine 연산자 — Publisher 결합
+
+> **면접 답변 한 줄 요약:** `combineLatest`는 각 Publisher의 최신 값을, `merge`는 같은 타입의 값을 도착 순서대로, `zip`은 소비하지 않은 값을 위치별 한 쌍으로 묶어요.
+
+여러 Publisher를 합칠 때 가장 중요한 질문은 **어떤 값끼리 결과 하나를 만들 것인가**예요. 세 연산자는 구독하는 Publisher 수가 같아도 값을 기다리고 소비하는 규칙이 서로 달라요.
+
+## 먼저 세 규칙을 비교해요
+
+| 연산자          | 결과를 만들 조건                                             | 이전 값 처리                                 | 출력 타입                         |
+| --------------- | ------------------------------------------------------------ | -------------------------------------------- | --------------------------------- |
+| `combineLatest` | 모든 Publisher가 한 번 이상 보낸 뒤 어느 하나가 새 값을 보냄 | 각 Publisher의 최신 값 하나를 기억           | 튜플 또는 변환 클로저의 반환 타입 |
+| `merge`         | 어느 Publisher든 값을 보냄                                   | 짝을 만들지 않고 바로 전달                   | 모든 Publisher와 같은 `Output`    |
+| `zip`           | 모든 Publisher에 아직 소비하지 않은 값이 하나 이상 있음      | Publisher별 대기열에서 가장 오래된 값을 소비 | 튜플 또는 변환 클로저의 반환 타입 |
+
+세 연산자 모두 여러 업스트림을 동시에 구독해요. 연결되는 Publisher들의 `Failure` 타입도 호환되어야 해요. 실패가 오면 아직 기다리던 값이 있어도 다운스트림으로 실패를 전달하고 끝날 수 있으므로 실패 경로도 설계해야 해요.
+
+## 각 Publisher의 최신 상태를 합쳐요
+
+<!-- combine-operator: combineLatest -->
+
+### `combineLatest`
+
+각 Publisher가 적어도 값 하나씩을 보낸 뒤부터, 어느 Publisher든 새 값을 보낼 때 모든 Publisher의 **현재 최신 값**을 묶어 보내요.
+
+```swift
+let query = PassthroughSubject<String, Never>()
+let isOnline = PassthroughSubject<Bool, Never>()
+
+let cancellable = query
+  .combineLatest(isOnline)
+  .sink { query, isOnline in
+    print(query, isOnline)
+  }
+
+query.send("Swift")    // isOnline의 값이 없어 아직 출력하지 않아요.
+isOnline.send(true)    // Swift true
+query.send("Combine")  // Combine true
+isOnline.send(false)   // Combine false
+```
+
+최신 값은 다시 사용돼요. `query`가 새 값을 보낼 때 직전 `isOnline` 값인 `true`를 함께 사용한 것이 핵심이에요.
+
+변환 클로저를 받는 오버로드는 튜플을 만든 뒤 바로 `map`하는 것과 같은 목적을 한 단계로 표현해요.
+
+```swift
+let canSearch = query
+  .combineLatest(isOnline) { query, isOnline in
+    !query.isEmpty && isOnline
+  }
+```
+
+한 번의 호출로 현재 Publisher를 포함해 최대 네 Publisher를 결합할 수 있어요.
+
+```swift
+let combined = first.combineLatest(second, third)
+let transformed = first.combineLatest(second, third) {
+  firstValue,
+  secondValue,
+  thirdValue in
+  // 세 값을 하나의 결과로 바꿔요.
+}
+```
+
+더 많은 상태는 작은 의미 단위로 먼저 결합한 뒤 그 결과를 다시 결합하거나, 별도 상태 타입을 만들어 읽기 쉬운 경계를 유지하세요.
+
+### 수요가 느리면 중간 상태가 합쳐질 수 있어요
+
+`combineLatest`는 각 업스트림의 최신 값 하나에 관심이 있어요. 다운스트림 수요가 부족한 동안 같은 업스트림에서 값이 여러 번 오면 모든 중간 조합을 보존하는 대기열로 생각하면 안 돼요. 모든 입력 쌍을 빠짐없이 처리해야 한다면 `zip`이나 별도 버퍼링 전략이 요구사항에 맞는지 확인하세요.
+
+## 같은 타입의 사건을 한 흐름으로 합쳐요
+
+<!-- combine-operator: merge -->
+
+### `merge(with:)`
+
+여러 Publisher의 값을 도착하는 대로 하나의 흐름에 섞어 보내요. 짝을 기다리지 않으므로 모든 Publisher의 `Output`과 `Failure` 타입이 같아야 해요.
+
+```swift
+enum RefreshReason {
+  case user
+  case foreground
+}
+
+let userRefresh = PassthroughSubject<RefreshReason, Never>()
+let foregroundRefresh = PassthroughSubject<RefreshReason, Never>()
+
+let cancellable = userRefresh
+  .merge(with: foregroundRefresh)
+  .sink { print($0) }
+
+userRefresh.send(.user)                  // user
+foregroundRefresh.send(.foreground)      // foreground
+userRefresh.send(.user)                  // user
+```
+
+“새로 고침을 요청하는 여러 원인”처럼 값의 의미가 같고 어느 쪽에서 왔는지 구분할 필요가 없을 때 적합해요. 출처가 필요하면 합치기 전에 `map`으로 태그를 붙이세요.
+
+```swift
+enum RefreshEvent {
+  case user
+  case foreground
+}
+
+let merged = userTap
+  .map { RefreshEvent.user }
+  .merge(
+    with: appDidEnterForeground
+      .map { RefreshEvent.foreground }
+  )
+```
+
+인스턴스 메서드 오버로드는 현재 Publisher를 포함해 최대 여덟 Publisher를 한 번에 합칠 수 있어요. 개수가 동적으로 정해진 같은 타입의 Publisher 배열은 `Publishers.MergeMany`를 사용해요.
+
+```swift
+let publishers: [AnyPublisher<Int, Never>] = [
+  first.eraseToAnyPublisher(),
+  second.eraseToAnyPublisher(),
+  third.eraseToAnyPublisher(),
+]
+
+let merged = Publishers.MergeMany(publishers)
+```
+
+`merge`는 모든 업스트림이 정상 완료해야 정상 완료해요. 하나라도 실패하면 합쳐진 Publisher도 실패해요.
+
+## 소비하지 않은 값을 순서대로 짝지어요
+
+<!-- combine-operator: zip -->
+
+### `zip`
+
+각 Publisher의 아직 소비하지 않은 가장 오래된 값끼리 묶어요. 한쪽이 빠르게 여러 값을 보내면 다른 쪽 값이 올 때까지 그 값들이 순서대로 기다려요.
+
+```swift
+let names = PassthroughSubject<String, Never>()
+let scores = PassthroughSubject<Int, Never>()
+
+let cancellable = names
+  .zip(scores)
+  .sink { name, score in
+    print(name, score)
+  }
+
+names.send("Blob")
+names.send("Swift")
+scores.send(90)  // Blob 90
+scores.send(80)  // Swift 80
+```
+
+`combineLatest`였다면 첫 `scores` 값이 온 순간 최신 이름인 `"Swift"`와 `90`을 묶었을 거예요. `zip`은 먼저 들어온 `"Blob"`을 소비하므로 입력 순서를 보존해요.
+
+변환 클로저를 받는 오버로드는 튜플을 바로 원하는 결과로 바꿔요.
+
+```swift
+let reports = names
+  .zip(scores) { name, score in
+    "\(name): \(score)점"
+  }
+```
+
+한 번의 호출로 현재 Publisher를 포함해 최대 네 Publisher를 묶을 수 있고, 각 개수에 변환 클로저 오버로드가 있어요.
+
+`zip`은 어떤 업스트림이 정상 완료하고 더 이상 완성할 묶음을 만들 수 없게 되면 끝나요. 속도 차이가 매우 크거나 한쪽이 오랫동안 값을 보내지 않으면 빠른 쪽의 소비되지 않은 값이 쌓일 수 있으므로 버퍼 크기와 종료 조건을 고려하세요.
+
+## 같은 입력으로 결과 차이를 확인해요
+
+두 Subject가 아래 순서로 값을 보낸다고 가정해요.
+
+```text
+A: A1 ── A2 ───────── A3
+B: ───────── B1 ─ B2
+```
+
+| 연산자          | 만들어지는 결과                                     |
+| --------------- | --------------------------------------------------- |
+| `combineLatest` | `(A2, B1)`, `(A2, B2)`, `(A3, B2)`                  |
+| `merge`         | 타입이 같다는 전제에서 `A1`, `A2`, `B1`, `B2`, `A3` |
+| `zip`           | `(A1, B1)`, `(A2, B2)`                              |
+
+`combineLatest`는 B의 첫 값이 오기 전 A1을 결과로 만들지 못하고, A2가 최신 값이 되어 A1을 대체해요. `zip`은 A1을 보관했다가 B1과 묶고, A2는 B2와 묶어요.
+
+## 어떤 연산자를 선택해야 하나요
+
+- 폼의 여러 입력값으로 현재 유효성을 계속 계산하면 `combineLatest`가 잘 맞아요.
+- 버튼 탭과 화면 진입처럼 같은 행동을 촉발하는 여러 사건을 하나로 모으면 `merge`가 자연스러워요.
+- 요청과 식별자, 이름과 점수처럼 순서대로 1:1 대응해야 하면 `zip`을 사용해요.
+- 새 Publisher가 올 때 이전 작업을 취소하려는 요구라면 결합 연산자가 아니라 `switchToLatest`를 검토해요.
+- 모든 내부 Publisher를 동시에 유지하며 출력을 합치려면 `flatMap`을 검토해요.
+
+## 적용 순서를 정리해요
+
+1. 결합할 Publisher의 `Output`과 `Failure` 타입을 적어요.
+2. 최신 값, 도착한 값, 소비하지 않은 값 중 무엇을 묶을지 정해요.
+3. 첫 결과가 나오기 위해 각 Publisher가 무엇을 보내야 하는지 확인해요.
+4. 속도가 다른 Publisher 사이에 값이 대기하거나 대체되는 규칙을 테스트해요.
+5. 하나가 실패하거나 먼저 완료할 때의 결과를 테스트해요.
+6. 결합 수가 많으면 의미 있는 중간 상태 타입으로 나눠요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `combineLatest`와 `zip`은 무엇이 다른가요?
+
+`combineLatest`는 각 Publisher의 최신 값을 기억하고 어느 하나가 갱신될 때 새 조합을 만들어요. `zip`은 각 Publisher에서 아직 소비하지 않은 가장 오래된 값을 한 번씩만 사용하므로 입력 순서를 맞춘 1:1 묶음에 적합해요.
+
+### `merge`에서 출력 타입이 같아야 하는 이유는 무엇인가요?
+
+`merge`는 값을 튜플로 묶지 않고 하나의 출력 흐름에 그대로 섞어요. 다운스트림이 단일 `Output` 타입으로 모든 값을 받아야 하므로 각 Publisher의 출력과 실패 타입이 같아야 해요.
+
+## 참고 자료
+
+- [Publisher — Collecting and republishing the latest elements from multiple publishers](https://developer.apple.com/documentation/combine/publisher#Collecting-and-republishing-the-latest-elements-from-multiple-publishers)
+- [Publisher — Republishing elements from multiple publishers as an interleaved stream](https://developer.apple.com/documentation/combine/publisher#Republishing-elements-from-multiple-publishers-as-an-interleaved-stream)
+- [Publisher — Collecting and republishing the oldest unconsumed elements from multiple publishers](https://developer.apple.com/documentation/combine/publisher#Collecting-and-republishing-the-oldest-unconsumed-elements-from-multiple-publishers)
+- [Publishers.CombineLatest](https://developer.apple.com/documentation/combine/publishers/combinelatest)
+- [Publishers.Merge](https://developer.apple.com/documentation/combine/publishers/merge)
+- [Publishers.Zip](https://developer.apple.com/documentation/combine/publishers/zip)

--- a/docs/guide/combine/operators-flatten-error.md
+++ b/docs/guide/combine/operators-flatten-error.md
@@ -1,0 +1,237 @@
+---
+title: Combine 연산자 — 평탄화와 오류 처리
+description: flatMap과 switchToLatest로 Publisher 안의 Publisher를 평탄화하고 catch, retry, assertNoFailure로 실패를 변환·복구하는 방법을 설명합니다.
+---
+
+# Combine 연산자 — 평탄화와 오류 처리
+
+> **면접 답변 한 줄 요약:** `flatMap`은 여러 내부 Publisher를 유지하며 출력을 합치고 `switchToLatest`는 최신 내부 Publisher만 남기며, 오류 처리 연산자는 실패를 대체·재시도하거나 개발 중 가정을 검증해요.
+
+`map`의 클로저가 Publisher를 반환하면 출력은 `Publisher<Publisher<...>>`처럼 한 겹 중첩돼요. 네트워크 요청이나 저장 작업처럼 입력마다 새 비동기 Publisher를 만들 때는 이 중첩을 평탄화해야 해요.
+
+## 먼저 `map`의 중첩을 확인해요
+
+```swift
+func loadProduct(id: Int) -> AnyPublisher<String, URLError> {
+  // 실제 앱에서는 URLSession Publisher를 반환해요.
+  Just("상품 \(id)")
+    .setFailureType(to: URLError.self)
+    .eraseToAnyPublisher()
+}
+
+let nested = [1, 2, 3].publisher
+  .setFailureType(to: URLError.self)
+  .map(loadProduct)
+```
+
+`nested`의 `Output`은 문자열이 아니라 `AnyPublisher<String, URLError>`예요. 문자열을 받으려면 내부 Publisher도 구독해 그 출력을 바깥 흐름으로 꺼내야 해요.
+
+## 모든 내부 Publisher의 출력을 합쳐요
+
+<!-- combine-operator: flatMap -->
+
+### `flatMap(maxPublishers:_:)`
+
+각 입력을 새 Publisher로 바꾸고, 활성화된 내부 Publisher들의 출력을 하나의 흐름으로 합쳐요.
+
+```swift
+let cancellable = [1, 2, 3].publisher
+  .setFailureType(to: URLError.self)
+  .flatMap { id in
+    loadProduct(id: id)
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+기본 `maxPublishers`는 `.unlimited`예요. 여러 입력이 빠르게 오면 여러 내부 Publisher를 동시에 구독하며, 완료 순서에 따라 결과 순서가 입력과 달라질 수 있어요.
+
+```swift
+let serial = ids
+  .flatMap(maxPublishers: .max(1)) { id in
+    loadProduct(id: id)
+  }
+```
+
+`.max(1)`은 동시에 활성화할 내부 Publisher를 하나로 제한해요. 다만 `flatMap`을 일반적인 직렬 작업 큐와 완전히 같다고 가정하지 말고, 업스트림과 내부 Publisher의 수요·버퍼 동작을 함께 테스트하세요.
+
+내부 Publisher와 바깥 Publisher의 `Failure` 타입은 호환되어야 해요. 한쪽이 `Never`이면 Combine이 제공하는 제약 오버로드가 실패 타입을 맞춰 주는 경우가 있지만, 코드 경계에서는 `setFailureType`이나 `mapError`로 의도를 명확히 표현하는 편이 읽기 쉬워요.
+
+### `flatMap`은 이전 작업을 자동으로 취소하지 않아요
+
+새 검색어가 올 때 이전 요청이 더 이상 필요 없더라도 `flatMap`은 이미 만든 내부 Publisher를 유지해요. 동시 작업 수 제한은 새 작업의 시작을 늦출 뿐 이전 작업을 최신 작업으로 교체하지 않아요. 최신 입력만 중요하다면 `switchToLatest`를 사용하세요.
+
+## 최신 내부 Publisher만 유지해요
+
+<!-- combine-operator: switchToLatest -->
+
+### `switchToLatest()`
+
+업스트림의 `Output` 자체가 Publisher일 때, 새 내부 Publisher가 오면 기존 내부 구독을 취소하고 최신 Publisher의 값만 전달해요.
+
+```swift
+let queries = PassthroughSubject<String, Never>()
+
+let results = queries
+  .map { query in
+    search(query)
+      .replaceError(with: [])
+      .eraseToAnyPublisher()
+  }
+  .switchToLatest()
+
+let cancellable = results
+  .sink { products in
+    print(products)
+  }
+```
+
+`"Sw"` 요청이 진행 중일 때 `"Swift"`가 오면 `"Sw"`의 내부 구독을 취소하고 새 검색 Publisher로 전환해요. 실제 네트워크 작업까지 중단되는지는 그 Publisher가 구독 취소를 기반 작업에 올바르게 전달하는지에 달려 있어요.
+
+`switchToLatest`는 바깥 Publisher와 내부 Publisher의 `Failure` 타입 관계에 맞는 여러 제약 오버로드를 제공해요. 둘 중 하나가 `Never`인 경우도 연결할 수 있지만, 최종 `Failure`가 무엇인지 IDE의 타입 정보로 확인하세요.
+
+## 실패를 다른 Publisher로 복구해요
+
+<!-- combine-operator: catch -->
+
+### `catch(_:)`
+
+업스트림이 실패하면 오류를 받아 **대체 Publisher 하나**를 반환해요. 정상 값과 정상 완료에는 개입하지 않아요.
+
+```swift
+enum LoadError: Error {
+  case offline
+}
+
+let remote = Fail<String, LoadError>(error: .offline)
+let cached = Just("캐시된 값")
+  .setFailureType(to: LoadError.self)
+
+let cancellable = remote
+  .catch { error in
+    print("원격 실패:", error)
+    return cached
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+
+// 원격 실패: offline
+// 캐시된 값
+// finished
+```
+
+대체 Publisher가 정상 완료하면 전체 흐름도 정상 완료하고, 대체 Publisher가 실패하면 그 실패가 전달돼요. `catch`는 원래 업스트림의 실패를 한 번 처리하는 연산자이지, 대체 Publisher의 실패를 같은 클로저로 계속 재귀 처리하지 않아요.
+
+대체 값 하나만 필요하고 오류 정보는 버려도 된다면 `replaceError(with:)`가 더 간단해요. 오류별로 다른 비동기 복구 흐름이 필요하면 `catch`가 적합해요.
+
+<!-- combine-operator: tryCatch -->
+
+### `tryCatch(_:)`
+
+오류 처리 클로저 자체가 던질 수 있는 `catch`예요. 복구 Publisher를 만들지 못하면 새 오류로 실패할 수 있고 반환 Publisher의 `Failure`는 `any Error`가 돼요.
+
+```swift
+enum RecoveryError: Error {
+  case cacheUnavailable
+}
+
+let cancellable = remote
+  .tryCatch { _ -> AnyPublisher<String, LoadError> in
+    guard cacheExists else {
+      throw RecoveryError.cacheUnavailable
+    }
+    return cached.eraseToAnyPublisher()
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+복구 로직이 던질 필요가 없다면 `catch`를 사용해 구체적인 `Failure` 타입을 유지하세요.
+
+## 같은 Publisher를 다시 구독해요
+
+<!-- combine-operator: retry -->
+
+### `retry(_:)`
+
+업스트림이 실패하면 지정한 횟수만큼 업스트림에 다시 구독해요. `retry(2)`는 최초 시도 뒤 최대 두 번 더 시도하므로 총 시도 횟수는 최대 세 번이에요.
+
+```swift
+let cancellable = requestPublisher
+  .retry(2)
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+재구독이 실제 작업을 새로 시작하는지는 업스트림 Publisher의 생성 방식에 달려 있어요. 예를 들어 `Future`는 생성 시 작업을 시작하고 결과를 저장하므로 같은 `Future`를 재구독해도 작업이 다시 실행되지 않을 수 있어요. 구독마다 작업을 새로 만들려면 `Deferred`로 감싸는 방식을 고려하세요.
+
+```swift
+let request = Deferred {
+  makeRequestPublisher()
+}
+.retry(2)
+```
+
+`retry`는 재시도 사이에 자동으로 기다리지 않고 오류 종류도 구분하지 않아요. 즉시 재시도하면 서버나 네트워크에 부담을 줄 수 있으므로, 일시적 오류만 골라 지수 백오프를 적용해야 한다면 `catch`, 지연 Publisher, 재시도 정책을 별도 함수로 구성하세요. 결제나 쓰기 요청은 멱등성도 확인해야 해요.
+
+## 실패하지 않는다는 가정을 검사해요
+
+<!-- combine-operator: assertNoFailure -->
+
+### `assertNoFailure(_:file:line:)`
+
+업스트림이 실패하지 않을 것이라는 개발자 가정을 표현해요. 값은 그대로 전달하고 반환 Publisher의 `Failure`는 `Never`가 되지만, 실제 실패가 오면 메시지와 소스 위치를 사용해 실행을 중단해요.
+
+```swift
+let configuration = loadConfiguration()
+  .assertNoFailure("앱 번들 설정은 항상 디코딩되어야 해요.")
+```
+
+실패가 사용자 환경에서 실제로 발생할 수 있다면 복구 수단으로 사용하면 안 돼요. `catch`, `replaceError`, 오류를 받는 `sink`로 정상적인 실패 경로를 처리하세요. `assertNoFailure`는 프로그램 불변식이 깨진 개발 오류를 찾는 도구예요.
+
+## 오류 처리 방법을 비교해요
+
+| 목표                                   | 연산자            | 완료 결과                                |
+| -------------------------------------- | ----------------- | ---------------------------------------- |
+| 오류 타입만 바꿔요                     | `mapError`        | 새 오류 타입으로 실패                    |
+| 실패를 값 하나로 바꿔요                | `replaceError`    | 대체 값 뒤 정상 완료, `Failure == Never` |
+| 실패를 다른 흐름으로 복구해요          | `catch`           | 대체 Publisher의 완료를 따름             |
+| 복구 흐름을 만들다 다시 던질 수 있어요 | `tryCatch`        | 던지면 `any Error`로 실패                |
+| 같은 업스트림을 다시 시도해요          | `retry`           | 성공하거나 재시도 소진 뒤 마지막 실패    |
+| 실패가 논리적으로 불가능함을 검사해요  | `assertNoFailure` | 실제 실패 시 실행 중단                   |
+
+## 적용 순서를 정리해요
+
+1. 입력마다 내부 Publisher를 만들 필요가 있는지 확인해요.
+2. 모든 내부 작업이 필요한지 최신 작업만 필요한지 정해요.
+3. 동시 작업 수와 결과 순서 요구사항을 정해요.
+4. 기술 오류를 `mapError`로 도메인 오류에 매핑해요.
+5. 복구 가능한 오류만 `catch`나 `retry`로 처리해요.
+6. 재시도의 간격, 최대 횟수, 멱등성, 취소 전파를 테스트해요.
+7. 실제 환경의 실패를 `assertNoFailure`로 숨기지 않아요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `flatMap`과 `switchToLatest`는 무엇이 다른가요?
+
+`flatMap`은 허용된 수만큼 내부 Publisher 구독을 함께 유지하고 모든 출력을 합쳐요. `switchToLatest`는 새 내부 Publisher가 오면 이전 구독을 취소하므로 검색 자동 완성처럼 최신 요청만 유효한 흐름에 적합해요.
+
+### `retry(3)`은 총 몇 번 요청하나요?
+
+최초 구독 한 번에 실패 후 재구독을 최대 세 번 추가하므로 총 네 번 시도할 수 있어요. 재시도 사이의 지연은 자동으로 생기지 않으며, Publisher가 구독마다 작업을 새로 만드는지도 확인해야 해요.
+
+## 참고 자료
+
+- [Publisher — Republishing elements by subscribing to new publishers](https://developer.apple.com/documentation/combine/publisher#Republishing-elements-by-subscribing-to-new-publishers)
+- [Publisher — Handling errors](https://developer.apple.com/documentation/combine/publisher#Handling-errors)
+- [Publishers.FlatMap](https://developer.apple.com/documentation/combine/publishers/flatmap)
+- [Publishers.SwitchToLatest](https://developer.apple.com/documentation/combine/publishers/switchtolatest)
+- [Publishers.Retry](https://developer.apple.com/documentation/combine/publishers/retry)

--- a/docs/guide/combine/operators-lifecycle.md
+++ b/docs/guide/combine/operators-lifecycle.md
@@ -1,0 +1,446 @@
+---
+title: Combine 연산자 — 연결·구독·디버깅
+description: encode, share, multicast, sink, assign, subscribe, values와 디버깅 연산자로 Combine 파이프라인의 연결·소비·관찰 방법을 설명합니다.
+---
+
+# Combine 연산자 — 연결·구독·디버깅
+
+> **면접 답변 한 줄 요약:** 연결 연산자는 업스트림 작업을 여러 Subscriber가 공유하거나 시작 시점을 제어하고, 구독 연산자는 값을 실제로 소비하며, 관찰 연산자는 흐름을 바꾸지 않고 생명 주기 이벤트를 확인해요.
+
+이 페이지는 Apple `Publisher` 문서의 **Encoding and decoding**, **Working with multiple subscribers**, **Performing type erasure**, **Adding explicit connectability**, **Connecting simple subscribers**, **Accessing elements asynchronously**, **Debugging** 항목을 모두 설명해요.
+
+## 먼저 중간 연산자와 최종 Subscriber를 구분해요
+
+`map`, `share`, `print` 같은 중간 연산자는 새 Publisher를 반환하므로 뒤에 다른 연산자를 연결할 수 있어요. `sink`와 `assign(to:on:)`은 값을 소비할 Subscriber를 만들고 `AnyCancellable`을 반환하므로 보통 파이프라인의 끝이에요.
+
+```text
+Publisher → 중간 연산자 → 중간 연산자 → Subscriber
+                                         └─ AnyCancellable
+```
+
+`subscribe(_:)`는 직접 만든 Subscriber나 Subject를 붙이는 더 낮은 수준의 연결 API예요.
+
+## 값을 데이터로 인코딩해요
+
+<!-- combine-operator: encode -->
+
+### `encode(encoder:)`
+
+`Output: Encodable`일 때 각 값을 지정한 `TopLevelEncoder`로 인코딩해요. `JSONEncoder`를 사용하면 출력은 `Data`가 돼요.
+
+```swift
+struct Draft: Codable {
+  let title: String
+}
+
+let cancellable = Just(Draft(title: "Combine"))
+  .encode(encoder: JSONEncoder())
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { data in
+      print(data.count)
+    }
+  )
+```
+
+인코딩이 실패할 수 있으므로 반환 Publisher의 `Failure`는 `any Error`예요. 도메인 오류 타입이 필요하면 뒤에서 `mapError`로 변환하세요.
+
+## 데이터를 값으로 디코딩해요
+
+<!-- combine-operator: decode -->
+
+### `decode(type:decoder:)`
+
+업스트림 출력이 `TopLevelDecoder.Input`과 같을 때 각 값을 지정한 `Decodable` 타입으로 변환해요.
+
+```swift
+let json = Data(#"{"title":"Combine"}"#.utf8)
+
+let cancellable = Just(json)
+  .decode(type: Draft.self, decoder: JSONDecoder())
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { draft in
+      print(draft.title)
+    }
+  )
+
+// Combine
+```
+
+디코딩 오류와 업스트림 오류를 모두 전달할 수 있어 `Failure`는 `any Error`예요. 배열 응답이면 `[Draft].self`처럼 실제 최상위 JSON 구조와 타입을 맞춰야 해요.
+
+## 구체 Publisher 타입을 감춰요
+
+<!-- combine-operator: eraseToAnyPublisher -->
+
+### `eraseToAnyPublisher()`
+
+긴 구체 Publisher 타입을 `AnyPublisher<Output, Failure>`로 감춰요. 값, 오류, 완료 동작을 바꾸지 않는 타입 소거 연산자예요.
+
+```swift
+protocol ProductLoading {
+  func load() -> AnyPublisher<[Product], LoadError>
+}
+
+func load() -> AnyPublisher<[Product], LoadError> {
+  request()
+    .map(\.products)
+    .eraseToAnyPublisher()
+}
+```
+
+반환 타입을 감추면 호출자가 내부 연산자 조합에 의존하지 않아 구현을 바꾸기 쉬워요. 그러나 파이프라인 중간마다 사용하면 컴파일러가 구체 타입을 최적화할 기회를 줄이고 타입 정보도 숨겨요. API 경계나 서로 다른 구체 Publisher를 같은 타입으로 보관해야 하는 곳에서 사용하세요.
+
+## 하나의 업스트림 구독을 공유해요
+
+<!-- combine-operator: share -->
+
+### `share()`
+
+여러 Subscriber가 같은 `share()` 결과 인스턴스를 구독할 때 하나의 업스트림 구독에서 받은 값과 완료를 함께 전달해요.
+
+```swift
+let sharedRequest = makeRequest()
+  .handleEvents(
+    receiveSubscription: { _ in
+      print("요청 시작")
+    }
+  )
+  .share()
+
+let first = sharedRequest
+  .sink(
+    receiveCompletion: { _ in },
+    receiveValue: { print("첫 번째:", $0) }
+  )
+
+let second = sharedRequest
+  .sink(
+    receiveCompletion: { _ in },
+    receiveValue: { print("두 번째:", $0) }
+  )
+```
+
+`share()`가 없으면 각 `sink`가 업스트림을 따로 구독해 네트워크 요청 같은 작업이 중복될 수 있어요. `Publishers.Share`는 대부분의 Publisher와 달리 클래스라서 참조 의미를 가지며, 같은 인스턴스를 보관하고 공유해야 효과가 있어요.
+
+Apple은 `share()`를 `multicast`에 `PassthroughSubject`와 암시적 `autoconnect()`를 조합한 것과 같은 동작으로 설명해요. 따라서 이전 값을 재생하는 캐시가 아니에요. 늦게 붙은 Subscriber는 이미 지나간 값을 받지 못할 수 있어요.
+
+## Subject를 선택하고 시작 시점을 직접 제어해요
+
+<!-- combine-operator: multicast -->
+
+### `multicast(_:)`와 `multicast(subject:)`
+
+하나의 업스트림 구독을 Subject를 통해 여러 Subscriber에 전달하는 `ConnectablePublisher`를 만들어요. Subscriber를 모두 먼저 붙인 뒤 `connect()`할 수 있어 시작 값의 누락을 피할 수 있어요.
+
+```swift
+let shared = [1, 2, 3].publisher
+  .multicast(subject: PassthroughSubject<Int, Never>())
+
+let first = shared.sink { print("첫 번째:", $0) }
+let second = shared.sink { print("두 번째:", $0) }
+
+let connection = shared.connect()
+```
+
+`connect()` 전에는 업스트림이 값을 보내지 않아요. 반환한 `Cancellable`을 취소하면 업스트림 연결을 끊을 수 있으므로 연결 수명도 보관해야 해요.
+
+두 오버로드는 Subject 제공 방법이 달라요.
+
+- `multicast { PassthroughSubject() }`는 클로저로 Subject를 만들어요.
+- `multicast(subject:)`는 호출자가 만든 하나의 Subject 인스턴스를 공유해요.
+
+`PassthroughSubject`는 과거 값을 재생하지 않고, `CurrentValueSubject`는 현재 값 하나를 새 Subscriber에게 보낼 수 있어요. 공유하려는 데이터의 의미에 맞는 Subject를 선택하세요.
+
+## 일반 Publisher에 명시적 연결을 추가해요
+
+<!-- combine-operator: makeConnectable -->
+
+### `makeConnectable()`
+
+`Failure == Never`인 일반 Publisher를 `ConnectablePublisher`로 감싸요. Subscriber를 먼저 구성한 다음 원하는 순간 `connect()`를 호출할 수 있어요.
+
+```swift
+let connectable = [1, 2, 3].publisher
+  .makeConnectable()
+
+let cancellable = connectable
+  .sink { print($0) }
+
+let connection = connectable.connect()
+```
+
+동기적으로 모든 값을 즉시 보내는 Publisher는 첫 Subscriber가 구독하자마자 끝날 수 있어요. 여러 Subscriber가 첫 값부터 함께 받아야 한다면 명시적 연결이 유용해요.
+
+<!-- combine-operator: autoconnect -->
+
+### `autoconnect()`
+
+`ConnectablePublisher`에 첫 Subscriber가 붙을 때 `connect()`를 자동 호출하는 일반 Publisher를 만들어요.
+
+```swift
+let cancellable = Timer
+  .publish(every: 1, on: .main, in: .common)
+  .autoconnect()
+  .sink { date in
+    print(date)
+  }
+```
+
+타이머처럼 별도의 `connect()` 토큰을 관리할 필요가 없는 단일 구독에 편리해요. 여러 Subscriber를 모두 준비한 뒤 정확히 같은 순간 시작해야 한다면 자동 연결 대신 `connect()`를 직접 호출하세요.
+
+## 클로저로 값을 소비해요
+
+<!-- combine-operator: sink -->
+
+### `sink(receiveCompletion:receiveValue:)`와 `sink(receiveValue:)`
+
+값과 완료를 클로저로 처리하는 `Subscribers.Sink`를 붙이고 `AnyCancellable`을 반환해요.
+
+```swift
+let cancellable = request
+  .sink(
+    receiveCompletion: { completion in
+      switch completion {
+      case .finished:
+        print("완료")
+      case let .failure(error):
+        print("실패:", error)
+      }
+    },
+    receiveValue: { value in
+      print("값:", value)
+    }
+  )
+```
+
+`Failure == Never`이면 완료 오류를 처리할 필요가 없는 `sink(receiveValue:)`를 사용할 수 있어요.
+
+```swift
+let cancellable = Just("완료")
+  .sink { print($0) }
+```
+
+`sink`는 구독 시 무제한 수요를 요청해요. 다운스트림 처리가 느리거나 메모리를 많이 사용한다면 클로저에서 블로킹하지 말고, `buffer`나 사용자 정의 Subscriber로 흐름 제어가 필요한지 검토하세요.
+
+클로저가 `self`를 강하게 잡고 `self`가 `AnyCancellable`을 보관하면 참조 순환이 생길 수 있어요. `[weak self]`가 항상 정답은 아니지만, 구독과 객체 중 어느 쪽이 어느 쪽을 소유해야 하는지 명시적으로 정해야 해요.
+
+## 프로퍼티에 값을 대입해요
+
+<!-- combine-operator: assign -->
+
+### `assign(to:on:)`
+
+`Failure == Never`인 Publisher의 각 값을 객체의 쓰기 가능한 키 경로에 대입하고 `AnyCancellable`을 반환해요.
+
+```swift
+final class LabelModel {
+  var text = ""
+}
+
+let model = LabelModel()
+
+let cancellable = Just("Combine")
+  .assign(to: \.text, on: model)
+```
+
+`Subscribers.Assign`은 대상 객체를 강하게 참조해요. 대상 객체가 이 `AnyCancellable`을 다시 보관하면 참조 순환이 생길 수 있으므로 수명을 확인하세요.
+
+### `assign(to:)`
+
+`@Published` 프로퍼티의 투영 Publisher에 값을 다시 게시해요.
+
+```swift
+final class ClockModel: ObservableObject {
+  @Published var now = Date()
+
+  init() {
+    Timer
+      .publish(every: 1, on: .main, in: .common)
+      .autoconnect()
+      .assign(to: &$now)
+  }
+}
+```
+
+이 오버로드는 `Published` 저장소의 수명에 구독을 묶고 `AnyCancellable`을 반환하지 않아요. `Published`가 해제되면 자동으로 구독이 취소돼요. 수동 취소가 필요하다면 `sink`나 `assign(to:on:)`을 사용하세요.
+
+## 직접 만든 Subscriber나 Subject를 연결해요
+
+<!-- combine-operator: subscribe -->
+
+### `subscribe(_:)`
+
+`Subscriber`를 따르는 사용자 정의 타입이나 Combine 제공 Subscriber를 Publisher에 붙여요. `Input`은 Publisher의 `Output`, Subscriber의 `Failure`는 Publisher의 `Failure`와 같아야 해요.
+
+```swift
+let subscriber = Subscribers.Sink<Int, Never>(
+  receiveCompletion: { print($0) },
+  receiveValue: { print($0) }
+)
+
+[1, 2, 3].publisher
+  .subscribe(subscriber)
+```
+
+`Subject`를 전달하는 오버로드는 Publisher의 값을 Subject로 전달하고 연결을 취소할 `AnyCancellable`을 반환해요.
+
+```swift
+let subject = PassthroughSubject<Int, Never>()
+let forwarding = [1, 2, 3].publisher
+  .subscribe(subject)
+```
+
+`Publisher`를 직접 구현할 때는 프로토콜 요구사항인 `receive(subscriber:)`에서 구독을 설정해요. 사용하는 쪽에서는 `receive(subscriber:)`를 직접 호출하지 않고 `subscribe(_:)`를 호출하세요. Combine이 제공하는 기본 `subscribe(_:)`가 요구사항으로 전달해요.
+
+## `async`/`await`로 값을 순회해요
+
+### `values`
+
+`values`는 메서드형 연산자는 아니지만 Publisher를 `AsyncSequence`처럼 소비하게 하는 공식 브리지예요.
+
+`Failure == Never`인 Publisher는 `for await`로 순회해요.
+
+```swift
+let task = Task {
+  for await value in model.$query.values {
+    print(value)
+  }
+}
+```
+
+실패할 수 있는 Publisher는 `for try await`로 순회해요.
+
+```swift
+let task = Task {
+  do {
+    for try await value in request.values {
+      print(value)
+    }
+  } catch {
+    print("실패:", error)
+  }
+}
+```
+
+끝나지 않는 Publisher를 순회하는 Task는 소유 객체가 사라질 때 취소하는 등 수명을 관리해야 해요. Combine 파이프라인의 여러 시간·결합 연산자를 그대로 활용한 뒤 소비 부분만 구조적 동시성 문법으로 읽고 싶을 때 유용해요.
+
+## 생명 주기 이벤트를 관찰해요
+
+<!-- combine-operator: handleEvents -->
+
+### `handleEvents(receiveSubscription:receiveOutput:receiveCompletion:receiveCancel:receiveRequest:)`
+
+구독, 값, 완료, 취소, 수요 요청을 선택적으로 관찰하는 클로저를 받아요. 값과 완료를 바꾸지 않고 그대로 전달해요.
+
+```swift
+let observed = request
+  .handleEvents(
+    receiveSubscription: { _ in
+      print("구독")
+    },
+    receiveOutput: { value in
+      print("값:", value)
+    },
+    receiveCompletion: { completion in
+      print("완료:", completion)
+    },
+    receiveCancel: {
+      print("취소")
+    },
+    receiveRequest: { demand in
+      print("수요:", demand)
+    }
+  )
+```
+
+로딩 표시, 메트릭, 디버깅 로그처럼 파이프라인 생명 주기에 붙는 부수 효과에 적합해요. 핵심 데이터 변환을 숨겨 넣으면 흐름을 읽기 어려워지므로 값 변경은 `map` 같은 전용 연산자에 두세요.
+
+<!-- combine-operator: print -->
+
+### `print(_:to:)`
+
+구독, 수요, 값, 완료, 취소 이벤트를 텍스트로 기록해요. 첫 문자열은 여러 파이프라인 로그를 구분하는 접두사예요.
+
+```swift
+let cancellable = [1, 2, 3].publisher
+  .print("numbers")
+  .sink { _ in }
+```
+
+기본 출력 대상은 표준 출력이에요. `TextOutputStream`을 따르는 대상을 `to:`에 전달할 수 있어요. 출력 형식은 프로그램 로직이나 테스트 계약으로 파싱하지 말고 진단 용도로만 사용하세요.
+
+<!-- combine-operator: breakpoint -->
+
+### `breakpoint(receiveSubscription:receiveOutput:receiveCompletion:)`
+
+각 클로저가 `true`를 반환한 생명 주기 이벤트에서 디버거가 멈출 수 있도록 트랩을 발생시켜요.
+
+```swift
+let debugged = values
+  .breakpoint(
+    receiveOutput: { value in
+      value < 0
+    }
+  )
+```
+
+특정 값이나 완료 상태가 발생하는 순간 호출 스택을 확인할 때 사용해요. 일반 오류 처리나 사용자에게 보여 줄 검증 로직을 대신하지 않아요.
+
+<!-- combine-operator: breakpointOnError -->
+
+### `breakpointOnError()`
+
+업스트림에서 실패 완료를 받으면 디버거가 멈출 수 있도록 트랩을 발생시키는 `breakpoint`의 편의 연산자예요.
+
+```swift
+let debuggedRequest = request
+  .breakpointOnError()
+```
+
+재현하기 어려운 실패의 최초 전달 위치를 조사할 때 유용해요. 배포 동작을 위한 복구 코드는 `catch`, `retry`, 오류를 받는 `sink`에 따로 작성하세요.
+
+## 공유와 구독 방법을 비교해요
+
+| 목표                                            | 선택                              |
+| ----------------------------------------------- | --------------------------------- |
+| 여러 Subscriber가 업스트림 하나를 자동으로 공유 | `share()`                         |
+| Subject 종류와 시작 순간을 직접 제어            | `multicast` + `connect()`         |
+| 실패하지 않는 일반 Publisher의 시작만 직접 제어 | `makeConnectable()` + `connect()` |
+| Connectable Publisher를 첫 구독에 자동 연결     | `autoconnect()`                   |
+| 클로저로 값과 완료를 처리                       | `sink`                            |
+| 객체 프로퍼티에 바로 대입                       | `assign`                          |
+| 수요를 직접 제어하는 Subscriber를 연결          | `subscribe(_:)`                   |
+| Task에서 비동기 시퀀스로 순회                   | `values`                          |
+
+## 적용 순서를 정리해요
+
+1. Subscriber마다 업스트림 작업을 새로 수행할지 공유할지 정해요.
+2. 모든 Subscriber가 준비된 뒤 시작해야 하는지 확인해요.
+3. `sink`, `assign`, `values`, 사용자 정의 Subscriber 중 소비 방식을 선택해요.
+4. `AnyCancellable`, 연결 토큰, Task의 소유 수명을 정해요.
+5. `share`가 과거 값을 재생하는 캐시는 아니라는 점을 테스트해요.
+6. `handleEvents`로 구독·완료·취소 전파를 관찰해요.
+7. API 경계에서만 필요한 만큼 타입을 소거해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `share`와 `multicast`는 무엇이 다른가요?
+
+`share`는 `PassthroughSubject` 기반 공유와 자동 연결을 간단히 제공해요. `multicast`는 사용할 Subject와 `connect()` 시점을 직접 정할 수 있어 여러 Subscriber를 먼저 연결한 뒤 동시에 시작해야 할 때 적합해요.
+
+### `assign(to:)`가 `AnyCancellable`을 반환하지 않는 이유는 무엇인가요?
+
+`@Published` 저장소가 구독의 수명을 관리하고 해제될 때 자동으로 취소하기 때문이에요. 수동 취소가 필요하면 취소 토큰을 반환하는 `assign(to:on:)`이나 `sink`를 사용해야 해요.
+
+## 참고 자료
+
+- [Publisher — Encoding and decoding](https://developer.apple.com/documentation/combine/publisher#Encoding-and-decoding)
+- [Publisher — Working with multiple subscribers](https://developer.apple.com/documentation/combine/publisher#Working-with-multiple-subscribers)
+- [Publisher — Connecting simple subscribers](https://developer.apple.com/documentation/combine/publisher#Connecting-simple-subscribers)
+- [Publisher — Debugging](https://developer.apple.com/documentation/combine/publisher#Debugging)
+- [Controlling Publishing with Connectable Publishers](https://developer.apple.com/documentation/combine/controlling-publishing-with-connectable-publishers)
+- [ConnectablePublisher](https://developer.apple.com/documentation/combine/connectablepublisher)
+- [Publishers.Share](https://developer.apple.com/documentation/combine/publishers/share)
+- [Processing Published Elements with Subscribers](https://developer.apple.com/documentation/combine/processing-published-elements-with-subscribers)

--- a/docs/guide/combine/operators-map-filter.md
+++ b/docs/guide/combine/operators-map-filter.md
@@ -1,0 +1,400 @@
+---
+title: Combine 연산자 — 변환과 필터링
+description: map, scan, filter, compactMap, removeDuplicates와 try 변형 등 Combine의 값·오류 타입 변환 및 필터링 연산자를 예제로 설명합니다.
+---
+
+# Combine 연산자 — 변환과 필터링
+
+> **면접 답변 한 줄 요약:** Combine의 변환 연산자는 값이나 오류의 타입을 바꾸고, 필터링 연산자는 조건에 맞는 값만 통과시키며, `try` 변형은 클로저가 던진 오류를 파이프라인의 실패로 바꿔요.
+
+이 페이지는 Apple `Publisher` 문서의 **Mapping elements**와 **Filtering elements**에 속한 연산자를 모두 설명해요. 예제는 각각 독립적으로 실행할 수 있으며, 출력 확인을 위해 `sink`를 사용해요.
+
+## 먼저 알아둘 타입 변화
+
+| 연산자 종류                  | `Output` 변화                    | `Failure` 변화                        |
+| ---------------------------- | -------------------------------- | ------------------------------------- |
+| 일반 `map`, `filter`, `scan` | 연산자에 따라 유지되거나 새 타입 | 업스트림 `Failure`를 유지             |
+| `try`로 시작하는 연산자      | 연산자에 따라 유지되거나 새 타입 | 클로저가 던질 수 있어 `any Error`     |
+| `mapError`                   | 그대로 유지                      | 클로저가 반환하는 새 오류 타입        |
+| `setFailureType`             | 그대로 유지                      | `Never`에서 지정한 오류 타입으로 맞춤 |
+
+`try` 연산자는 단순히 문법이 다른 것이 아니라 파이프라인의 `Failure` 타입을 바꿔요. 클로저가 실제로 던질 일이 없다면 일반 연산자를 사용해야 뒤쪽의 오류 타입도 단순하게 유지돼요.
+
+## 값을 다른 형태로 바꿔요
+
+<!-- combine-operator: map -->
+
+### `map(_:)`
+
+업스트림의 모든 값을 클로저로 변환해요. 값의 개수와 완료 이벤트는 유지하고 `Output` 타입만 바꿀 수 있어요.
+
+```swift
+let cancellable = [1, 2, 3].publisher
+  .map { "상품 \($0)" }
+  .sink { print($0) }
+
+// 상품 1
+// 상품 2
+// 상품 3
+```
+
+`map(\.name)`처럼 키 경로 하나를 전달할 수 있고, `map(\.name, \.price)`와 세 개의 키 경로 오버로드는 여러 프로퍼티를 튜플로 뽑아요. 키 경로 오버로드는 단순 프로퍼티 추출 의도를 클로저보다 짧게 표현해요.
+
+<!-- combine-operator: tryMap -->
+
+### `tryMap(_:)`
+
+변환 중 오류를 던질 수 있는 `map`이에요. 던진 오류는 `.failure(error)` 완료가 되고 이후 값은 전달되지 않아요. 반환 Publisher의 `Failure`는 `any Error`예요.
+
+```swift
+enum ParseError: Error {
+  case invalidNumber
+}
+
+let cancellable = ["10", "없음"].publisher
+  .tryMap { text in
+    guard let number = Int(text) else {
+      throw ParseError.invalidNumber
+    }
+    return number
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+
+// 10
+// failure(ParseError.invalidNumber)
+```
+
+<!-- combine-operator: replaceNil -->
+
+### `replaceNil(with:)`
+
+`Output`이 옵셔널일 때 `nil`을 지정한 값으로 바꾸고 옵셔널을 벗겨요. Publisher가 아무 값도 보내지 않는 상황은 `nil`과 다르므로 `replaceEmpty(with:)`를 사용해야 해요.
+
+```swift
+let cancellable = [1, nil, 3].publisher
+  .replaceNil(with: 0)
+  .sink { print($0) }
+
+// 1
+// 0
+// 3
+```
+
+## 이전 결과를 기억하며 변환해요
+
+<!-- combine-operator: scan -->
+
+### `scan(_:_:)`
+
+초기 누적값과 현재 값을 클로저에 전달하고, 계산된 누적값을 **입력마다** 내보내요. 최종 결과 하나만 내보내는 `reduce`와 달라요.
+
+```swift
+let cancellable = [10, -3, 5].publisher
+  .scan(0, +)
+  .sink { print($0) }
+
+// 10
+// 7
+// 12
+```
+
+장바구니 합계나 진행 중 상태처럼 중간 누적값도 필요할 때 사용해요. 누적값이 큰 컬렉션이면 값마다 복사 비용이 생길 수 있으므로 상태 크기도 확인하세요.
+
+<!-- combine-operator: tryScan -->
+
+### `tryScan(_:_:)`
+
+누적 클로저가 오류를 던질 수 있는 `scan`이에요. 유효하지 않은 중간 상태를 발견하면 실패로 끝낼 수 있으며 `Failure`는 `any Error`가 돼요.
+
+```swift
+enum BalanceError: Error {
+  case overdrawn
+}
+
+let cancellable = [10, -3, -8].publisher
+  .tryScan(0) { balance, change in
+    let next = balance + change
+    guard next >= 0 else {
+      throw BalanceError.overdrawn
+    }
+    return next
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+
+// 10
+// 7
+// failure(BalanceError.overdrawn)
+```
+
+## 오류 타입을 바꿔요
+
+<!-- combine-operator: mapError -->
+
+### `mapError(_:)`
+
+업스트림의 실패만 다른 오류 타입으로 변환해요. 정상 값은 그대로 통과하고, 실패하지 않으면 클로저도 호출되지 않아요.
+
+```swift
+enum APIError: Error {
+  case requestFailed
+}
+
+let request = Fail<Int, URLError>(
+  error: URLError(.notConnectedToInternet)
+)
+
+let cancellable = request
+  .mapError { _ in APIError.requestFailed }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+하위 계층의 `URLError`, 디코딩 오류 등을 화면 계층이 이해하는 도메인 오류로 모을 때 유용해요. 원래 원인까지 진단해야 한다면 새 오류의 연관 값에 원본 오류를 보관하세요.
+
+<!-- combine-operator: setFailureType -->
+
+### `setFailureType(to:)`
+
+`Failure == Never`인 Publisher가 지정한 오류 타입으로 실패하는 것처럼 타입만 맞춰요. 실제 오류를 새로 만들거나 보내지는 않아요.
+
+```swift
+enum SearchError: Error {
+  case unavailable
+}
+
+let local = Just("저장된 결과")
+  .setFailureType(to: SearchError.self)
+
+let remote = Fail<String, SearchError>(error: .unavailable)
+
+let cancellable = local
+  .append(remote)
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+실패하지 않는 로컬 Publisher를 실패 가능한 원격 Publisher와 결합할 때처럼 `Failure` 타입을 일치시키는 용도예요. 이미 실패 가능한 Publisher의 오류를 바꾸려면 `mapError`를 사용해요.
+
+## 조건에 맞는 값만 통과시켜요
+
+<!-- combine-operator: filter -->
+
+### `filter(_:)`
+
+조건 클로저가 `true`를 반환한 값만 다운스트림으로 보내요. 걸러진 값은 실패가 아니며 조용히 사라져요.
+
+```swift
+let cancellable = [1, 2, 3, 4].publisher
+  .filter { $0.isMultiple(of: 2) }
+  .sink { print($0) }
+
+// 2
+// 4
+```
+
+<!-- combine-operator: tryFilter -->
+
+### `tryFilter(_:)`
+
+조건을 계산하다 오류를 던질 수 있는 `filter`예요. 오류를 던지면 파이프라인이 실패하고 `Failure`는 `any Error`가 돼요.
+
+```swift
+enum ValidationError: Error {
+  case negative
+}
+
+let cancellable = [1, -1, 2].publisher
+  .tryFilter { value in
+    guard value >= 0 else {
+      throw ValidationError.negative
+    }
+    return value.isMultiple(of: 2)
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+단순히 조건에 맞지 않는 값은 `false`, 데이터 자체가 잘못되어 흐름을 중단해야 하는 상황은 `throw`로 구분할 수 있어요.
+
+<!-- combine-operator: compactMap -->
+
+### `compactMap(_:)`
+
+각 값을 새 값으로 변환하되 클로저가 `nil`을 반환한 입력은 버려요. `map`과 `filter`를 한 단계로 합친 형태예요.
+
+```swift
+let cancellable = ["10", "없음", "30"].publisher
+  .compactMap(Int.init)
+  .sink { print($0) }
+
+// 10
+// 30
+```
+
+파싱 실패를 무시해도 되는 입력에 적합해요. 실패 이유가 중요하거나 잘못된 입력에서 흐름을 끝내야 한다면 `tryMap`을 사용하세요.
+
+<!-- combine-operator: tryCompactMap -->
+
+### `tryCompactMap(_:)`
+
+`nil`이면 값을 버리고, 오류를 던지면 실패로 끝내는 `compactMap`이에요. “없는 값”과 “잘못된 값”을 나눌 때 사용해요.
+
+```swift
+enum ScoreError: Error {
+  case outOfRange
+}
+
+let cancellable = ["42", "", "120"].publisher
+  .tryCompactMap { text -> Int? in
+    guard !text.isEmpty else { return nil }
+    guard let score = Int(text), 0...100 ~= score else {
+      throw ScoreError.outOfRange
+    }
+    return score
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 연속된 중복을 제거해요
+
+<!-- combine-operator: removeDuplicates -->
+
+### `removeDuplicates()`와 `removeDuplicates(by:)`
+
+바로 앞에서 통과시킨 값과 같은 새 값을 버려요. 전체 이력을 검사하는 집합 연산이 아니므로 `1, 2, 1`은 세 값 모두 통과해요.
+
+```swift
+let cancellable = [1, 1, 2, 2, 1].publisher
+  .removeDuplicates()
+  .sink { print($0) }
+
+// 1
+// 2
+// 1
+```
+
+매개변수 없는 오버로드는 `Output: Equatable`일 때 `==`를 사용해요. `removeDuplicates(by:)`는 두 값이 중복인지 직접 판단하므로 식별자나 일부 프로퍼티만 비교할 수 있어요.
+
+```swift
+struct Product {
+  let id: Int
+  let name: String
+}
+
+let products = [
+  Product(id: 1, name: "연필"),
+  Product(id: 1, name: "연필"),
+  Product(id: 2, name: "지우개"),
+]
+
+let cancellable = products.publisher
+  .removeDuplicates { $0.id == $1.id }
+  .sink { print($0.name) }
+```
+
+<!-- combine-operator: tryRemoveDuplicates -->
+
+### `tryRemoveDuplicates(by:)`
+
+중복 비교가 오류를 던질 수 있는 변형이에요. 비교 중 던진 오류는 실패 완료가 되고 `Failure`는 `any Error`로 바뀌어요.
+
+```swift
+enum ComparisonError: Error {
+  case invalidID
+}
+
+let cancellable = products.publisher
+  .tryRemoveDuplicates { previous, current in
+    guard previous.id > 0, current.id > 0 else {
+      throw ComparisonError.invalidID
+    }
+    return previous.id == current.id
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0.name) }
+  )
+```
+
+비교가 실패할 이유가 없다면 일반 `removeDuplicates(by:)`를 사용해 오류 타입을 넓히지 마세요.
+
+## 값이 없거나 실패했을 때 대체해요
+
+<!-- combine-operator: replaceEmpty -->
+
+### `replaceEmpty(with:)`
+
+업스트림이 값을 하나도 보내지 않고 정상 완료하면 대체 값 하나를 보낸 뒤 정상 완료해요. 업스트림이 실패하면 대체하지 않고 실패를 그대로 전달해요.
+
+```swift
+let cancellable = Empty<String, Never>()
+  .replaceEmpty(with: "검색 결과 없음")
+  .sink { print($0) }
+
+// 검색 결과 없음
+```
+
+`filter`나 `compactMap` 뒤에서 모든 값이 제거된 경우에도 사용할 수 있어요. `nil` 값 하나를 바꾸는 `replaceNil(with:)`와 구분하세요.
+
+<!-- combine-operator: replaceError -->
+
+### `replaceError(with:)`
+
+업스트림이 실패하면 오류 대신 대체 값 하나를 보내고 **정상 완료**해요. 반환 Publisher의 `Failure`는 `Never`가 돼요.
+
+```swift
+let cancellable = Fail<Int, URLError>(
+  error: URLError(.timedOut)
+)
+.replaceError(with: -1)
+.sink { print($0) }
+
+// -1
+```
+
+오류 정보를 버리므로 “대체 값을 보여 주면 충분한가?”를 먼저 판단해야 해요. 오류에 따라 다른 Publisher로 복구하거나 로그를 남겨야 한다면 `catch`가 더 적합해요.
+
+## 비슷한 연산자를 비교해요
+
+| 원하는 동작                                 | 연산자          |
+| ------------------------------------------- | --------------- |
+| 모든 입력을 다른 값으로 바꿔요              | `map`           |
+| 변환 실패를 오류로 끝내요                   | `tryMap`        |
+| 변환 결과가 없는 입력만 버려요              | `compactMap`    |
+| 없는 입력은 버리고 잘못된 입력은 실패시켜요 | `tryCompactMap` |
+| 입력마다 현재 누적값을 보내요               | `scan`          |
+| 마지막 누적값 하나만 보내요                 | `reduce`        |
+| `nil`이라는 값을 바꿔요                     | `replaceNil`    |
+| 값 없이 정상 완료한 흐름에 값을 넣어요      | `replaceEmpty`  |
+| 실패한 흐름을 대체 값으로 정상 완료시켜요   | `replaceError`  |
+
+## 적용 기준을 정리해요
+
+1. `Output`만 바꿀지, 값의 개수도 줄일지 먼저 정해요.
+2. “버릴 값”과 “실패시킬 값”을 구분해요.
+3. 클로저가 던질 필요가 없으면 `try`가 없는 연산자를 선택해요.
+4. `try` 연산자 뒤에서 도메인 오류가 필요하면 `mapError`로 다시 제한해요.
+5. `replaceError`가 원인을 숨겨도 되는지 확인해요.
+6. 상태 누적은 `scan`, 최종 집계는 `reduce`로 구분해요.
+
+## 참고 자료
+
+- [Publisher — Mapping elements](https://developer.apple.com/documentation/combine/publisher#Mapping-elements)
+- [Publisher — Filtering elements](https://developer.apple.com/documentation/combine/publisher#Filtering-elements)
+- [Publishers.Map](https://developer.apple.com/documentation/combine/publishers/map)
+- [Publishers.RemoveDuplicates](https://developer.apple.com/documentation/combine/publishers/removeduplicates)

--- a/docs/guide/combine/operators-reduce-match.md
+++ b/docs/guide/combine/operators-reduce-match.md
@@ -1,0 +1,350 @@
+---
+title: Combine 연산자 — 축약과 조건 판정
+description: collect, reduce, count, min, max, contains, allSatisfy 등 여러 값을 모으거나 최종 결과와 조건 판정을 만드는 Combine 연산자를 설명합니다.
+---
+
+# Combine 연산자 — 축약과 조건 판정
+
+> **면접 답변 한 줄 요약:** 축약 연산자는 여러 입력을 배열이나 값 하나로 모으고, 조건 판정 연산자는 입력을 검사해 `Bool` 하나를 내보내며, 대부분 업스트림이 완료되어야 최종 결과를 확정해요.
+
+이 페이지는 Apple `Publisher` 문서의 **Reducing elements**, **Applying mathematical operations on elements**, **Applying matching criteria to elements**에 속한 연산자를 모두 설명해요.
+
+## 먼저 완료 시점을 확인해요
+
+`collect()`, `reduce`, `count`, `min`, `max`는 앞으로 값이 더 올 수 있는 동안 최종 결과를 알 수 없어요. 따라서 유한한 업스트림이 정상 완료해야 값을 내보내요. 끝나지 않는 타이머나 Subject에 그대로 사용하면 결과도 영원히 나오지 않을 수 있어요.
+
+반면 아래 조건 판정은 답이 확정되는 순간 일찍 끝날 수 있어요.
+
+- `contains`는 일치하는 값 하나를 찾으면 `true`를 보내고 끝나요.
+- `allSatisfy`는 조건을 어기는 값 하나를 찾으면 `false`를 보내고 끝나요.
+
+## 값을 배열로 모아요
+
+<!-- combine-operator: collect -->
+
+### `collect()`, `collect(_:)`, `collect(_:options:)`
+
+`collect()`는 정상 완료할 때까지 모든 값을 배열에 모아 한 번 내보내요.
+
+```swift
+let cancellable = [1, 2, 3].publisher
+  .collect()
+  .sink { print($0) }
+
+// [1, 2, 3]
+```
+
+입력이 많거나 끝나지 않으면 메모리 사용량도 계속 늘어나요. 전체 값이 꼭 필요하지 않다면 개수나 시간 기준 오버로드를 사용하세요.
+
+`collect(_:)`는 지정한 최대 개수씩 배열로 묶어요. 마지막 묶음은 개수보다 작을 수 있어요.
+
+```swift
+let cancellable = [1, 2, 3, 4, 5].publisher
+  .collect(2)
+  .sink { print($0) }
+
+// [1, 2]
+// [3, 4]
+// [5]
+```
+
+`collect(_:options:)`의 첫 매개변수는 `Publishers.TimeGroupingStrategy`예요.
+
+- `.byTime(scheduler, interval)`은 일정 시간마다 모은 값을 보내요.
+- `.byTimeOrCount(scheduler, interval, count)`는 시간이나 개수 중 먼저 충족한 기준으로 보내요.
+- `options`는 선택한 스케줄러에 전달할 실행 옵션이에요.
+
+```swift
+let cancellable = subject
+  .collect(
+    .byTimeOrCount(
+      DispatchQueue.main,
+      .seconds(1),
+      20
+    )
+  )
+  .sink { batch in
+    print("한 번에 처리할 값:", batch)
+  }
+```
+
+시간 기반 묶음은 다운스트림 호출 횟수를 줄여요. 다만 업스트림이 매우 빠르면 묶음 안의 값이 많아질 수 있으므로 개수 제한도 함께 고려하세요.
+
+## 값은 버리고 완료만 전달해요
+
+<!-- combine-operator: ignoreOutput -->
+
+### `ignoreOutput()`
+
+업스트림의 모든 값을 버리고 정상 완료나 실패만 전달해요. 반환 Publisher의 `Output` 타입 자체는 유지되지만 실제 출력은 없어요.
+
+```swift
+let cancellable = [1, 2, 3].publisher
+  .ignoreOutput()
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print("호출되지 않음:", $0) }
+  )
+
+// finished
+```
+
+값은 필요 없고 작업의 성공·실패가 끝나는 시점만 다음 단계에 연결할 때 유용해요.
+
+## 마지막 누적값 하나를 만들어요
+
+<!-- combine-operator: reduce -->
+
+### `reduce(_:_:)`
+
+초기값과 각 입력을 누적한 뒤 업스트림이 정상 완료하면 마지막 결과 하나를 보내요.
+
+```swift
+let cancellable = [10, -3, 5].publisher
+  .reduce(0, +)
+  .sink { print($0) }
+
+// 12
+```
+
+입력마다 중간 누적값도 필요하면 `scan`을 사용해요. 큰 배열을 계속 복사하는 누적 클로저는 성능 비용이 커질 수 있으므로 필요한 정보만 누적하세요.
+
+<!-- combine-operator: tryReduce -->
+
+### `tryReduce(_:_:)`
+
+누적 클로저가 오류를 던질 수 있는 `reduce`예요. 오류가 발생하면 최종 값 없이 실패하고 `Failure`는 `any Error`가 돼요.
+
+```swift
+enum TotalError: Error {
+  case negativePrice
+}
+
+let cancellable = [10, 20, -1].publisher
+  .tryReduce(0) { total, price in
+    guard price >= 0 else {
+      throw TotalError.negativePrice
+    }
+    return total + price
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 값의 개수를 세어요
+
+<!-- combine-operator: count -->
+
+### `count()`
+
+업스트림이 정상 완료하면 받은 값의 개수를 `Int` 하나로 보내요. 실패하면 개수를 보내지 않고 실패를 전달해요.
+
+```swift
+let cancellable = ["A", "B", "C"].publisher
+  .count()
+  .sink { print($0) }
+
+// 3
+```
+
+조건에 맞는 값만 세려면 `filter` 뒤에 `count()`를 연결해요.
+
+## 가장 작은 값과 큰 값을 찾아요
+
+<!-- combine-operator: min -->
+
+### `min()`과 `min(by:)`
+
+업스트림이 정상 완료하면 가장 작은 값 하나를 보내요. 입력이 없으면 값 없이 정상 완료해요.
+
+```swift
+let cancellable = [7, 2, 9].publisher
+  .min()
+  .sink { print($0) }
+
+// 2
+```
+
+매개변수 없는 `min()`은 `Output: Comparable`일 때 `<`를 사용해요. `min(by:)`는 첫 번째 값을 두 번째보다 앞에 둘지를 판단하는 비교 클로저를 받아 사용자 정의 타입이나 다른 정렬 기준을 지원해요.
+
+<!-- combine-operator: tryMin -->
+
+### `tryMin(by:)`
+
+비교 클로저가 오류를 던질 수 있는 `min(by:)`예요. 비교 중 오류가 나면 실패하고 `Failure`는 `any Error`가 돼요.
+
+```swift
+enum RankError: Error {
+  case invalid
+}
+
+let cancellable = [3, -1, 2].publisher
+  .tryMin { left, right in
+    guard left >= 0, right >= 0 else {
+      throw RankError.invalid
+    }
+    return left < right
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+<!-- combine-operator: max -->
+
+### `max()`와 `max(by:)`
+
+업스트림이 정상 완료하면 가장 큰 값 하나를 보내요. 입력이 없으면 값 없이 정상 완료해요.
+
+```swift
+struct Product {
+  let name: String
+  let price: Int
+}
+
+let products = [
+  Product(name: "연필", price: 1_000),
+  Product(name: "노트", price: 3_000),
+]
+
+let cancellable = products.publisher
+  .max { $0.price < $1.price }
+  .sink { print($0.name) }
+
+// 노트
+```
+
+매개변수 없는 `max()`는 `Output: Comparable`일 때 사용하고, `max(by:)`는 비교 기준을 직접 받아요.
+
+<!-- combine-operator: tryMax -->
+
+### `tryMax(by:)`
+
+비교 클로저가 오류를 던질 수 있는 `max(by:)`예요. 검증과 비교를 함께 해야 하는 경우에만 사용하고, 단순 비교라면 일반 오버로드로 오류 타입을 유지하세요.
+
+```swift
+let cancellable = products.publisher
+  .tryMax { left, right in
+    guard left.price >= 0, right.price >= 0 else {
+      throw RankError.invalid
+    }
+    return left.price < right.price
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0.name) }
+  )
+```
+
+## 값 하나라도 일치하는지 확인해요
+
+<!-- combine-operator: contains -->
+
+### `contains(_:)`와 `contains(where:)`
+
+`contains(_:)`는 `Output: Equatable`일 때 지정한 값과 같은 입력이 하나라도 있는지 확인해요. 일치하면 즉시 `true`를 보내고 정상 완료해요. 끝까지 없으면 업스트림 정상 완료 시 `false`를 보내요.
+
+```swift
+let cancellable = [1, 2, 3].publisher
+  .contains(2)
+  .sink { print($0) }
+
+// true
+```
+
+`contains(where:)`는 직접 조건을 정해요.
+
+```swift
+let cancellable = products.publisher
+  .contains { $0.price >= 3_000 }
+  .sink { print($0) }
+
+// true
+```
+
+<!-- combine-operator: tryContains -->
+
+### `tryContains(where:)`
+
+조건 클로저가 오류를 던질 수 있는 `contains`예요. 일치하면 `true`로 일찍 끝나고, 검사 중 오류가 발생하면 실패하며 `Failure`는 `any Error`가 돼요.
+
+```swift
+let cancellable = [1, -1, 4].publisher
+  .tryContains { value in
+    guard value >= 0 else {
+      throw RankError.invalid
+    }
+    return value.isMultiple(of: 2)
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 모든 값이 조건을 만족하는지 확인해요
+
+<!-- combine-operator: allSatisfy -->
+
+### `allSatisfy(_:)`
+
+모든 입력이 조건을 만족하는지 검사해요. 조건을 어기는 값이 하나라도 오면 즉시 `false`를 보내고 정상 완료해요. 끝까지 모두 만족하거나 입력이 비어 있으면 업스트림 정상 완료 시 `true`를 보내요.
+
+```swift
+let cancellable = [2, 4, 6].publisher
+  .allSatisfy { $0.isMultiple(of: 2) }
+  .sink { print($0) }
+
+// true
+```
+
+빈 입력의 결과가 `true`인 이유는 조건을 위반한 값이 하나도 없기 때문이에요. 빈 입력을 별도로 처리해야 한다면 `collect()`한 뒤 비어 있는지도 함께 검사하세요.
+
+<!-- combine-operator: tryAllSatisfy -->
+
+### `tryAllSatisfy(_:)`
+
+조건 클로저가 오류를 던질 수 있는 `allSatisfy`예요. 조건 위반은 `false`와 정상 완료이고, 검사 자체의 실패는 `.failure`라는 차이가 있어요.
+
+```swift
+let cancellable = [2, -1, 4].publisher
+  .tryAllSatisfy { value in
+    guard value >= 0 else {
+      throw RankError.invalid
+    }
+    return value.isMultiple(of: 2)
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 결과가 나오는 시점을 비교해요
+
+| 연산자                          | 결과 개수    | 결과가 확정되는 시점                   |
+| ------------------------------- | ------------ | -------------------------------------- |
+| `collect()`                     | 배열 하나    | 정상 완료                              |
+| `collect(count)`                | 배열 여러 개 | 개수가 차거나 정상 완료                |
+| `reduce`, `count`, `min`, `max` | 최대 한 값   | 정상 완료                              |
+| `contains`                      | `Bool` 하나  | 일치하면 즉시, 없으면 정상 완료        |
+| `allSatisfy`                    | `Bool` 하나  | 위반하면 즉시, 모두 만족하면 정상 완료 |
+| `ignoreOutput`                  | 값 없음      | 업스트림 완료만 그대로 전달            |
+
+## 적용 기준을 정리해요
+
+1. 중간 결과가 필요한지 최종 결과만 필요한지 정해요.
+2. 업스트림이 실제로 완료되는 흐름인지 확인해요.
+3. 전체 값을 모을 필요가 없으면 `collect()` 대신 `reduce`로 필요한 정보만 누적해요.
+4. 빠른 흐름을 묶을 때 개수와 시간 제한을 함께 검토해요.
+5. 조건 불일치와 검사 오류를 구분해야 할 때만 `try` 변형을 사용해요.
+
+## 참고 자료
+
+- [Publisher — Reducing elements](https://developer.apple.com/documentation/combine/publisher#Reducing-elements)
+- [Publisher — Applying mathematical operations on elements](https://developer.apple.com/documentation/combine/publisher#Applying-mathematical-operations-on-elements)
+- [Publisher — Applying matching criteria to elements](https://developer.apple.com/documentation/combine/publisher#Applying-matching-criteria-to-elements)
+- [Processing Published Elements with Subscribers](https://developer.apple.com/documentation/combine/processing-published-elements-with-subscribers)

--- a/docs/guide/combine/operators-sequence-selection.md
+++ b/docs/guide/combine/operators-sequence-selection.md
@@ -1,0 +1,373 @@
+---
+title: Combine 연산자 — 시퀀스와 요소 선택
+description: append, prepend, drop, prefix, first, last, output 등 Publisher의 앞뒤를 연결하고 원하는 구간과 요소를 선택하는 연산자를 설명합니다.
+---
+
+# Combine 연산자 — 시퀀스와 요소 선택
+
+> **면접 답변 한 줄 요약:** 시퀀스 연산자는 업스트림의 앞뒤에 값을 잇거나 일정 구간을 버리고, 선택 연산자는 필요한 위치나 조건의 값만 내보낸 뒤 가능한 시점에 구독을 끝내요.
+
+이 페이지는 Apple `Publisher` 문서의 **Applying sequence operations to elements**와 **Selecting specific elements**에 속한 연산자를 모두 설명해요.
+
+## 먼저 종료 시점을 구분해요
+
+연산자가 원하는 값을 찾았다고 항상 업스트림 완료를 기다릴 필요는 없어요.
+
+- `first`, `prefix`, `output(at:)`은 필요한 값을 받으면 업스트림을 취소하고 정상 완료할 수 있어요.
+- `last`는 더 뒤의 값이 없는지 알아야 하므로 업스트림 정상 완료를 기다려요.
+- `append`는 업스트림이 정상 완료해야 뒤쪽 Publisher나 값을 이어요.
+- 업스트림이 실패하면 대부분 실패를 그대로 전달하고 뒤쪽 처리를 시작하지 않아요.
+
+## 완료 뒤에 값을 이어 붙여요
+
+<!-- combine-operator: append -->
+
+### `append(_:)`
+
+업스트림이 **정상 완료한 뒤** 다른 Publisher, Sequence, 또는 나열한 값을 이어서 보내요.
+
+```swift
+let cancellable = [1, 2].publisher
+  .append(3, 4)
+  .sink { print($0) }
+
+// 1
+// 2
+// 3
+// 4
+```
+
+세 가지 오버로드의 역할은 같아요.
+
+| 입력                                 | 예시                       |
+| ------------------------------------ | -------------------------- |
+| 같은 `Output`, `Failure`의 Publisher | `first.append(second)`     |
+| 같은 요소 타입의 Sequence            | `publisher.append([3, 4])` |
+| 같은 타입의 값 여러 개               | `publisher.append(3, 4)`   |
+
+업스트림이 실패하면 추가 값이나 뒤쪽 Publisher를 구독하지 않고 그 실패로 끝나요.
+
+```swift
+enum LoadError: Error {
+  case failed
+}
+
+let cancellable = Fail<Int, LoadError>(error: .failed)
+  .append(Just(3).setFailureType(to: LoadError.self))
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+
+// failure(LoadError.failed)
+```
+
+## 시작 전에 값을 붙여요
+
+<!-- combine-operator: prepend -->
+
+### `prepend(_:)`
+
+업스트림을 구독해 값을 받기 전에 다른 Publisher, Sequence, 또는 나열한 값을 먼저 보내요.
+
+```swift
+let cancellable = [3, 4].publisher
+  .prepend(1, 2)
+  .sink { print($0) }
+
+// 1
+// 2
+// 3
+// 4
+```
+
+Publisher를 받는 오버로드에서는 앞 Publisher가 정상 완료한 다음 원래 업스트림을 구독해요. 앞 Publisher가 실패하면 원래 업스트림까지 가지 않아요. 화면에 초기값을 먼저 보여 주려는 목적이라면 현재 값을 보관하는 `CurrentValueSubject`나 `@Published`가 모델에 더 잘 맞는지도 비교하세요.
+
+## 시작 구간을 버려요
+
+<!-- combine-operator: dropFirst -->
+
+### `dropFirst(_:)`
+
+처음 지정한 개수의 값을 버리고 나머지를 보내요. 기본값은 `1`이에요.
+
+```swift
+let cancellable = [10, 20, 30, 40].publisher
+  .dropFirst(2)
+  .sink { print($0) }
+
+// 30
+// 40
+```
+
+`@Published`가 구독 직후 보내는 현재 값은 필요 없고 이후 변경만 받고 싶을 때 `dropFirst()`를 자주 사용해요. 다만 초기값을 무조건 버리는 규칙이 정말 도메인 의도인지 확인하세요.
+
+<!-- combine-operator: drop -->
+
+### `drop(while:)`와 `drop(untilOutputFrom:)`
+
+`drop(while:)`은 조건이 `true`인 시작 구간만 버려요. 처음 `false`가 나온 값부터는 조건을 다시 검사하지 않고 모든 값을 전달해요.
+
+```swift
+let cancellable = [1, 2, 5, 1, 6].publisher
+  .drop { $0 < 5 }
+  .sink { print($0) }
+
+// 5
+// 1
+// 6
+```
+
+전체 흐름에서 조건에 맞지 않는 값을 계속 버리려면 `filter`를 사용해야 해요.
+
+`drop(untilOutputFrom:)`은 두 번째 Publisher가 값을 하나 보낼 때까지 원래 업스트림 값을 버려요. 화면이 나타났다는 신호나 권한 준비 완료처럼 별도 시작 신호로 문을 열 때 사용해요.
+
+```swift
+let values = PassthroughSubject<Int, Never>()
+let gate = PassthroughSubject<Void, Never>()
+
+let cancellable = values
+  .drop(untilOutputFrom: gate)
+  .sink { print($0) }
+
+values.send(1)  // 버려요.
+gate.send(())
+values.send(2)  // 2
+```
+
+두 Publisher의 `Failure` 타입이 같아야 하며, 게이트 Publisher의 실패도 다운스트림 실패가 될 수 있어요.
+
+<!-- combine-operator: tryDrop -->
+
+### `tryDrop(while:)`
+
+시작 구간을 검사하는 클로저가 오류를 던질 수 있는 `drop(while:)`예요. 던진 오류는 실패 완료가 되고 `Failure`는 `any Error`가 돼요.
+
+```swift
+enum SequenceError: Error {
+  case invalid
+}
+
+let cancellable = [1, -1, 5].publisher
+  .tryDrop { value in
+    guard value >= 0 else {
+      throw SequenceError.invalid
+    }
+    return value < 5
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 시작 구간만 가져와요
+
+<!-- combine-operator: prefix -->
+
+### `prefix(_:)`, `prefix(while:)`, `prefix(untilOutputFrom:)`
+
+`prefix(_:)`는 처음 지정한 개수만 보내고 정상 완료해요. 필요한 개수를 받으면 업스트림도 취소돼요.
+
+```swift
+let cancellable = [1, 2, 3, 4].publisher
+  .prefix(2)
+  .sink { print($0) }
+
+// 1
+// 2
+```
+
+`prefix(while:)`은 조건이 `true`인 동안 값을 보내다가 처음 `false`인 값을 만나면 그 값은 보내지 않고 정상 완료해요.
+
+```swift
+let cancellable = [1, 2, 5, 1].publisher
+  .prefix { $0 < 5 }
+  .sink { print($0) }
+
+// 1
+// 2
+```
+
+`prefix(untilOutputFrom:)`은 두 번째 Publisher가 값을 보낼 때까지 원래 업스트림 값을 전달하다가 신호가 오면 정상 완료해요.
+
+```swift
+let values = PassthroughSubject<Int, Never>()
+let stop = PassthroughSubject<Void, Never>()
+
+let cancellable = values
+  .prefix(untilOutputFrom: stop)
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+
+values.send(1)  // 1
+stop.send(())   // finished
+values.send(2)  // 전달되지 않아요.
+```
+
+이 오버로드는 종료 신호 Publisher의 출력만 관찰하며 원래 업스트림의 `Failure` 타입을 유지해요.
+
+<!-- combine-operator: tryPrefix -->
+
+### `tryPrefix(while:)`
+
+조건 클로저가 오류를 던질 수 있는 `prefix(while:)`예요. 조건이 `false`이면 정상 완료하고, 검사 중 던지면 실패 완료한다는 차이가 있어요.
+
+```swift
+let cancellable = [1, -1, 5].publisher
+  .tryPrefix { value in
+    guard value >= 0 else {
+      throw SequenceError.invalid
+    }
+    return value < 5
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 첫 번째 값을 선택해요
+
+<!-- combine-operator: first -->
+
+### `first()`와 `first(where:)`
+
+`first()`는 첫 값 하나를 보내고 즉시 정상 완료해요. 업스트림이 값 없이 정상 완료하면 아무 값도 보내지 않아요.
+
+```swift
+let cancellable = [10, 20, 30].publisher
+  .first()
+  .sink { print($0) }
+
+// 10
+```
+
+`first(where:)`는 조건을 만족하는 첫 값 하나를 보내요.
+
+```swift
+let cancellable = [1, 3, 4, 6].publisher
+  .first { $0.isMultiple(of: 2) }
+  .sink { print($0) }
+
+// 4
+```
+
+조건을 만족하는 값이 없으면 업스트림 정상 완료 시 값 없이 완료해요.
+
+<!-- combine-operator: tryFirst -->
+
+### `tryFirst(where:)`
+
+조건 클로저가 오류를 던질 수 있는 `first(where:)`예요. 값을 찾으면 정상 완료하고, 검사 중 오류가 나면 실패하며 `Failure`는 `any Error`가 돼요.
+
+```swift
+let cancellable = [1, -1, 4].publisher
+  .tryFirst { value in
+    guard value >= 0 else {
+      throw SequenceError.invalid
+    }
+    return value.isMultiple(of: 2)
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 마지막 값을 선택해요
+
+<!-- combine-operator: last -->
+
+### `last()`와 `last(where:)`
+
+`last()`는 업스트림이 정상 완료한 뒤 마지막 값 하나를 보내요. `last(where:)`는 조건을 만족했던 마지막 값을 기억했다가 완료 시 보내요.
+
+```swift
+let cancellable = [1, 2, 3, 4].publisher
+  .last { $0.isMultiple(of: 2) }
+  .sink { print($0) }
+
+// 4
+```
+
+끝나지 않는 Publisher에서는 마지막 값을 확정할 수 없어요. “현재까지 최신 값”이 필요하면 `scan`, `combineLatest`, `CurrentValueSubject`처럼 입력마다 결과가 나오는 방법을 사용하세요.
+
+<!-- combine-operator: tryLast -->
+
+### `tryLast(where:)`
+
+조건 클로저가 오류를 던질 수 있는 `last(where:)`예요. 일치하는 값을 찾았더라도 더 뒤의 값을 검사해야 하므로 업스트림 정상 완료까지 기다려요.
+
+```swift
+let cancellable = [1, 2, -1, 4].publisher
+  .tryLast { value in
+    guard value >= 0 else {
+      throw SequenceError.invalid
+    }
+    return value.isMultiple(of: 2)
+  }
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+## 위치로 값을 선택해요
+
+<!-- combine-operator: output -->
+
+### `output(at:)`와 `output(in:)`
+
+`output(at:)`은 0부터 시작하는 위치의 값 하나를 보내고 정상 완료해요.
+
+```swift
+let cancellable = ["A", "B", "C"].publisher
+  .output(at: 1)
+  .sink { print($0) }
+
+// B
+```
+
+업스트림이 해당 위치보다 먼저 완료하면 값 없이 완료해요. `output(in:)`은 정수 범위에 속한 위치의 값들을 차례로 보내요.
+
+```swift
+let cancellable = ["A", "B", "C", "D"].publisher
+  .output(in: 1..<3)
+  .sink { print($0) }
+
+// B
+// C
+```
+
+범위의 마지막 위치까지 받으면 업스트림을 더 소비하지 않고 정상 완료할 수 있어요. 값의 위치가 아니라 내용으로 선택하려면 `filter`, `first(where:)`, `prefix(while:)`를 사용하세요.
+
+## 비슷한 연산자를 비교해요
+
+| 질문                                            | 연산자                                               |
+| ----------------------------------------------- | ---------------------------------------------------- |
+| 처음 N개를 버릴까요?                            | `dropFirst(N)`                                       |
+| 시작 조건이 유지되는 동안 버릴까요?             | `drop(while:)`                                       |
+| 모든 값에 계속 조건을 적용할까요?               | `filter(_:)`                                         |
+| 처음 N개만 가져올까요?                          | `prefix(N)`                                          |
+| 조건이 깨지기 전까지만 가져올까요?              | `prefix(while:)`                                     |
+| 조건을 만족하는 첫 값만 가져올까요?             | `first(where:)`                                      |
+| 조건을 만족하는 마지막 값을 완료 후 가져올까요? | `last(where:)`                                       |
+| 다른 신호로 시작하거나 끝낼까요?                | `drop(untilOutputFrom:)`, `prefix(untilOutputFrom:)` |
+
+## 적용 기준을 정리해요
+
+1. 필요한 구간이 위치 기준인지 값의 조건 기준인지 정해요.
+2. 결과를 찾는 즉시 끝낼 수 있는지 업스트림 완료를 기다려야 하는지 확인해요.
+3. 초기값을 붙이는 일과 현재 상태를 보관하는 일을 구분해요.
+4. `append` 뒤쪽 작업은 업스트림 실패 시 시작되지 않는다는 점을 고려해요.
+5. 시작·종료 신호 Publisher의 실패와 취소도 함께 테스트해요.
+
+## 참고 자료
+
+- [Publisher — Applying sequence operations to elements](https://developer.apple.com/documentation/combine/publisher#Applying-sequence-operations-to-elements)
+- [Publisher — Selecting specific elements](https://developer.apple.com/documentation/combine/publisher#Selecting-specific-elements)
+- [Publishers.DropUntilOutput](https://developer.apple.com/documentation/combine/publishers/dropuntiloutput)
+- [Publishers.PrefixUntilOutput](https://developer.apple.com/documentation/combine/publishers/prefixuntiloutput)

--- a/docs/guide/combine/operators-time-buffer.md
+++ b/docs/guide/combine/operators-time-buffer.md
@@ -1,0 +1,266 @@
+---
+title: Combine 연산자 — 시간·버퍼·스케줄러
+description: debounce, throttle, delay, timeout, buffer와 subscribe(on:), receive(on:)으로 값의 빈도·대기열·실행 위치를 제어하는 방법을 설명합니다.
+---
+
+# Combine 연산자 — 시간·버퍼·스케줄러
+
+> **면접 답변 한 줄 요약:** 시간 연산자는 값의 전달 시점과 빈도를 바꾸고, `buffer`는 생산자와 소비자의 속도 차이를 흡수하며, 스케줄러 연산자는 구독 작업과 다운스트림 전달의 실행 위치를 나눠요.
+
+검색창에는 짧은 시간에 여러 글자가 입력되고, 센서나 소켓은 화면이 처리하는 속도보다 빠르게 값을 보낼 수 있어요. 이 페이지는 Apple `Publisher` 문서의 **Controlling timing**, **Buffering elements**, **Specifying schedulers**에 속한 연산자를 모두 설명해요.
+
+## 먼저 시간 연산자의 질문을 구분해요
+
+| 질문                                                | 연산자            |
+| --------------------------------------------------- | ----------------- |
+| 마지막 입력 뒤 조용한 시간이 생겼나요?              | `debounce`        |
+| 일정 구간마다 첫 값이나 최신 값 하나만 보낼까요?    | `throttle`        |
+| 모든 이벤트를 같은 시간만큼 뒤로 미룰까요?          | `delay`           |
+| 너무 오랫동안 값이 없으면 끝낼까요?                 | `timeout`         |
+| 값 사이에 얼마나 시간이 흘렀나요?                   | `measureInterval` |
+| 빠른 업스트림의 값을 제한된 공간에 잠시 보관할까요? | `buffer`          |
+
+시간 연산자가 사용하는 `SchedulerTimeType.Stride`는 스케줄러마다 표현이 달라요. `DispatchQueue`에서는 `.milliseconds(300)`, `.seconds(1)`처럼 작성할 수 있어요.
+
+## 이벤트 사이 시간을 측정해요
+
+<!-- combine-operator: measureInterval -->
+
+### `measureInterval(using:options:)`
+
+업스트림 이벤트가 도착한 간격을 지정한 스케줄러의 `Stride` 값으로 보내요. 원래 `Output` 대신 시간 간격이 출력돼요.
+
+```swift
+let cancellable = events
+  .measureInterval(using: DispatchQueue.main)
+  .sink { interval in
+    print("이벤트 간격:", interval)
+  }
+```
+
+성능 계측, 사용자 입력 간격, 주기적인 소스의 흔들림을 관찰할 때 사용해요. 벽시계의 절대 날짜가 아니라 선택한 스케줄러의 시간 체계로 측정한다는 점을 기억하세요. `options`는 스케줄러별 실행 옵션이에요.
+
+## 입력이 잠잠해진 뒤 최신 값을 보내요
+
+<!-- combine-operator: debounce -->
+
+### `debounce(for:scheduler:options:)`
+
+값을 받은 뒤 지정한 시간 동안 새 값이 오지 않을 때 그 최신 값을 보내요. 기다리는 중 새 값이 오면 이전 값은 버리고 타이머를 다시 시작해요.
+
+```swift
+let cancellable = $query
+  .debounce(
+    for: .milliseconds(300),
+    scheduler: DispatchQueue.main
+  )
+  .removeDuplicates()
+  .sink { query in
+    print("검색:", query)
+  }
+```
+
+사용자가 타이핑을 잠시 멈춘 뒤 검색을 시작하는 상황에 적합해요. 값이 끊임없이 간격보다 빠르게 오면 전달이 계속 미뤄질 수 있어요. 일정 주기로 반드시 값을 받고 싶다면 `throttle`이 요구사항에 더 가까워요.
+
+## 일정 구간마다 대표 값 하나를 보내요
+
+<!-- combine-operator: throttle -->
+
+### `throttle(for:scheduler:latest:)`
+
+지정한 시간 구간마다 값을 최대 하나 보내요.
+
+- `latest: true`이면 구간에 들어온 값 중 최신 값을 선택해요.
+- `latest: false`이면 구간에서 먼저 선택된 값을 유지해요.
+
+```swift
+let cancellable = scrollOffsets
+  .throttle(
+    for: .milliseconds(100),
+    scheduler: DispatchQueue.main,
+    latest: true
+  )
+  .sink { offset in
+    updateHeader(offset)
+  }
+```
+
+스크롤처럼 계속 들어오는 값을 제한된 빈도로 화면에 반영할 때 유용해요. `debounce`는 조용한 구간을 기다리지만 `throttle`은 입력이 계속 와도 정해진 최대 빈도로 결과를 보낼 수 있다는 차이가 있어요.
+
+## 모든 이벤트를 뒤로 미뤄요
+
+<!-- combine-operator: delay -->
+
+### `delay(for:tolerance:scheduler:options:)`
+
+업스트림의 값과 완료 이벤트를 지정한 시간만큼 늦춰 다운스트림에 전달해요. 값의 순서나 개수는 바꾸지 않아요.
+
+```swift
+let cancellable = Just("표시")
+  .delay(
+    for: .seconds(1),
+    scheduler: DispatchQueue.main
+  )
+  .sink { print($0) }
+```
+
+`tolerance`는 스케줄러가 전력과 실행 효율을 위해 허용할 수 있는 시간 오차예요. `nil`이면 스케줄러 기본 허용치를 사용해요. `delay`는 다운스트림 전달을 미루는 연산자이지 업스트림 구독이나 작업 시작 자체를 늦추는 연산자가 아니에요. 작업 생성을 구독 시점까지 늦추려면 `Deferred`를 검토하세요.
+
+## 값이 오지 않으면 종료해요
+
+<!-- combine-operator: timeout -->
+
+### `timeout(_:scheduler:options:customError:)`
+
+업스트림이 지정한 시간보다 오래 새 값을 보내지 않으면 구독을 종료해요. 값이 오면 제한 시간이 다시 계산돼요.
+
+```swift
+enum RequestError: Error {
+  case timedOut
+}
+
+let cancellable = request
+  .timeout(
+    .seconds(5),
+    scheduler: DispatchQueue.main,
+    customError: { RequestError.timedOut }
+  )
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+`customError`가 반환하는 타입은 업스트림의 `Failure`와 같아야 해요. 오류 클로저를 제공하면 시간 초과를 그 실패로 전달하고, 제공하지 않으면 시간 초과 시 정상 완료해요. 사용자가 시간 초과와 정상적인 값 없는 완료를 구분해야 한다면 명시적인 오류를 제공하세요.
+
+이 연산자는 **각 이벤트 사이의 무응답 시간**을 제한해요. 요청 전체의 절대 마감 시간이나 외부 작업 자체의 취소 보장은 업스트림 구현과 별도로 확인해야 해요.
+
+## 속도 차이를 버퍼로 흡수해요
+
+<!-- combine-operator: buffer -->
+
+### `buffer(size:prefetch:whenFull:)`
+
+다운스트림이 바로 처리하지 못한 값을 제한된 크기의 버퍼에 보관해요.
+
+```swift
+let buffered = fastPublisher
+  .buffer(
+    size: 100,
+    prefetch: .keepFull,
+    whenFull: .dropOldest
+  )
+```
+
+`prefetch`는 업스트림에 값을 어떻게 요청할지 정해요.
+
+| `Publishers.PrefetchStrategy` | 동작                                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `.keepFull`                   | 구독 시 버퍼 크기만큼 요청하고, 값이 빠질 때마다 버퍼를 다시 채우도록 추가 요청해요. |
+| `.byRequest`                  | 미리 채우지 않고 다운스트림 요청에 따라 업스트림 요청을 전달해요.                    |
+
+버퍼가 가득 찼을 때의 정책도 선택해야 해요.
+
+| `Publishers.BufferingStrategy` | 동작                                                       |
+| ------------------------------ | ---------------------------------------------------------- |
+| `.dropNewest`                  | 새로 들어온 값을 버리고 이미 기다리던 오래된 값을 지켜요.  |
+| `.dropOldest`                  | 가장 오래 기다린 값을 버리고 최신 값을 보관해요.           |
+| `.customError { ... }`         | 버퍼 초과를 지정한 `Failure`로 바꾸고 파이프라인을 끝내요. |
+
+상태 화면처럼 최신 값이 중요하면 `.dropOldest`, 이벤트 감사 로그처럼 먼저 온 값을 지켜야 하면 `.dropNewest`가 더 가까울 수 있어요. 어떤 값도 잃으면 안 되는 작업에서는 버리기 정책으로 문제를 숨기지 말고 생산 속도 제한, 배치 처리, 저장소 큐 같은 구조를 설계하세요.
+
+버퍼는 메모리와 지연을 맞바꾸는 도구예요. 크기를 크게 잡는 것만으로 느린 소비자를 해결할 수는 없어요.
+
+## 업스트림 구독 작업의 위치를 정해요
+
+<!-- combine-operator: subscribe -->
+
+### `subscribe(on:options:)`
+
+업스트림을 구독하고, 수요를 요청하고, 구독을 취소하는 작업을 지정한 스케줄러에서 수행하도록 영향을 줘요.
+
+```swift
+let backgroundQueue = DispatchQueue(
+  label: "com.swiftkr.decode",
+  qos: .userInitiated
+)
+
+let cancellable = jsonPublisher
+  .subscribe(on: backgroundQueue)
+  .sink(
+    receiveCompletion: { print($0) },
+    receiveValue: { print($0) }
+  )
+```
+
+`subscribe(on:)`을 호출한 아래쪽의 모든 클로저가 반드시 그 큐에서 실행된다는 뜻은 아니에요. **업스트림 방향의 구독·요청·취소**에 영향을 주는 연산자예요. 값 전달 위치를 정하려면 `receive(on:)`을 사용해요.
+
+## 다운스트림 값 전달 위치를 정해요
+
+<!-- combine-operator: receive -->
+
+### `receive(on:options:)`
+
+이 연산자 아래쪽 Subscriber가 값과 완료를 받을 스케줄러를 정해요.
+
+```swift
+let cancellable = jsonPublisher
+  .subscribe(on: backgroundQueue)
+  .map(decode)
+  .receive(on: DispatchQueue.main)
+  .sink { model in
+    updateUI(model)
+  }
+```
+
+위 예제에서 업스트림 구독과 디코딩은 배경 큐에서 수행하도록 구성하고, `receive(on:)` 아래의 UI 갱신은 메인 큐에서 받아요. 연산자를 체인의 어디에 두는지에 따라 영향을 받는 다운스트림 범위가 달라져요.
+
+`receive(on:)`은 값과 완료의 전달 위치를 바꾸지만 Subscriber의 `receive(subscription:)` 호출에는 같은 방식으로 적용되지 않아요. 사용자 인터페이스를 바꾸는 `sink`나 `assign` 앞에서 명시하는 패턴이 읽기 쉬워요.
+
+## `subscribe(on:)`과 `receive(on:)`을 비교해요
+
+```text
+Subscriber의 요청
+sink ── receive(on: main) ── map ── subscribe(on: background) ── source
+                                                       ← 구독·요청·취소
+
+Publisher의 값
+source ── map ── receive(on: main) ── sink
+                         값·완료 →
+```
+
+| 질문                                       | 연산자           |
+| ------------------------------------------ | ---------------- |
+| Publisher를 구독하고 취소하는 작업 위치는? | `subscribe(on:)` |
+| 이 지점 아래에서 값과 완료를 받는 위치는?  | `receive(on:)`   |
+
+스케줄러 전환은 동시성 안전성을 자동으로 보장하지 않아요. 여러 Publisher가 공유 가변 상태에 접근한다면 상태의 소유자와 격리 방법을 별도로 설계하세요.
+
+## 적용 순서를 정리해요
+
+1. 줄이려는 것이 지연인지 호출 빈도인지 구분해요.
+2. 첫 값, 최신 값, 모든 값 중 반드시 보존해야 하는 값을 정해요.
+3. 업스트림과 다운스트림의 최대 속도 차이를 측정해요.
+4. 버퍼 크기와 초과 정책을 명시하고 값 손실을 테스트해요.
+5. 구독 작업과 값 전달 작업의 실행 위치를 각각 정해요.
+6. UI 갱신 직전에 `receive(on:)`이 있는지 확인해요.
+7. 가상 시간이나 제어 가능한 스케줄러를 주입해 시간 기반 테스트를 안정화해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `debounce`와 `throttle`은 무엇이 다른가요?
+
+`debounce`는 새 입력이 없는 조용한 시간이 생긴 뒤 최신 값을 보내므로 검색어 입력처럼 마지막 값이 중요한 흐름에 적합해요. `throttle`은 입력이 계속 와도 정해진 구간마다 첫 값이나 최신 값 하나를 보내 최대 전달 빈도를 제한해요.
+
+### `subscribe(on:)`과 `receive(on:)`은 무엇이 다른가요?
+
+`subscribe(on:)`은 업스트림 방향의 구독, 수요 요청, 취소 작업에 영향을 줘요. `receive(on:)`은 그 지점 아래 다운스트림으로 값과 완료를 전달할 스케줄러를 바꿔요.
+
+## 참고 자료
+
+- [Publisher — Controlling timing](https://developer.apple.com/documentation/combine/publisher#Controlling-timing)
+- [Publisher — Buffering elements](https://developer.apple.com/documentation/combine/publisher#Buffering-elements)
+- [Publisher — Specifying schedulers](https://developer.apple.com/documentation/combine/publisher#Specifying-schedulers)
+- [Processing Published Elements with Subscribers](https://developer.apple.com/documentation/combine/processing-published-elements-with-subscribers)
+- [Publishers.PrefetchStrategy](https://developer.apple.com/documentation/combine/publishers/prefetchstrategy)
+- [Publishers.BufferingStrategy](https://developer.apple.com/documentation/combine/publishers/bufferingstrategy)

--- a/docs/guide/rxswift/_meta.json
+++ b/docs/guide/rxswift/_meta.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "custom-link",
+    "label": "RxSwift 시작하기",
+    "link": "/guide/rxswift/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "모든 연산자",
+    "collapsible": true,
+    "collapsed": false,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "생성과 변환",
+        "link": "/guide/rxswift/operators-create-convert"
+      },
+      {
+        "type": "custom-link",
+        "label": "변환과 필터링",
+        "link": "/guide/rxswift/operators-transform-filter"
+      },
+      {
+        "type": "custom-link",
+        "label": "선택·집계·시간",
+        "link": "/guide/rxswift/operators-select-time"
+      },
+      {
+        "type": "custom-link",
+        "label": "Observable 결합",
+        "link": "/guide/rxswift/operators-combine"
+      },
+      {
+        "type": "custom-link",
+        "label": "오류·스케줄러·구독",
+        "link": "/guide/rxswift/operators-error-lifecycle"
+      },
+      {
+        "type": "custom-link",
+        "label": "공유와 연결",
+        "link": "/guide/rxswift/operators-share-connect"
+      },
+      {
+        "type": "custom-link",
+        "label": "Traits와 폐기 API",
+        "link": "/guide/rxswift/operators-traits-deprecated"
+      }
+    ]
+  }
+]

--- a/docs/guide/rxswift/index.md
+++ b/docs/guide/rxswift/index.md
@@ -1,0 +1,264 @@
+---
+title: Swift로 시작하는 RxSwift
+description: Observable과 Observer, Disposable, Subject, Trait의 관계부터 RxSwift 6.10.2의 모든 공개 연산자를 고르는 방법까지 단계적으로 설명합니다.
+---
+
+# Swift로 시작하는 RxSwift
+
+> **면접 답변 한 줄 요약:** RxSwift는 `Observable`이 시간에 따라 보내는 값·오류·완료 이벤트를 연산자로 조합하고, Observer가 구독과 폐기를 통해 소비하도록 만드는 Reactive Extensions의 Swift 구현이에요.
+
+버튼 탭, 검색어, 위치 변화, 네트워크 응답은 도착 시점과 개수가 서로 달라요. 각각을 콜백과 상태 변수로 연결하면 취소, 오류, 실행 스레드가 여러 곳으로 흩어지기 쉬워요. RxSwift는 이런 비동기 값을 모두 `Observable<Element>`라는 한 가지 형태로 표현하고, 작은 연산자를 연결해 처리 흐름을 만들어요.
+
+이 섹션은 기본 Swift 문법을 알지만 RxSwift는 처음 접하는 독자를 대상으로 해요. 문서와 연산자 인벤토리는 공식 저장소의 **RxSwift 6.10.2** 공개 API를 기준으로 작성했어요.
+
+## 먼저 알아둘 RxSwift 용어
+
+| 용어                    | 쉬운 뜻                                                                                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Reactive Extensions, Rx | 시간에 따라 도착하는 값을 관찰 가능한 시퀀스로 표현하고 공통 연산자로 조합하는 규약과 라이브러리 계열이에요.                                              |
+| `Observable<Element>`   | `Element` 타입의 값을 0개 이상 보내고, 선택적으로 오류나 정상 완료로 끝나는 시퀀스예요.                                                                   |
+| Observer                | Observable을 구독해 `.next`, `.error`, `.completed` 이벤트를 받는 소비자예요.                                                                             |
+| 연산자(operator)        | Observable을 만들거나 값·시간·오류·구독 방식을 바꿔 새 Observable 또는 Trait을 만드는 메서드예요.                                                         |
+| `Disposable`            | 구독과 기반 작업을 더 이상 사용하지 않을 때 폐기하는 토큰이에요. Combine의 `AnyCancellable`과 비슷한 역할이에요.                                          |
+| `DisposeBag`            | 여러 `Disposable`을 보관하고 자신이 해제될 때 모두 `dispose()`하는 컨테이너예요.                                                                          |
+| Subject                 | Observable이면서 Observer이기도 해서 외부 코드가 `onNext`로 값을 넣을 수 있는 타입이에요.                                                                 |
+| Scheduler               | 구독 작업, 값 전달, 타이머가 실행될 위치와 시간을 표현해요. `MainScheduler`, `SerialDispatchQueueScheduler` 등이 있어요.                                  |
+| Trait                   | 값의 개수, 오류 가능성, 실행 위치 같은 Observable의 제약을 타입으로 드러낸 래퍼예요. `Single`, `Maybe`, `Completable`, `Infallible`이 RxSwift에 포함돼요. |
+| hot·cold Observable     | cold는 구독마다 작업과 값 생산을 새로 시작하고, hot은 구독과 무관하게 진행되는 값 생산을 여러 Observer가 볼 수 있는 시퀀스예요.                           |
+
+이 섹션에서는 다음 내용을 배워요.
+
+1. Observable이 지켜야 하는 이벤트 규칙을 이해해요.
+2. 구독과 `DisposeBag`으로 자원 수명을 관리해요.
+3. Subject와 Relay의 상태·이벤트 역할을 구분해요.
+4. 값 변환, 결합, 오류 처리, 스케줄러 연산자를 선택해요.
+5. 공유 연산자로 중복 작업을 막고 replay 범위를 정해요.
+6. Trait과 Swift Concurrency 사이를 변환해요.
+
+## Observable은 값 뒤에 종료 이벤트를 보낼 수 있어요
+
+RxSwift의 Observable 이벤트 규칙은 다음과 같이 표현해요.
+
+```text
+next* (error | completed)?
+```
+
+- `.next(element)`는 0번 이상 올 수 있어요.
+- `.error(error)`나 `.completed`는 최대 한 번 오고 시퀀스를 끝내요.
+- 종료 이벤트 뒤에는 다른 이벤트가 올 수 없어요.
+- 끝나지 않는 버튼 탭이나 타이머 시퀀스도 만들 수 있어요.
+
+가장 작은 Observable을 만들고 구독해 볼게요.
+
+```swift
+import RxSwift
+
+let numbers = Observable.of(1, 2, 3)
+
+let disposable = numbers
+  .subscribe(
+    onNext: { value in
+      print("값:", value)
+    },
+    onCompleted: {
+      print("완료")
+    }
+  )
+
+// 값: 1
+// 값: 2
+// 값: 3
+// 완료
+```
+
+`Observable.of`는 인자로 받은 값을 차례로 보내고 정상 완료해요. `subscribe`는 Observable의 실행을 시작하고 구독을 끊을 수 있는 `Disposable`을 반환해요.
+
+## 연산자를 연결해 처리 흐름을 만들어요
+
+짝수만 남기고 문자열로 바꿔 볼게요.
+
+```swift
+let disposable = Observable.of(1, 2, 3, 4, 5)
+  .filter { $0.isMultiple(of: 2) }
+  .map { "값: \($0)" }
+  .subscribe(onNext: { print($0) })
+
+// 값: 2
+// 값: 4
+```
+
+각 연산자는 원본을 직접 수정하지 않고 새 Observable을 반환해요.
+
+```text
+Observable<Int> → filter → map → subscribe
+       소스                         Observer
+```
+
+Observable은 보통 `subscribe`가 호출될 때 업스트림을 구독해 작업을 시작해요. 하지만 Subject나 이미 실행 중인 시스템 이벤트처럼 구독과 무관하게 값 생산이 진행되는 hot Observable도 있으므로, “Observable은 모두 구독할 때 처음 시작한다”고 단정하면 안 돼요.
+
+## DisposeBag으로 구독 수명을 객체에 맞춰요
+
+끝나지 않는 Observable은 구독을 폐기하지 않으면 기반 작업과 Observer가 계속 남을 수 있어요.
+
+```swift
+final class SearchViewModel {
+  private let disposeBag = DisposeBag()
+
+  init(query: Observable<String>) {
+    query
+      .debounce(
+        .milliseconds(300),
+        scheduler: MainScheduler.instance
+      )
+      .distinctUntilChanged()
+      .subscribe(onNext: { [weak self] query in
+        self?.search(query)
+      })
+      .disposed(by: disposeBag)
+  }
+
+  private func search(_ query: String) {
+    // 실제 앱에서는 검색 작업을 시작해요.
+  }
+}
+```
+
+`disposed(by:)`는 반환된 `Disposable`을 bag에 보관해요. `SearchViewModel`이 해제되면 bag도 해제되면서 구독을 폐기해요. 같은 객체가 구독을 보관하고 구독 클로저가 객체를 강하게 잡으면 참조 순환이 생길 수 있으므로 `[weak self]`나 `withUnretained`를 소유 관계에 맞게 사용하세요.
+
+`dispose()`는 `.completed` 이벤트를 보내는 연산이 아니에요. Observer와 생산자 사이 연결을 끊고 자원을 정리하는 별도 생명 주기 동작이에요.
+
+## Subject는 외부 이벤트를 Observable에 넣어요
+
+| Subject           | 새 Observer가 처음 받는 값                                                             |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| `PublishSubject`  | 구독 이후에 들어오는 값만 받아요.                                                      |
+| `BehaviorSubject` | 현재 값 하나를 저장하고 새 Observer에게 먼저 보내요.                                   |
+| `ReplaySubject`   | 설정한 버퍼 크기만큼 과거 값을 새 Observer에게 다시 보내요.                            |
+| `AsyncSubject`    | 원본이 정상 완료했을 때 마지막 값 하나만 보내고 완료해요. 오류가 나면 오류만 전달해요. |
+
+```swift
+let subject = BehaviorSubject(value: "초기 검색어")
+
+let disposable = subject
+  .subscribe(onNext: { print($0) })
+
+subject.onNext("RxSwift")
+```
+
+Subject는 delegate나 콜백을 Rx 경계에 연결할 때 유용하지만, 여러 곳에서 `onNext`를 호출하면 상태 변경 경로가 감춰져요. 오류와 완료를 외부에서 보내지 않아야 하는 상태에는 RxRelay의 `BehaviorRelay`, 단발 이벤트에는 `PublishRelay`도 고려하세요.
+
+## RxSwift 생태계 모듈을 구분해요
+
+| 모듈         | 역할                                                                                  |
+| ------------ | ------------------------------------------------------------------------------------- |
+| `RxSwift`    | Observable, 연산자, Subject, Scheduler, Disposable과 코어 Trait을 제공해요.           |
+| `RxCocoa`    | Apple UI 프레임워크용 바인딩, `Driver`, `Signal`, `ControlProperty` 등을 제공해요.    |
+| `RxRelay`    | 오류나 완료 없이 값만 받는 `PublishRelay`, `BehaviorRelay`, `ReplayRelay`를 제공해요. |
+| `RxTest`     | 가상 시간 Scheduler와 기록 가능한 Observer로 시간 기반 테스트를 지원해요.             |
+| `RxBlocking` | 테스트에서 Observable 결과를 동기적으로 기다리는 API를 제공해요.                      |
+
+이 섹션의 “모든 연산자”는 **RxSwift 코어 모듈**의 공개 연산자를 뜻해요. RxCocoa의 컨트롤별 바인더는 UI API이므로 범위에 넣지 않았고, `Driver`와 `Signal`은 [Trait 문서](./operators-traits-deprecated)에서 역할과 경계를 설명해요.
+
+## Swift Package Manager로 설치해요
+
+`Package.swift`에서는 공식 저장소와 사용할 제품을 선언해요.
+
+```swift
+dependencies: [
+  .package(
+    url: "https://github.com/ReactiveX/RxSwift.git",
+    from: "6.10.2"
+  ),
+],
+targets: [
+  .target(
+    name: "MyApp",
+    dependencies: [
+      .product(name: "RxSwift", package: "RxSwift"),
+      .product(name: "RxCocoa", package: "RxSwift"),
+      .product(name: "RxRelay", package: "RxSwift"),
+    ]
+  ),
+]
+```
+
+코어만 필요하면 `RxSwift`만 추가하세요. 앱의 실제 배포 기준과 호환성을 검토해 버전을 고정하거나 업데이트 범위를 정해야 해요.
+
+## Trait으로 값의 규칙을 타입에 담아요
+
+| Trait             | 값과 종료 규칙                                    | 대표 용도                   |
+| ----------------- | ------------------------------------------------- | --------------------------- |
+| `Single<Element>` | 값 하나 또는 오류 하나                            | 네트워크 응답 하나          |
+| `Maybe<Element>`  | 값 하나, 값 없는 정상 완료, 또는 오류             | 있을 수도 없는 캐시 조회    |
+| `Completable`     | 값 없이 정상 완료 또는 오류                       | 저장·삭제 작업의 성공 여부  |
+| `Infallible`      | 오류 없이 값 0개 이상                             | 실패하지 않는 도메인 이벤트 |
+| `Driver`          | 오류 없음, 메인 Scheduler 관찰, 최신 값 1개 공유  | UI 상태 구동, RxCocoa       |
+| `Signal`          | 오류 없음, 메인 Scheduler 관찰, 과거 값 재생 없음 | UI 단발 이벤트, RxCocoa     |
+
+Trait은 런타임에 완전히 다른 스트림 엔진이 아니라 Observable의 제약과 의미를 타입으로 표현하는 래퍼예요. 값 하나가 보장되는 API를 `Observable`로 노출하기보다 `Single`로 노출하면 호출자가 결과 개수를 추측할 필요가 없어요.
+
+## 모든 연산자를 목적별로 찾아봐요
+
+아래 인벤토리는 RxSwift 6.10.2 모듈을 빌드해 추출한 공개 심볼을 이름별로 묶은 것이에요. 오버로드는 각 문서에서 차이를 함께 설명하고, 폐기된 이름도 최신 대체 API와 연결해요.
+
+| 목적                 | 연산자                                                                                                                                             | 문서                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| 생성                 | `create`, `just`, `of`, `from`, `empty`, `error`, `never`, `deferred`, `generate`, `range`, `repeatElement`, `interval`, `timer`, `using`          | [생성과 변환](./operators-create-convert)          |
+| 타입·비동기 변환     | `asObservable`, `asSingle`, `asMaybe`, `asCompletable`, `asInfallible`, `values`, `value`, `decode`                                                | [생성과 변환](./operators-create-convert)          |
+| 값 변환과 분류       | `map`, `compactMap`, `filter`, `enumerated`, `distinctUntilChanged`, `scan`, `reduce`, `groupBy`, `materialize`, `dematerialize`, `withUnretained` | [변환과 필터링](./operators-transform-filter)      |
+| 요소 선택과 기본값   | `element`, `first`, `single`, `toArray`, `ignoreElements`, `skip`, `take`, `takeLast`, `startWith`, `ifEmpty`                                      | [선택·집계·시간](./operators-select-time)          |
+| 시간과 묶음          | `buffer`, `window`, `sample`, `debounce`, `throttle`, `delay`, `delaySubscription`, `timeout`                                                      | [선택·집계·시간](./operators-select-time)          |
+| 여러 Observable 결합 | `combineLatest`, `zip`, `merge`, `concat`, `concatMap`, `amb`, `withLatestFrom`                                                                    | [Observable 결합](./operators-combine)             |
+| 내부 Observable 전환 | `flatMap`, `flatMapLatest`, `flatMapFirst`, `switchLatest`                                                                                         | [Observable 결합](./operators-combine)             |
+| 오류 처리            | `catch`, `catchAndReturn`, `retry`                                                                                                                 | [오류·스케줄러·구독](./operators-error-lifecycle)  |
+| Scheduler와 구독     | `observe(on:)`, `subscribe(on:)`, `subscribe`, `do`, `debug`                                                                                       | [오류·스케줄러·구독](./operators-error-lifecycle)  |
+| 공유와 연결          | `multicast`, `publish`, `replay`, `replayAll`, `share`, `connect`, `refCount`                                                                      | [공유와 연결](./operators-share-connect)           |
+| Trait 전용           | `andThen`, `flatMapCompletable`, `flatMapMaybe` 및 Trait별 `create`, `subscribe`, 변환 오버로드                                                    | [Traits와 폐기 API](./operators-traits-deprecated) |
+| 폐기된 별칭          | `catchError`, `catchErrorJustReturn`, `elementAt`, `observeOn`, `retryWhen`, `skipUntil`, `skipWhile`, `subscribeOn`, `takeUntil`, `takeWhile`     | [Traits와 폐기 API](./operators-traits-deprecated) |
+
+## RxSwift와 Combine을 비교해요
+
+| 질문          | RxSwift                                               | Combine                                                            |
+| ------------- | ----------------------------------------------------- | ------------------------------------------------------------------ |
+| 오류 타입     | 모든 Observable 오류는 `Swift.Error`로 전달돼요.      | `Publisher<Output, Failure>`가 구체적인 `Failure` 타입을 추적해요. |
+| 취소          | `Disposable.dispose()`와 `DisposeBag`을 사용해요.     | `Cancellable.cancel()`과 `AnyCancellable`을 사용해요.              |
+| 역압력        | 일반 Observable에는 수요 협상 프로토콜이 없어요.      | Subscriber가 `Demand`로 요청 개수를 제어할 수 있어요.              |
+| UI 계층       | RxCocoa의 `Driver`, `Signal`, Binder가 풍부해요.      | Apple 프레임워크와 `@Published`를 직접 연결해요.                   |
+| 플랫폼        | 오픈 소스이며 Apple 플랫폼과 Linux를 지원해요.        | Apple 플랫폼 프레임워크예요.                                       |
+| 비동기 브리지 | `values`와 `AsyncSequence.asObservable()`을 제공해요. | Publisher의 `values`를 `AsyncSequence`로 순회할 수 있어요.         |
+
+새 프로젝트에서 한 번의 비동기 작업만 처리한다면 `async`/`await`가 더 단순할 수 있어요. 기존 RxSwift 코드가 많거나 여러 UI 이벤트와 시간 기반 흐름을 조합한다면 RxSwift의 일관된 연산자와 RxCocoa 생태계가 여전히 유용해요.
+
+## 적용 순서를 정리해요
+
+1. 값이 몇 번 오고 정상 완료·오류가 가능한지 정해요.
+2. `Observable`, `Single`, `Maybe`, `Completable`, `Infallible` 중 계약을 가장 잘 드러내는 타입을 고르세요.
+3. 생성, 변환, 결합, 오류 처리, Scheduler 전환을 작은 단계로 연결해요.
+4. cold·hot 여부와 Subscriber마다 작업을 반복할지 공유할지 정해요.
+5. `Disposable`, `DisposeBag`, Task의 소유 수명을 정해요.
+6. UI 갱신은 메인 Scheduler와 RxCocoa Trait 제약을 확인해요.
+7. RxTest의 가상 시간으로 시간 기반 연산자와 종료 경로를 테스트해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Observable의 이벤트 규칙은 무엇인가요?
+
+`.next`는 0번 이상 올 수 있고 `.error`나 `.completed`는 최대 한 번 와서 시퀀스를 끝내요. 종료 뒤에는 다른 이벤트를 보낼 수 없으며, 끝나지 않는 Observable도 가능해요.
+
+### `dispose()`와 `.completed`는 무엇이 다른가요?
+
+`.completed`는 생산자가 Observer에게 보내는 정상 종료 이벤트예요. `dispose()`는 소비자가 구독 연결을 끊고 자원을 정리하는 동작이라 Observer에 정상 완료를 보장하지 않아요.
+
+### cold Observable과 hot Observable은 무엇이 다른가요?
+
+cold Observable은 보통 Subscriber마다 값 생산과 부수 효과를 새로 시작해요. hot Observable은 구독과 별개로 진행되는 값 생산을 관찰하므로 늦게 구독하면 이전 값을 놓칠 수 있고, `share`나 Subject를 이용해 하나의 소스를 여러 Observer가 볼 수 있어요.
+
+## 참고 자료
+
+- [ReactiveX/RxSwift 6.10.2](https://github.com/ReactiveX/RxSwift/tree/6.10.2)
+- [RxSwift 공식 API 문서](https://docs.rxswift.org/)
+- [ObservableType](https://docs.rxswift.org/protocols/observabletype)
+- [Getting Started](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/GettingStarted.md)
+- [Traits](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md)
+- [Swift Concurrency](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/SwiftConcurrency.md)
+- [Hot and Cold Observables](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/HotAndColdObservables.md)

--- a/docs/guide/rxswift/operators-combine.md
+++ b/docs/guide/rxswift/operators-combine.md
@@ -1,0 +1,281 @@
+---
+title: RxSwift 연산자 — Observable 결합
+description: combineLatest, zip, merge, concat, withLatestFrom과 flatMap 계열로 여러 Observable의 최신 값·순서·내부 구독을 조합하는 방법을 설명합니다.
+---
+
+# RxSwift 연산자 — Observable 결합
+
+> **면접 답변 한 줄 요약:** 결합 연산자는 최신 값, 같은 순번, 도착 순서 중 어떤 규칙으로 여러 Observable을 합칠지 정하고, `flatMap` 계열은 입력마다 만든 내부 Observable의 동시 구독 정책을 정해요.
+
+결합 연산자를 고를 때는 “어떤 값끼리 결과 하나를 만들까요?”와 “새 내부 작업이 들어오면 기존 작업을 어떻게 할까요?”를 나눠 생각해야 해요.
+
+## 여러 Observable의 최신 상태를 합쳐요
+
+<!-- rxswift-operator: combineLatest -->
+
+### `combineLatest`
+
+모든 소스가 적어도 값 하나씩을 보낸 뒤, 어느 소스든 새 값을 보낼 때 각 소스의 최신 값을 조합해요.
+
+```swift
+let query = PublishSubject<String>()
+let isOnline = PublishSubject<Bool>()
+
+Observable.combineLatest(
+  query,
+  isOnline
+) { query, isOnline in
+  !query.isEmpty && isOnline
+}
+.subscribe(onNext: { print("검색 가능:", $0) })
+.disposed(by: disposeBag)
+
+query.onNext("Rx")
+isOnline.onNext(true)   // 검색 가능: true
+query.onNext("")        // 검색 가능: false
+```
+
+`query`가 첫 값을 보냈어도 `isOnline`의 첫 값 전에는 결과를 만들 수 없어요. 한번 값이 생긴 뒤에는 최신 값을 다시 사용해요.
+
+두 개부터 여덟 개까지 받는 오버로드와 컬렉션 오버로드가 있어요. 결과 선택 클로저로 튜플이나 도메인 상태를 만들 수 있고, 같은 타입의 컬렉션은 `[Element]` 결과로 모을 수 있어요.
+
+## 같은 순번의 값을 한 번씩 짝지어요
+
+<!-- rxswift-operator: zip -->
+
+### `zip`
+
+각 소스에서 아직 소비하지 않은 가장 오래된 값을 같은 순번끼리 묶어요.
+
+```swift
+let names = PublishSubject<String>()
+let scores = PublishSubject<Int>()
+
+Observable.zip(names, scores) { name, score in
+  "\(name): \(score)점"
+}
+.subscribe(onNext: { print($0) })
+.disposed(by: disposeBag)
+
+names.onNext("Blob")
+names.onNext("Rx")
+scores.onNext(90)  // Blob: 90점
+scores.onNext(80)  // Rx: 80점
+```
+
+빠른 소스의 소비되지 않은 값은 느린 소스의 다음 값을 기다려요. 속도 차이가 크거나 한쪽이 오래 멈추면 대기 값이 쌓일 수 있어요.
+
+두 개부터 여덟 개까지의 오버로드와 컬렉션 오버로드가 있으며, 결과 선택 클로저로 묶음을 즉시 변환할 수 있어요.
+
+## 도착하는 값을 한 흐름에 섞어요
+
+<!-- rxswift-operator: merge -->
+
+### `merge`
+
+여러 Observable의 같은 타입 값을 도착하는 대로 한 Observable에 전달해요. 짝을 기다리지 않아요.
+
+```swift
+let refreshTap = PublishSubject<String>()
+let foreground = PublishSubject<String>()
+
+Observable.merge(refreshTap, foreground)
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+```
+
+정적 오버로드는 배열, 컬렉션, 가변 인자를 받고, `Observable<Observable<Element>>.merge()`는 내부 Observable들을 평탄화해요.
+
+`merge(maxConcurrent:)`는 동시에 구독할 내부 Observable 수를 제한해요.
+
+```swift
+let requests: Observable<Observable<Response>> = requestQueue
+
+let responses = requests
+  .merge(maxConcurrent: 3)
+```
+
+한 내부 Observable이 실패하면 합쳐진 Observable도 실패하고 다른 내부 구독도 폐기돼요.
+
+## Observable을 앞에서부터 순서대로 이어요
+
+<!-- rxswift-operator: concat -->
+
+### `concat`
+
+첫 Observable이 정상 완료한 뒤 다음 Observable을 구독해 값을 이어 붙여요.
+
+```swift
+let cached = Observable.just("캐시")
+let remote = Observable.just("원격")
+
+Observable.concat(cached, remote)
+// 캐시, 원격
+```
+
+배열·시퀀스·가변 인자 정적 오버로드와 인스턴스 오버로드가 있어요. `Observable<Observable<Element>>.concat()`은 내부 Observable을 한 번에 하나씩 구독해 순서를 지켜요.
+
+앞 Observable이 완료하지 않으면 다음 Observable을 시작하지 않고, 오류가 나면 이어 가지 않고 실패해요.
+
+<!-- rxswift-operator: concatMap -->
+
+### `concatMap(_:)`
+
+각 입력을 내부 Observable로 바꾼 뒤 하나씩 순서대로 구독해 결과를 이어요. `map`과 `concat`을 합친 연산이에요.
+
+```swift
+let uploads = fileURLs
+  .concatMap { url in
+    upload(url)
+  }
+```
+
+입력 순서대로 작업을 수행해야 하는 업로드나 저장에 적합해요. 앞 작업이 끝나지 않으면 뒤 작업이 시작되지 않아 전체 처리 시간이 길어질 수 있어요.
+
+## 먼저 반응한 Observable을 선택해요
+
+<!-- rxswift-operator: amb -->
+
+### `amb(_:)`
+
+여러 Observable 중 **가장 먼저 이벤트를 보낸** 하나를 선택하고, 나머지 구독은 폐기해요. 첫 이벤트는 값뿐 아니라 오류나 완료일 수도 있어요.
+
+```swift
+let fastest = primaryRequest
+  .amb(backupRequest)
+```
+
+동일 데이터를 가져오는 여러 소스 중 먼저 응답한 결과를 쓰는 경주에 적합해요. 선택되지 않은 작업이 실제로 중단되려면 각 Observable의 Disposable이 기반 작업 취소를 구현해야 해요.
+
+컬렉션을 받는 정적 오버로드도 있어요.
+
+## 한 Observable을 트리거로 다른 최신 값을 가져와요
+
+<!-- rxswift-operator: withLatestFrom -->
+
+### `withLatestFrom`
+
+원본 Observable이 값을 보낼 때 두 번째 Observable의 최신 값을 가져와요. 두 번째 Observable이 아직 값을 보내지 않았다면 원본 값은 결과를 만들지 못하고 버려져요.
+
+```swift
+let submitTap = PublishSubject<Void>()
+let latestForm = BehaviorSubject(value: Form.empty)
+
+submitTap
+  .withLatestFrom(latestForm)
+  .subscribe(onNext: { form in
+    submit(form)
+  })
+  .disposed(by: disposeBag)
+```
+
+결과 선택 오버로드는 원본 값과 최신 값을 함께 원하는 결과로 바꿔요.
+
+```swift
+submitTap.withLatestFrom(latestForm) {
+  tap,
+  form in
+  Submission(form: form)
+}
+```
+
+버튼 탭이 폼의 최신 상태를 읽는 것처럼 한쪽이 **언제**, 다른 쪽이 **무엇을** 결정할 때 적합해요.
+
+## 모든 내부 Observable을 함께 유지해요
+
+<!-- rxswift-operator: flatMap -->
+
+### `flatMap(_:)`
+
+각 입력을 내부 Observable로 바꾸고 모든 활성 내부 Observable의 값을 합쳐요.
+
+```swift
+userIDs
+  .flatMap { id in
+    loadUser(id: id)
+  }
+```
+
+입력이 빠르면 여러 내부 구독이 동시에 살아 있고 결과 순서는 입력 순서와 달라질 수 있어요. 동시 수를 제한하려면 중첩 Observable을 만든 뒤 `merge(maxConcurrent:)`, 순서를 보장하려면 `concatMap`을 사용해요.
+
+## 최신 내부 Observable로 전환해요
+
+<!-- rxswift-operator: flatMapLatest -->
+
+### `flatMapLatest(_:)`
+
+각 입력을 내부 Observable로 바꾸고 새 입력이 오면 이전 내부 구독을 폐기해 최신 Observable의 값만 보내요. `map`과 `switchLatest`의 조합이에요.
+
+```swift
+query
+  .debounce(
+    .milliseconds(300),
+    scheduler: MainScheduler.instance
+  )
+  .flatMapLatest { query in
+    search(query)
+      .catchAndReturn([])
+  }
+```
+
+검색 자동 완성처럼 이전 결과가 더 이상 필요 없는 흐름에 적합해요. 구독 폐기가 실제 네트워크 요청 취소로 이어지는지는 소스 구현에 달려 있어요.
+
+<!-- rxswift-operator: switchLatest -->
+
+### `switchLatest()`
+
+원본의 `Element` 자체가 Observable일 때 새 내부 Observable이 오면 이전 내부 구독을 폐기하고 최신 값만 전달해요.
+
+```swift
+let requestStreams: Observable<Observable<[Product]>> = query
+  .map(search)
+
+let latestResults = requestStreams
+  .switchLatest()
+```
+
+이미 중첩 Observable이 있다면 `switchLatest`, 입력을 중첩 Observable로 바꾸는 단계까지 함께 표현하려면 `flatMapLatest`를 사용해요.
+
+## 첫 내부 Observable이 끝날 때까지 새 입력을 무시해요
+
+<!-- rxswift-operator: flatMapFirst -->
+
+### `flatMapFirst(_:)`
+
+내부 Observable이 활성화된 동안 새 원본 입력을 무시해요. 내부 Observable이 끝난 뒤 들어오는 다음 입력부터 새 작업을 만들어요.
+
+```swift
+saveButtonTap
+  .flatMapFirst {
+    saveDocument()
+  }
+```
+
+저장 버튼 중복 탭처럼 실행 중인 작업을 유지하고 추가 요청을 버려야 할 때 적합해요. 새 요청을 대기열에 쌓아야 한다면 `concatMap`, 최신 요청으로 교체해야 한다면 `flatMapLatest`를 사용하세요.
+
+## 내부 작업 정책을 비교해요
+
+| 새 입력이 왔을 때 원하는 동작             | 연산자                          |
+| ----------------------------------------- | ------------------------------- |
+| 기존 작업을 모두 유지하고 결과를 섞어요   | `flatMap`                       |
+| 기존 작업을 취소하고 최신 작업으로 바꿔요 | `flatMapLatest`                 |
+| 기존 작업 중이면 새 입력을 버려요         | `flatMapFirst`                  |
+| 새 입력을 기다렸다가 순서대로 실행해요    | `concatMap`                     |
+| 동시 작업 수만 제한해요                   | `map` + `merge(maxConcurrent:)` |
+
+## 결합 기준을 비교해요
+
+| 질문                                          | 연산자           |
+| --------------------------------------------- | ---------------- |
+| 모든 소스의 최신 상태가 필요한가요?           | `combineLatest`  |
+| 같은 순번의 값을 한 번씩 짝지어야 하나요?     | `zip`            |
+| 같은 타입 이벤트를 도착하는 대로 합칠까요?    | `merge`          |
+| 앞 소스가 끝난 뒤 다음 소스를 시작할까요?     | `concat`         |
+| 트리거 순간 다른 소스의 최신 값이 필요한가요? | `withLatestFrom` |
+| 여러 대안 중 먼저 반응한 소스만 쓸까요?       | `amb`            |
+
+## 참고 자료
+
+- [ObservableType 공식 API](https://docs.rxswift.org/protocols/observabletype)
+- [Combining 연산자 구현](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxSwift/Observables)
+- [ReactiveX Operators](https://reactivex.io/documentation/operators.html)

--- a/docs/guide/rxswift/operators-create-convert.md
+++ b/docs/guide/rxswift/operators-create-convert.md
@@ -1,0 +1,420 @@
+---
+title: RxSwift 연산자 — 생성과 변환
+description: create, just, from, deferred, interval, using으로 Observable을 만들고 Single·Maybe·Completable·Infallible 및 Swift Concurrency로 변환하는 방법을 설명합니다.
+---
+
+# RxSwift 연산자 — 생성과 변환
+
+> **면접 답변 한 줄 요약:** 생성 연산자는 값 생산과 자원 정리 시점을 정의하고, 변환 연산자는 같은 이벤트 흐름에 값 개수·오류 가능성 같은 더 구체적인 타입 계약을 부여해요.
+
+이 페이지는 RxSwift 6.10.2의 Observable 생성 연산자와 Observable·Trait·Swift Concurrency 사이의 변환 API를 모두 설명해요.
+
+## 값을 직접 보내는 Observable을 만들어요
+
+<!-- rxswift-operator: just -->
+
+### `just(_:)`
+
+값 하나를 `.next`로 보내고 정상 완료해요. Scheduler를 받는 오버로드는 해당 Scheduler에서 이벤트를 보내요.
+
+```swift
+Observable.just("RxSwift")
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+```
+
+<!-- rxswift-operator: of -->
+
+### `of(_:scheduler:)`
+
+나열한 값을 순서대로 보내고 정상 완료해요.
+
+```swift
+Observable.of(1, 2, 3)
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+```
+
+배열 자체를 값 하나로 보내려면 `Observable.just([1, 2, 3])`, 배열의 각 요소를 보내려면 `Observable.from([1, 2, 3])`을 사용해요.
+
+<!-- rxswift-operator: from -->
+
+### `from(_:scheduler:)`와 `from(optional:)`
+
+배열이나 `Sequence`의 요소를 차례로 보내요.
+
+```swift
+Observable.from([1, 2, 3])
+```
+
+옵셔널 오버로드는 값이 있으면 하나를 보내고, `nil`이면 값 없이 정상 완료해요.
+
+```swift
+let name: String? = nil
+
+Observable.from(optional: name)
+  .subscribe(
+    onNext: { print($0) },
+    onCompleted: { print("값 없음") }
+  )
+  .disposed(by: disposeBag)
+```
+
+<!-- rxswift-operator: empty -->
+
+### `empty()`
+
+값 없이 즉시 정상 완료해요. 분기에서 “할 일이 없지만 성공적으로 끝남”을 표현할 때 사용해요.
+
+```swift
+let noResults = Observable<String>.empty()
+```
+
+<!-- rxswift-operator: error -->
+
+### `error(_:)`
+
+값 없이 지정한 오류를 즉시 보내고 끝나요.
+
+```swift
+enum LoadError: Error {
+  case offline
+}
+
+let failed = Observable<String>.error(LoadError.offline)
+```
+
+<!-- rxswift-operator: never -->
+
+### `never()`
+
+값, 오류, 완료를 아무것도 보내지 않는 Observable을 만들어요. 구독은 직접 폐기하기 전까지 끝나지 않아요.
+
+```swift
+let pending = Observable<String>.never()
+```
+
+테스트 대역이나 다른 Observable만 결과를 결정해야 하는 결합에 쓸 수 있지만, 실수로 사용하면 대기와 자원이 영원히 남을 수 있어요.
+
+## 구독 로직을 직접 정의해요
+
+<!-- rxswift-operator: create -->
+
+### `create(_:)`
+
+Observer에게 어떤 이벤트를 보낼지 직접 정의하고, 구독을 폐기할 때 실행할 `Disposable`을 반환해요.
+
+```swift
+func loadName() -> Observable<String> {
+  Observable.create { observer in
+    let task = URLSession.shared.dataTask(
+      with: URL(string: "https://example.com/name")!
+    ) { data, _, error in
+      if let error {
+        observer.onError(error)
+        return
+      }
+
+      let name = data.flatMap {
+        String(data: $0, encoding: .utf8)
+      } ?? ""
+
+      observer.onNext(name)
+      observer.onCompleted()
+    }
+
+    task.resume()
+
+    return Disposables.create {
+      task.cancel()
+    }
+  }
+}
+```
+
+다음 규칙을 지켜야 해요.
+
+- `.error` 또는 `.completed` 뒤에 이벤트를 보내지 않아요.
+- 같은 구독에서 이벤트를 동시에 호출하지 않도록 직렬화해요.
+- 반환한 Disposable에서 네트워크·타이머·콜백 등록을 실제로 해제해요.
+- 가능하면 기존 RxSwift 생성 연산자나 공식 래퍼를 먼저 사용해 수동 구현을 줄여요.
+
+<!-- rxswift-operator: deferred -->
+
+### `deferred(_:)`
+
+Observable을 만드는 클로저를 **구독할 때마다** 실행해 새 Observable을 반환해요.
+
+```swift
+let request = Observable.deferred {
+  print("구독 시 요청 생성")
+  return loadName()
+}
+```
+
+현재 시각, 인증 토큰, 요청 객체처럼 매 구독 시점의 상태로 소스를 만들어야 할 때 사용해요. 이미 만들어진 hot Observable을 반환하면 기반 생산까지 새로 만들어지는 것은 아니에요.
+
+<!-- rxswift-operator: using -->
+
+### `using(_:observableFactory:)`
+
+`Disposable`인 자원을 만들고 그 자원으로 Observable을 구성해, 구독이 종료되거나 폐기될 때 자원도 함께 폐기해요.
+
+```swift
+final class FileHandleResource: Disposable {
+  func dispose() {
+    // 열린 파일 핸들을 닫아요.
+  }
+}
+
+let lines = Observable<String>.using(
+  { FileHandleResource() },
+  observableFactory: { resource in
+    // resource로 값을 읽는 Observable을 반환해요.
+    Observable.just("한 줄")
+  }
+)
+```
+
+자원 수명과 Observable 구독 수명을 정확히 묶어야 하는 파일·소켓 래퍼에 적합해요.
+
+## 규칙으로 값을 생성해요
+
+<!-- rxswift-operator: generate -->
+
+### `generate(initialState:condition:scheduler:iterate:)`
+
+초기 상태에서 시작해 조건이 참인 동안 현재 상태를 보내고, `iterate`로 다음 상태를 계산해요.
+
+```swift
+let countdown = Observable.generate(
+  initialState: 3,
+  condition: { $0 >= 0 },
+  scheduler: CurrentThreadScheduler.instance,
+  iterate: { $0 - 1 }
+)
+```
+
+일반 `for` 루프와 비슷한 유한 상태 생성을 Observable 문법으로 표현해요.
+
+<!-- rxswift-operator: range -->
+
+### `range(start:count:scheduler:)`
+
+정수 시작값부터 지정한 개수만큼 연속된 정수를 보내요.
+
+```swift
+Observable.range(start: 5, count: 3)
+// 5, 6, 7
+```
+
+<!-- rxswift-operator: repeatElement -->
+
+### `repeatElement(_:scheduler:)`
+
+같은 값을 끝없이 반복해요. `take`, `take(for:)`, 구독 폐기 같은 종료 조건과 함께 사용해야 해요.
+
+```swift
+Observable.repeatElement("ping")
+  .take(3)
+// ping, ping, ping
+```
+
+<!-- rxswift-operator: interval -->
+
+### `interval(_:scheduler:)`
+
+지정한 주기마다 `0`부터 증가하는 정수를 끝없이 보내요.
+
+```swift
+Observable<Int>
+  .interval(
+    .seconds(1),
+    scheduler: MainScheduler.instance
+  )
+```
+
+첫 값도 한 주기가 지난 뒤 와요. 화면이 사라질 때 구독이 폐기되도록 수명을 관리하세요.
+
+<!-- rxswift-operator: timer -->
+
+### `timer(_:period:scheduler:)`
+
+첫 대기 시간이 지난 뒤 정수 값을 보내요. `period`를 지정하면 이후에도 주기적으로 증가하는 값을 보내고, `nil`이면 값 하나를 보낸 뒤 완료해요.
+
+```swift
+let once = Observable<Int>.timer(
+  .seconds(2),
+  scheduler: MainScheduler.instance
+)
+
+let repeating = Observable<Int>.timer(
+  .seconds(1),
+  period: .seconds(5),
+  scheduler: MainScheduler.instance
+)
+```
+
+`interval`은 첫 대기와 반복 주기가 같고, `timer`는 첫 대기와 반복 주기를 다르게 정할 수 있어요.
+
+## Observable의 구체 타입을 맞춰요
+
+<!-- rxswift-operator: asObservable -->
+
+### `asObservable()`
+
+`ObservableType`이나 Trait을 일반 `Observable<Element>`로 바꿔요. 이벤트 동작은 유지하고 구체 래퍼 타입만 지워 API 경계를 단순하게 해요.
+
+```swift
+let observable: Observable<String> = Single
+  .just("RxSwift")
+  .asObservable()
+```
+
+RxSwift 6.10.2에는 반대 방향의 Swift Concurrency 브리지도 있어요. `AsyncSequence.asObservable(priority:)`는 별도 Task에서 비동기 시퀀스를 순회하고 값·오류·완료를 Observable 이벤트로 바꿔요.
+
+```swift
+let stream = AsyncStream<Int> { continuation in
+  continuation.yield(1)
+  continuation.finish()
+}
+
+let observable = stream.asObservable()
+```
+
+구독을 폐기하면 내부 Task도 취소돼요. UI 전달 위치는 `observe(on:)`으로 별도 지정하세요.
+
+<!-- rxswift-operator: asSingle -->
+
+### `asSingle()`
+
+원본이 정상 완료할 때 값이 정확히 하나였으면 `Single<Element>`로 바꿔요. 값이 없으면 `RxError.noElements`, 둘 이상이면 `RxError.moreThanOneElement`로 실패해요.
+
+```swift
+let single = Observable.just("한 개")
+  .asSingle()
+```
+
+`take(1).asSingle()`처럼 앞에서 값을 잘라 쓰면 “원본에 값이 하나뿐”이라는 계약을 검증하지 못하므로 API 의도를 구분하세요.
+
+<!-- rxswift-operator: asMaybe -->
+
+### `asMaybe()`
+
+원본이 정상 완료할 때 값이 0개 또는 1개면 `Maybe<Element>`로 바꿔요. 둘 이상이면 `RxError.moreThanOneElement`로 실패해요.
+
+```swift
+let cachedName = Observable<String>.empty()
+  .asMaybe()
+```
+
+<!-- rxswift-operator: asCompletable -->
+
+### `asCompletable()`
+
+원본의 모든 `.next` 값을 무시하고 정상 완료나 오류만 `Completable`로 전달해요.
+
+```swift
+let finished = loadName()
+  .asCompletable()
+```
+
+결과 값은 필요 없고 작업 성공 여부만 계약으로 노출할 때 사용해요.
+
+<!-- rxswift-operator: asInfallible -->
+
+### `asInfallible(...)`
+
+오류 가능한 Observable이나 Trait을 오류가 없는 `Infallible`로 바꿔요. 오류를 없애는 정책을 반드시 하나 제공해야 해요.
+
+| 오버로드            | 오류가 오면 하는 일                       |
+| ------------------- | ----------------------------------------- |
+| `onErrorJustReturn` | 대체 값 하나를 보내요.                    |
+| `onErrorFallbackTo` | 대체 `Infallible`로 전환해요.             |
+| `onErrorRecover`    | 오류를 보고 대체 `Infallible`을 선택해요. |
+
+```swift
+let safe = loadName()
+  .asInfallible(onErrorJustReturn: "알 수 없음")
+```
+
+오류를 무시해도 되는 도메인인지 먼저 판단하고, 진단이 필요하면 변환 전에 `do(onError:)`로 기록하세요.
+
+## Swift Concurrency로 값을 읽어요
+
+<!-- rxswift-operator: values -->
+
+### `values`
+
+Observable과 오류 가능한 타입은 `AsyncThrowingStream`으로 변환되어 `for try await`로 순회해요.
+
+```swift
+let task = Task {
+  do {
+    for try await value in observable.values {
+      print(value)
+    }
+  } catch {
+    print(error)
+  }
+}
+```
+
+`Infallible`은 `AsyncStream`을 제공하므로 `for await`로 순회할 수 있어요. Task가 취소되면 구독도 폐기되고, Observable 구독이 완료되지 않은 채 폐기되면 비동기 순회에는 `CancellationError`가 전달될 수 있어요.
+
+<!-- rxswift-operator: value -->
+
+### `value`
+
+값이 최대 하나인 Primitive Sequence는 프로퍼티를 직접 `await`할 수 있어요.
+
+```swift
+let name: String = try await nameSingle.value
+let cached: String? = try await cachedMaybe.value
+try await saveCompletable.value
+```
+
+- `Single.value`는 `Element`를 반환하거나 던져요.
+- `Maybe.value`는 값이 없으면 `nil`, 오류면 던져요.
+- `Completable.value`는 정상 완료 시 `Void`, 오류면 던져요.
+
+Task와 기반 작업의 취소가 서로 전파되는지 사용자 정의 Observable의 Disposable 구현도 확인하세요.
+
+## Data를 Decodable 타입으로 바꿔요
+
+<!-- rxswift-operator: decode -->
+
+### `decode(type:decoder:)`
+
+각 `Data`를 지정한 `TopLevelDecoder`로 `Decodable` 타입에 디코딩해요. 실패하면 디코딩 오류로 시퀀스가 끝나요.
+
+```swift
+struct Product: Decodable {
+  let name: String
+}
+
+let products = responseData
+  .decode(type: [Product].self, decoder: JSONDecoder())
+```
+
+네트워크 상태 코드와 빈 응답 검증은 디코딩 전에 처리해야 해요. 이 연산자는 데이터 형식 변환만 책임져요.
+
+## 생성 방법을 비교해요
+
+| 요구사항                         | 선택                           |
+| -------------------------------- | ------------------------------ |
+| 이미 있는 값 하나                | `just`                         |
+| 값 여러 개                       | `of`, `from`                   |
+| 값 없이 정상 완료·오류·무한 대기 | `empty`, `error`, `never`      |
+| 구독마다 최신 상태로 소스 생성   | `deferred`                     |
+| 콜백 API를 직접 감싸고 취소 연결 | `create`                       |
+| 자원 수명을 구독과 묶기          | `using`                        |
+| 일정한 규칙의 정수·시간 값       | `range`, `interval`, `timer`   |
+| Swift 비동기 시퀀스 연결         | `AsyncSequence.asObservable()` |
+
+## 참고 자료
+
+- [ObservableType 공식 API](https://docs.rxswift.org/protocols/observabletype)
+- [Observable 생성 소스](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxSwift/Observables)
+- [PrimitiveSequence](https://docs.rxswift.org/rxswift/traits/primitivesequence)
+- [Swift Concurrency](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/SwiftConcurrency.md)

--- a/docs/guide/rxswift/operators-error-lifecycle.md
+++ b/docs/guide/rxswift/operators-error-lifecycle.md
@@ -1,0 +1,237 @@
+---
+title: RxSwift 연산자 — 오류·스케줄러·구독
+description: catch와 retry로 오류를 복구하고 observe, subscribe, do, debug로 실행 위치와 Observable 생명주기를 다루는 방법을 설명합니다.
+---
+
+# RxSwift 연산자 — 오류·스케줄러·구독
+
+> **면접 답변 한 줄 요약:** `catch`는 실패를 다른 흐름으로 바꾸고 `retry`는 원본을 다시 구독하며, `observe(on:)`과 `subscribe(on:)`은 각각 이벤트 전달과 구독 부수 효과가 실행될 스케줄러를 정해요.
+
+Observable의 오류는 값 하나가 아니라 시퀀스를 끝내는 종료 이벤트예요. 따라서 복구 연산자는 오류 뒤에 같은 구독을 계속하는 것이 아니라 대체 Observable로 전환하거나 원본 Observable을 새로 구독해요.
+
+## 오류를 다른 Observable로 바꿔요
+
+<!-- rxswift-operator: catch -->
+
+### `catch(_:)`
+
+원본이 오류로 끝나면 오류를 클로저에 전달하고, 클로저가 반환한 Observable로 전환해요. 정상 완료하면 복구 클로저는 호출되지 않아요.
+
+```swift
+let products = remoteProducts()
+  .catch { error in
+    logger.record(error)
+    return cachedProducts()
+  }
+```
+
+복구 클로저 자체도 `throw`할 수 있어요. 클로저가 오류를 던지거나 대체 Observable이 실패하면 결과도 그 오류로 끝나요.
+
+정적 `Observable.catch(_:)`는 Observable 시퀀스를 앞에서부터 구독해요. 하나가 실패하면 다음 후보로 넘어가고, 어느 후보가 정상 완료하면 전체도 완료해요.
+
+```swift
+let products = Observable.catch(sequence: [
+  primaryProducts(),
+  backupProducts(),
+  cachedProducts(),
+])
+```
+
+모든 후보가 실패하면 마지막 오류를 전달해요. 단순 대체 값이 아니라 실패 원인에 따라 다른 정책을 적용할 때 적합해요.
+
+<!-- rxswift-operator: catchAndReturn -->
+
+### `catchAndReturn(_:)`
+
+오류가 오면 대체 값 하나를 보낸 뒤 정상 완료해요.
+
+```swift
+let count = loadCartCount()
+  .catchAndReturn(0)
+```
+
+오류 정보를 버리므로 진단이 필요하면 앞에서 `do(onError:)`로 기록하세요. 오류와 정상적인 기본값을 도메인에서 구분해야 한다면 `Result` 같은 값으로 바꾸는 편이 더 명확할 수 있어요.
+
+## 실패한 작업을 다시 구독해요
+
+<!-- rxswift-operator: retry -->
+
+### `retry(...)`
+
+원본이 실패하면 원본 Observable을 다시 구독해요.
+
+```swift
+let response = request()
+  .retry(3)
+```
+
+RxSwift의 `retry(3)`에서 `3`은 **최대 전체 시도 횟수**예요. 최초 구독 한 번과 재시도 두 번을 합쳐 최대 세 번 실행해요. 인자 없는 `retry()`는 성공하거나 구독이 폐기될 때까지 제한 없이 재시도하므로 지속적으로 실패하는 작업에 그대로 사용하지 마세요.
+
+`retry(when:)`은 오류 Observable을 알림 Observable로 바꿔 재시도 시점과 종료 조건을 정해요.
+
+```swift
+let response = request()
+  .retry { errors in
+    errors
+      .enumerated()
+      .flatMap { attempt, error -> Observable<Int> in
+        guard attempt < 2 else {
+          return .error(error)
+        }
+
+        return Observable<Int>
+          .timer(
+            .seconds(attempt + 1),
+            scheduler: MainScheduler.instance
+          )
+      }
+  }
+```
+
+알림 Observable의 이벤트에 따라 동작이 달라져요.
+
+| 알림 Observable의 이벤트 | 결과                                     |
+| ------------------------ | ---------------------------------------- |
+| `next`                   | 원본을 다시 구독해요.                    |
+| `completed`              | 더 재시도하지 않고 결과를 정상 완료해요. |
+| `error`                  | 해당 오류로 결과를 종료해요.             |
+
+결제처럼 중복 실행이 위험한 작업에는 멱등성 키나 서버 정책 없이 재시도를 붙이면 안 돼요. 네트워크 오류처럼 다시 시도할 가치가 있는 오류만 선별하고, 횟수 제한과 지수 백오프를 함께 설계하세요.
+
+## 이벤트를 받을 실행 문맥을 정해요
+
+<!-- rxswift-operator: observe -->
+
+### `observe(on:)`
+
+이 연산자 뒤로 전달되는 `next`, `error`, `completed` 이벤트와 하위 연산자의 작업을 지정한 스케줄러에서 실행해요.
+
+```swift
+loadProfile()
+  .observe(on: MainScheduler.instance)
+  .subscribe(onNext: { profile in
+    nameLabel.text = profile.name
+  })
+  .disposed(by: disposeBag)
+```
+
+UI 갱신 직전에 메인 스케줄러로 전환하는 식으로 사용해요. 체인에 여러 번 배치하면 각각의 위치부터 실행 문맥이 바뀌어요.
+
+<!-- rxswift-operator: subscribe -->
+
+### `subscribe(...)`
+
+Observable을 구독해 실행을 시작하고 `Disposable`을 반환해요. 이벤트 전체를 받거나 `onNext`, `onError`, `onCompleted`, `onDisposed` 클로저를 나눠 전달할 수 있어요.
+
+```swift
+let disposable = loadProfile()
+  .subscribe(
+    onNext: { profile in
+      print(profile.name)
+    },
+    onError: { error in
+      print("실패:", error)
+    },
+    onCompleted: {
+      print("완료")
+    },
+    onDisposed: {
+      print("구독 정리")
+    }
+  )
+
+disposable.disposed(by: disposeBag)
+```
+
+`subscribe(with:onNext:onError:onCompleted:onDisposed:)` 오버로드는 객체를 약하게 캡처해 구독 클로저와 객체 사이의 강한 참조 순환을 줄여요.
+
+```swift
+viewModel.output
+  .subscribe(with: self) { owner, value in
+    owner.render(value)
+  }
+  .disposed(by: disposeBag)
+```
+
+오류 가능한 Observable에서 `onError`를 생략하면 처리되지 않은 오류가 RxSwift의 기본 오류 처리 훅으로 전달돼요. 오류가 실제로 불가능한 계약이라면 `Infallible`, `Driver`처럼 타입으로 표현하고, 그렇지 않다면 오류 처리를 명시하세요.
+
+### `subscribe(on:)`
+
+`subscribe(on:)`은 원본에 대한 **구독과 구독 해제 부수 효과**가 실행될 스케줄러를 정해요. 체인 어디에 놓아도 주로 소스 쪽 동작에 영향을 줘요.
+
+```swift
+let image = decodeImage()
+  .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .userInitiated))
+  .observe(on: MainScheduler.instance)
+```
+
+두 스케줄러 연산자의 차이를 정리하면 다음과 같아요.
+
+| 질문                                       | 연산자           |
+| ------------------------------------------ | ---------------- |
+| 소스 구독과 구독 해제를 어디서 실행할까요? | `subscribe(on:)` |
+| 이후 이벤트와 연산자를 어디서 실행할까요?  | `observe(on:)`   |
+
+RxSwift 연산자는 별도 지정이 없으면 현재 실행 문맥에서 동작해요. `Observable`이라는 이유만으로 자동으로 백그라운드 실행되는 것은 아니에요.
+
+## 생명주기에 부수 효과를 끼워 넣어요
+
+<!-- rxswift-operator: do -->
+
+### `do(...)`
+
+이벤트를 바꾸지 않고 구독 생명주기를 관찰해요. 로깅, 지표 수집, 로딩 상태 변경처럼 흐름 밖의 부수 효과에 사용해요.
+
+```swift
+loadProfile()
+  .do(
+    onSubscribe: {
+      loading.accept(true)
+    },
+    onNext: { profile in
+      metrics.record(profile)
+    },
+    onError: { error in
+      logger.record(error)
+    },
+    onDispose: {
+      loading.accept(false)
+    }
+  )
+```
+
+값·오류·완료의 전달 전후를 관찰하는 `onNext`/`afterNext`, `onError`/`afterError`, `onCompleted`/`afterCompleted`와 `onSubscribe`, `onSubscribed`, `onDispose`를 제공해요.
+
+`onCompleted`는 정상 완료 때만 호출되지만 `onDispose`는 정상 완료, 오류, 수동 폐기 뒤의 정리 시점에 호출돼요. `do` 클로저가 오류를 던지면 원래 이벤트 대신 그 오류로 시퀀스가 끝날 수 있으므로 관찰 코드도 안전하게 작성해야 해요.
+
+<!-- rxswift-operator: debug -->
+
+### `debug(...)`
+
+구독, 이벤트, 폐기 과정을 콘솔에 출력해요. 식별자를 지정하면 여러 체인을 구분할 수 있어요.
+
+```swift
+loadProfile()
+  .debug("profile-request", trimOutput: true)
+  .subscribe()
+  .disposed(by: disposeBag)
+```
+
+`trimOutput`은 긴 이벤트 설명을 잘라 로그 폭을 제한해요. `debug`는 개발 중 흐름을 확인하는 도구예요. 운영 환경의 구조화된 로깅, 개인정보 마스킹, 장애 추적은 별도 로거로 설계하세요.
+
+## 종료와 폐기를 구분해요
+
+| 상황                    | `completed`/`error` | 구독 폐기 | `onDispose` |
+| ----------------------- | ------------------- | --------- | ----------- |
+| 정상 완료               | `completed`         | 실행됨    | 호출됨      |
+| 오류 종료               | `error`             | 실행됨    | 호출됨      |
+| `dispose()`로 조기 중단 | 전달되지 않음       | 실행됨    | 호출됨      |
+
+구독을 폐기하면 이후 이벤트 전달을 중단하지만, 사용자 정의 Observable이 반환한 Disposable에서 기반 작업 취소를 구현해야 네트워크 요청이나 타이머 같은 실제 자원도 중단돼요.
+
+## 참고 자료
+
+- [ObservableType 공식 API](https://docs.rxswift.org/protocols/observabletype)
+- [오류 처리 연산자 구현](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxSwift/Observables)
+- [Schedulers 문서](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Schedulers.md)
+- [RxSwift Hooks](https://docs.rxswift.org/enums/hooks)

--- a/docs/guide/rxswift/operators-select-time.md
+++ b/docs/guide/rxswift/operators-select-time.md
@@ -1,0 +1,357 @@
+---
+title: RxSwift 연산자 — 선택·집계·시간
+description: element, first, single, skip, take, buffer, window, debounce, throttle, delay, timeout으로 필요한 값과 전달 시점을 제어하는 방법을 설명합니다.
+---
+
+# RxSwift 연산자 — 선택·집계·시간
+
+> **면접 답변 한 줄 요약:** 선택 연산자는 필요한 위치·조건·구간의 값만 남기고, 집계 연산자는 완료 시 결과를 모으며, 시간 연산자는 Scheduler를 기준으로 값의 전달 빈도와 종료 시점을 제어해요.
+
+이 페이지의 연산자는 값의 개수와 종료 시점을 크게 바꿀 수 있어요. 끝나지 않는 Observable에 완료가 필요한 집계 연산자를 사용하면 결과도 나오지 않는다는 점부터 확인하세요.
+
+## 위치와 개수로 값을 선택해요
+
+<!-- rxswift-operator: element -->
+
+### `element(at:)`
+
+0부터 시작하는 지정 위치의 값 하나를 보내고 정상 완료해요. 해당 위치 전에 원본이 완료하면 `RxError.argumentOutOfRange`로 실패해요.
+
+```swift
+Observable.of("A", "B", "C")
+  .element(at: 1)
+// B
+```
+
+<!-- rxswift-operator: first -->
+
+### `first()`
+
+첫 값 하나를 `Single<Element?>`로 보내요. 원본이 값 없이 정상 완료하면 `nil`을 보내고, 원본 오류는 그대로 전달해요.
+
+```swift
+let firstName: Single<String?> = names.first()
+```
+
+값이 반드시 하나 있어야 한다면 `take(1)`보다 계약이 명확한 `asSingle` 또는 도메인 API의 `Single`을 검토하세요.
+
+<!-- rxswift-operator: single -->
+
+### `single()`과 `single(_:)`
+
+원본이 정상 완료할 때 값이 정확히 하나면 그 값을 보내요. 값이 없으면 `RxError.noElements`, 둘 이상이면 `RxError.moreThanOneElement`로 실패해요.
+
+```swift
+Observable.just("한 개")
+  .single()
+```
+
+조건 오버로드는 조건에 맞는 값이 정확히 하나인지 검사해요.
+
+```swift
+Observable.of(1, 2, 3)
+  .single { $0.isMultiple(of: 2) }
+// 2
+```
+
+`first`는 첫 값을 찾으면 끝낼 수 있지만, `single`은 두 번째 일치 값이 없는지 확인해야 하므로 원본 완료까지 검사해요.
+
+<!-- rxswift-operator: skip -->
+
+### `skip(...)`
+
+시작 부분을 여러 기준으로 버려요.
+
+| 오버로드                     | 동작                                                            |
+| ---------------------------- | --------------------------------------------------------------- |
+| `skip(count)`                | 처음 지정한 개수의 값을 버려요.                                 |
+| `skip(duration, scheduler:)` | 구독 뒤 지정한 시간 동안 도착한 값을 버려요.                    |
+| `skip(while:)`               | 조건이 참인 시작 구간을 버리고, 처음 거짓인 값부터 모두 보내요. |
+| `skip(until:)`               | 다른 Observable이 값을 보낼 때까지 원본 값을 버려요.            |
+
+```swift
+Observable.of(1, 2, 5, 1)
+  .skip(while: { $0 < 5 })
+// 5, 1
+```
+
+전체 시퀀스에서 조건에 맞지 않는 값을 계속 버리려면 `filter`를 사용해요.
+
+<!-- rxswift-operator: take -->
+
+### `take(...)`
+
+시작 부분에서 값을 가져오고 조건이 충족되면 정상 완료해요.
+
+| 오버로드                | 동작                                                     |
+| ----------------------- | -------------------------------------------------------- |
+| `take(count)`           | 처음 지정한 개수만 보내요.                               |
+| `take(for:scheduler:)`  | 구독 뒤 지정한 시간 동안 온 값만 보내요.                 |
+| `take(until: other)`    | 다른 Observable이 값을 보내기 전까지만 원본 값을 보내요. |
+| `take(while:behavior:)` | 조건이 참인 동안 보내요.                                 |
+| `take(until:behavior:)` | 조건이 참이 되는 지점까지 보내요.                        |
+
+`TakeBehavior.exclusive`는 조건을 깨거나 만족시킨 경계 값을 제외하고, `.inclusive`는 그 값도 포함해요.
+
+```swift
+Observable.of(1, 2, 5, 1)
+  .take(while: { $0 < 5 }, behavior: .inclusive)
+// 1, 2, 5
+```
+
+화면 객체 해제 신호나 취소 버튼 Observable을 `take(until:)`에 연결하면 구독 수명을 선언적으로 제한할 수 있어요.
+
+<!-- rxswift-operator: takeLast -->
+
+### `takeLast(_:)`
+
+원본이 정상 완료할 때 마지막 N개 값을 원래 순서대로 보내요.
+
+```swift
+Observable.of(1, 2, 3, 4)
+  .takeLast(2)
+// 정상 완료 뒤 3, 4
+```
+
+끝나지 않는 Observable에서는 값을 내보내지 않고, N개 값을 내부에 보관하므로 메모리 비용도 고려해야 해요.
+
+## 값을 앞에 붙이거나 빈 결과를 바꿔요
+
+<!-- rxswift-operator: startWith -->
+
+### `startWith(_:)`
+
+원본을 구독해 값을 받기 전에 나열한 초기값을 먼저 보내요.
+
+```swift
+searchResults
+  .startWith([])
+```
+
+현재 상태를 저장하고 새 Observer에게 재생해야 하는 요구라면 `BehaviorSubject`, `BehaviorRelay`, `share(replay:)`와 의미를 비교하세요.
+
+<!-- rxswift-operator: ifEmpty -->
+
+### `ifEmpty(default:)`와 `ifEmpty(switchTo:)`
+
+원본이 값 없이 정상 완료했을 때 대체 결과를 만들어요.
+
+```swift
+Observable<String>.empty()
+  .ifEmpty(default: "결과 없음")
+```
+
+`switchTo` 오버로드는 대체 Observable로 전환해요.
+
+```swift
+remoteResults
+  .ifEmpty(switchTo: cachedResults)
+```
+
+원본이 오류로 끝나면 빈 결과가 아니므로 대체하지 않고 오류를 전달해요. 오류 복구는 `catch`를 사용하세요.
+
+## 완료 뒤 전체 결과를 받아요
+
+<!-- rxswift-operator: toArray -->
+
+### `toArray()`
+
+원본의 모든 값을 배열에 모으고 정상 완료할 때 `Single<[Element]>` 하나를 보내요.
+
+```swift
+let all: Single<[Int]> = Observable
+  .of(1, 2, 3)
+  .toArray()
+```
+
+끝나지 않거나 값이 매우 많은 Observable에서는 결과가 나오지 않거나 메모리가 커질 수 있어요. 일부씩 처리하려면 `buffer`를 사용하세요.
+
+<!-- rxswift-operator: ignoreElements -->
+
+### `ignoreElements()`
+
+모든 `.next` 값을 버리고 오류와 정상 완료만 전달하는 `Observable<Never>`를 반환해요.
+
+```swift
+let completionOnly = saveProgress
+  .ignoreElements()
+```
+
+작업 결과 값은 필요 없고 종료만 다음 흐름에 연결할 때 사용해요. `Completable` 타입 계약이 필요하면 `asCompletable()`로 변환하세요.
+
+## 값을 배열이나 작은 Observable로 묶어요
+
+<!-- rxswift-operator: buffer -->
+
+### `buffer(timeSpan:count:scheduler:)`
+
+지정한 시간이나 개수 중 먼저 충족한 기준마다 값을 배열로 묶어 보내요.
+
+```swift
+events
+  .buffer(
+    timeSpan: .seconds(1),
+    count: 20,
+    scheduler: MainScheduler.instance
+  )
+  .subscribe(onNext: { batch in
+    print("일괄 처리:", batch)
+  })
+```
+
+빠른 이벤트를 일괄 처리해 Observer 호출 횟수를 줄일 수 있어요. 배열을 만드는 동안 메모리가 필요하고 처리 지연이 생겨요.
+
+<!-- rxswift-operator: window -->
+
+### `window(timeSpan:count:scheduler:)`
+
+`buffer`와 같은 시간·개수 기준으로 나누지만 배열 대신 각 구간을 `Observable<Element>`로 보내요.
+
+```swift
+events
+  .window(
+    timeSpan: .seconds(1),
+    count: 20,
+    scheduler: MainScheduler.instance
+  )
+  .flatMap { window in
+    window.reduce(0) { count, _ in count + 1 }
+  }
+```
+
+구간 내부도 연산자로 처리하거나 값이 도착하는 즉시 소비하고 싶을 때 사용해요. 바깥 Observable과 각 window의 구독·종료 수명을 함께 추적해야 해서 배열보다 구조가 복잡해요.
+
+## 다른 Observable의 틱에 최신 값을 뽑아요
+
+<!-- rxswift-operator: sample -->
+
+### `sample(_:defaultValue:)`
+
+sampler Observable이 값을 보낼 때, 직전 sampler 틱 이후 원본에서 새로 들어온 최신 값 하나를 보내요.
+
+```swift
+sensorValues
+  .sample(
+    Observable<Int>.interval(
+      .seconds(1),
+      scheduler: MainScheduler.instance
+    )
+  )
+```
+
+틱 사이에 새 값이 없다면 기본적으로 아무것도 보내지 않고, `defaultValue`를 지정하면 그 값을 보내요. 일정 주기마다 최신 상태를 확인하는 흐름에 적합해요.
+
+## 입력이 잠잠해지면 최신 값을 보내요
+
+<!-- rxswift-operator: debounce -->
+
+### `debounce(_:scheduler:)`
+
+값을 받은 뒤 지정한 시간 안에 새 값이 오지 않을 때 최신 값을 보내요. 기다리는 중 새 값이 오면 이전 값은 버리고 타이머를 다시 시작해요.
+
+```swift
+query
+  .debounce(
+    .milliseconds(300),
+    scheduler: MainScheduler.instance
+  )
+  .distinctUntilChanged()
+```
+
+검색어처럼 사용자가 잠시 멈춘 뒤 마지막 값을 처리할 때 적합해요. 값이 계속 빠르게 오면 전달이 계속 미뤄질 수 있어요.
+
+<!-- rxswift-operator: throttle -->
+
+### `throttle(_:latest:scheduler:)`
+
+두 출력 사이가 지정한 시간보다 짧지 않도록 제한해요. 첫 값은 보내고, `latest: true`이면 제한 구간에 들어온 최신 값도 다음 가능한 시점에 보내요.
+
+```swift
+scrollOffsets
+  .throttle(
+    .milliseconds(100),
+    latest: true,
+    scheduler: MainScheduler.instance
+  )
+```
+
+`debounce`는 조용한 구간을 기다리지만 `throttle`은 입력이 계속 와도 제한된 빈도로 값을 보낼 수 있어요. `latest: false`이면 구간 중 뒤에 들어온 값을 보존하지 않아요.
+
+## 이벤트나 구독 시작을 미뤄요
+
+<!-- rxswift-operator: delay -->
+
+### `delay(_:scheduler:)`
+
+원본의 값과 정상 완료를 지정한 시간만큼 뒤로 미뤄요. **오류 이벤트는 지연하지 않고 즉시 전달해요.**
+
+```swift
+Observable.just("표시")
+  .delay(
+    .seconds(1),
+    scheduler: MainScheduler.instance
+  )
+```
+
+<!-- rxswift-operator: delaySubscription -->
+
+### `delaySubscription(_:scheduler:)`
+
+원본 Observable을 구독하는 시점 자체를 미뤄요.
+
+```swift
+let delayedRequest = request
+  .delaySubscription(
+    .seconds(1),
+    scheduler: MainScheduler.instance
+  )
+```
+
+`delay`는 작업이 시작된 뒤 이벤트 전달을 미루고, `delaySubscription`은 cold Observable의 작업 시작 자체를 늦출 수 있다는 차이가 있어요.
+
+## 값 사이 대기가 너무 길면 종료하거나 전환해요
+
+<!-- rxswift-operator: timeout -->
+
+### `timeout(_:scheduler:)`와 `timeout(_:other:scheduler:)`
+
+이전 값 뒤 지정한 시간 안에 다음 값이 오지 않으면 기본 오버로드는 `RxError.timeout`으로 실패해요.
+
+```swift
+request
+  .timeout(
+    .seconds(5),
+    scheduler: MainScheduler.instance
+  )
+```
+
+`other` 오버로드는 오류 대신 대체 Observable로 전환해 이후 이벤트를 받아요.
+
+```swift
+remote
+  .timeout(
+    .seconds(5),
+    other: cached,
+    scheduler: MainScheduler.instance
+  )
+```
+
+이 연산자는 이벤트 사이의 제한 시간을 다뤄요. 기반 네트워크 요청이 실제로 취소되는지는 원본 Observable이 폐기를 작업 취소에 연결했는지도 확인해야 해요.
+
+## 선택 기준을 정리해요
+
+| 질문                                          | 연산자                            |
+| --------------------------------------------- | --------------------------------- |
+| 첫 값, 정확히 한 값, 특정 위치 중 무엇인가요? | `first`, `single`, `element`      |
+| 앞부분을 버리거나 가져올까요?                 | `skip`, `take`                    |
+| 완료 뒤 마지막 값이나 전체 값이 필요한가요?   | `takeLast`, `toArray`             |
+| 값은 버리고 종료만 필요한가요?                | `ignoreElements`, `asCompletable` |
+| 값이 잠잠해진 뒤 처리할까요?                  | `debounce`                        |
+| 계속 오는 값을 제한된 빈도로 처리할까요?      | `throttle`, `sample`              |
+| 모든 이벤트를 미룰지 구독 자체를 미룰까요?    | `delay`, `delaySubscription`      |
+
+## 참고 자료
+
+- [ObservableType 공식 API](https://docs.rxswift.org/protocols/observabletype)
+- [Selection 연산자 구현](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxSwift/Observables)
+- [Schedulers](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Schedulers.md)

--- a/docs/guide/rxswift/operators-share-connect.md
+++ b/docs/guide/rxswift/operators-share-connect.md
@@ -1,0 +1,185 @@
+---
+title: RxSwift 연산자 — 공유와 연결
+description: multicast, publish, replay, share, connect, refCount로 하나의 원본 구독을 여러 Observer가 안전하게 공유하는 방법을 설명합니다.
+---
+
+# RxSwift 연산자 — 공유와 연결
+
+> **면접 답변 한 줄 요약:** `publish`와 `replay`는 원본을 Connectable Observable로 만들고 `connect`가 공유 구독을 시작하며, `refCount`와 `share`는 구독자 수에 맞춰 연결 수명을 자동 관리해요.
+
+일반적인 cold Observable은 Observer마다 원본 작업을 새로 시작해요. 네트워크 요청 하나를 여러 화면 상태가 구독하면 요청도 여러 번 실행될 수 있어요. 공유 연산자는 원본 구독 하나의 이벤트를 여러 Observer에게 전달해 이런 중복을 제어해요.
+
+## Subject를 통해 원본 구독을 공유해요
+
+<!-- rxswift-operator: multicast -->
+
+### `multicast(...)`
+
+원본 이벤트를 지정한 Subject에 전달하는 `ConnectableObservable`을 만들어요. Observer들은 원본이 아니라 같은 Subject를 구독해요.
+
+```swift
+let shared = source.multicast(PublishSubject<Int>())
+
+shared
+  .subscribe(onNext: { print("A:", $0) })
+  .disposed(by: disposeBag)
+
+shared
+  .subscribe(onNext: { print("B:", $0) })
+  .disposed(by: disposeBag)
+
+let connection = shared.connect()
+connection.disposed(by: disposeBag)
+```
+
+Subject 인스턴스, 구독 연결마다 Subject를 만드는 팩터리, 공유 범위 안에서 결과 Observable을 선택하는 오버로드가 있어요. 직접 사용할 때는 Subject의 버퍼와 종료 이벤트 보존 특성이 공유 결과에도 적용된다는 점을 확인하세요.
+
+<!-- rxswift-operator: publish -->
+
+### `publish()`
+
+`PublishSubject`를 사용한 `multicast`의 간단한 형태예요. 연결 뒤에 도착한 이벤트만 현재 구독자에게 전달하고 이전 값은 재생하지 않아요.
+
+```swift
+let connectable = request().publish()
+```
+
+모든 Observer를 먼저 등록한 다음 `connect()`를 호출해 같은 시작점에서 이벤트를 받게 할 때 유용해요.
+
+<!-- rxswift-operator: replay -->
+
+### `replay(_:)`
+
+지정한 개수만큼 최근 값을 보관하는 Connectable Observable을 만들어요. 늦게 구독한 Observer는 버퍼의 최근 값을 먼저 받고 이어서 새 값을 받아요.
+
+```swift
+let connectable = request()
+  .replay(1)
+```
+
+상태나 마지막 응답을 늦은 구독자에게 전달할 때 `replay(1)`을 자주 사용해요. 버퍼 수가 크고 값이 무거우면 메모리 사용량도 커져요.
+
+<!-- rxswift-operator: replayAll -->
+
+### `replayAll()`
+
+연결 뒤에 발생한 모든 값을 보관해 늦은 구독자에게 다시 보내요.
+
+```swift
+let history = events.replayAll()
+```
+
+완료되지 않는 장기 스트림에서는 버퍼가 제한 없이 커질 수 있어요. 전체 기록이 정말 필요하고 시퀀스 길이가 제한된 경우가 아니라면 `replay(_:)`로 상한을 두세요.
+
+## 공유 연결을 직접 시작하고 끝내요
+
+<!-- rxswift-operator: connect -->
+
+### `connect()`
+
+Connectable Observable을 원본에 연결해 실제 구독을 시작하고, 연결을 끊을 수 있는 `Disposable`을 반환해요.
+
+```swift
+let connectable = ticks.publish()
+
+let first = connectable
+  .subscribe(onNext: { print("A:", $0) })
+let second = connectable
+  .subscribe(onNext: { print("B:", $0) })
+
+let connection = connectable.connect()
+
+first.disposed(by: disposeBag)
+second.disposed(by: disposeBag)
+connection.disposed(by: disposeBag)
+```
+
+Observer의 구독 Disposable과 원본 연결 Disposable은 역할이 달라요. Observer 하나를 폐기해도 다른 Observer와 원본 연결은 유지되고, 연결 Disposable을 폐기하면 공유 중인 원본 구독이 종료돼요.
+
+## 구독자 수로 연결 수명을 관리해요
+
+<!-- rxswift-operator: refCount -->
+
+### `refCount()`
+
+Connectable Observable의 첫 Observer가 구독할 때 자동으로 `connect()`하고, 마지막 Observer가 떠나면 원본 연결을 폐기해요.
+
+```swift
+let shared = request()
+  .replay(1)
+  .refCount()
+```
+
+Observer가 모두 사라진 뒤 다시 구독하면 새 연결이 시작돼요. 다만 Connectable Observable이 같은 Subject를 계속 사용하는 경우 Subject에 남은 값이나 종료 이벤트가 다음 연결에 영향을 줄 수 있으므로 원하는 격리 범위를 확인해야 해요.
+
+<!-- rxswift-operator: share -->
+
+### `share(replay:scope:)`
+
+`multicast`와 `refCount`를 자주 쓰는 형태로 묶은 연산자예요. 구독자가 있을 때만 원본을 연결하고 하나의 구독을 공유해요.
+
+```swift
+let profile = api.loadProfile()
+  .share(replay: 1, scope: .whileConnected)
+```
+
+`replay`는 새 Observer에게 다시 보낼 최근 값의 개수예요.
+
+| 설정        | 늦게 구독한 Observer가 받는 값                   |
+| ----------- | ------------------------------------------------ |
+| `replay: 0` | 구독 뒤 새로 발생한 값부터 받아요.               |
+| `replay: 1` | 가장 최근 값 하나를 먼저 받은 뒤 새 값을 받아요. |
+| `replay: n` | 최근 값 최대 `n`개를 먼저 받아요.                |
+
+`share()`는 원본을 자동으로 비동기 실행하거나 스레드를 바꾸지 않아요. 실행 위치는 `subscribe(on:)`과 `observe(on:)`으로 별도 결정해야 해요.
+
+## 공유 범위를 선택해요
+
+`SubjectLifetimeScope`는 연결이 끊긴 뒤 다음 구독이 같은 Subject를 재사용할지 정해요.
+
+### `.whileConnected`
+
+연결마다 별도의 Subject를 만들어요. 모든 Observer가 떠나 연결이 끊기면 그 연결의 버퍼와 상태도 분리되고, 다음 Observer는 새 Subject와 새 원본 구독을 사용해요.
+
+```swift
+let shared = source
+  .share(replay: 1, scope: .whileConnected)
+```
+
+서로 다른 연결의 이벤트가 섞이지 않아 일반적으로 권장되는 기본값이에요. 종료 뒤 이어지는 `retry`나 `concat`도 새 연결을 만들 수 있어요.
+
+### `.forever`
+
+여러 연결이 하나의 Subject를 공유해요. 연결이 잠시 끊겨도 Subject의 재생 버퍼와 종료 상태가 다음 구독에 영향을 줄 수 있어요.
+
+```swift
+let shared = source
+  .share(replay: 1, scope: .forever)
+```
+
+Subject가 오류나 완료를 받으면 이후 Observer도 보존된 종료 이벤트를 받을 수 있어요. 이 경우 `retry`나 `concat`을 `share` 뒤에 배치해도 원본의 새 실행을 기대한 대로 만들지 못할 수 있어요. 결과를 애플리케이션 수명 동안 캐시해야 하는 경우처럼 재사용 의도가 분명할 때 선택하세요.
+
+## 연산자를 선택해요
+
+| 원하는 제어 수준                                   | 선택                   |
+| -------------------------------------------------- | ---------------------- |
+| Subject 종류와 선택 클로저를 직접 구성해요         | `multicast`            |
+| 재생 없이 연결 시점을 직접 정해요                  | `publish` + `connect`  |
+| 최근 값 버퍼와 연결 시점을 직접 정해요             | `replay` + `connect`   |
+| Connectable Observable을 구독자 수로 자동 연결해요 | `refCount`             |
+| 일반적인 공유와 최근 값 재생을 간단히 구성해요     | `share(replay:scope:)` |
+| 유한한 전체 값을 늦은 구독자에게 다시 보내요       | `replayAll`            |
+
+## 흔한 실수를 피해요
+
+- 동일 요청이 여러 번 실행된다면 각 구독마다 cold Observable이 새로 시작되는지 확인하세요.
+- `share(replay: 1)`은 영구 캐시가 아니에요. 기본 `.whileConnected`에서는 마지막 구독자가 떠난 뒤 다음 연결이 새로 시작돼요.
+- `replayAll()`과 큰 재생 버퍼에 무거운 모델이나 이미지를 넣으면 메모리를 오래 점유할 수 있어요.
+- 원본이 완료되지 않아도 마지막 Observer가 떠나면 `refCount` 연결은 폐기돼요. Disposable이 실제 기반 작업을 취소하도록 구현되어 있어야 자원도 해제돼요.
+
+## 참고 자료
+
+- [ConnectableObservableType 공식 API](https://docs.rxswift.org/protocols/connectableobservabletype)
+- [공유 연산자 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxSwift/Observables/ShareReplayScope.swift)
+- [Multicast 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxSwift/Observables/Multicast.swift)
+- [Subjects 공식 API](https://docs.rxswift.org/rxswift/subjects)

--- a/docs/guide/rxswift/operators-traits-deprecated.md
+++ b/docs/guide/rxswift/operators-traits-deprecated.md
@@ -1,0 +1,183 @@
+---
+title: RxSwift 연산자 — Traits와 폐기 API
+description: Single, Maybe, Completable, Infallible의 계약과 전용 연산자를 익히고 RxSwift 6의 폐기 연산자를 최신 이름으로 마이그레이션합니다.
+---
+
+# RxSwift 연산자 — Traits와 폐기 API
+
+> **면접 답변 한 줄 요약:** Traits는 Observable 위에 값 개수와 오류 가능성 계약을 타입으로 표현하고, RxSwift 6에서 폐기된 옛 연산자 이름은 Swift API Design Guidelines에 맞춘 최신 이름으로 바꿔야 해요.
+
+`Single`, `Maybe`, `Completable`, `Infallible`은 별도 실행 엔진이 아니라 제한된 이벤트 문법을 표현하는 `PrimitiveSequence`예요. 일반 Observable 연산자 대부분을 같은 의미로 사용하면서 반환 타입의 계약을 유지할 수 있어요.
+
+## Traits의 이벤트 계약을 구분해요
+
+| Trait           | 성공 시 값 수 | 실패 가능 | 대표 용도                        |
+| --------------- | ------------- | --------- | -------------------------------- |
+| `Single<T>`     | 정확히 1개    | 가능      | 네트워크 응답, 한 번의 조회      |
+| `Maybe<T>`      | 0개 또는 1개  | 가능      | 캐시 조회, 선택적인 검색 결과    |
+| `Completable`   | 0개           | 가능      | 저장·삭제의 성공 여부            |
+| `Infallible<T>` | 0개 이상      | 불가능    | 오류가 없는 상태와 이벤트 스트림 |
+
+Observable에서 Trait으로 변환하는 `asSingle`, `asMaybe`, `asCompletable`, `asInfallible`과 Swift Concurrency의 `value`는 [생성과 변환](/guide/rxswift/operators-create-convert)에서 설명해요.
+
+Trait의 계약과 실제 이벤트가 맞지 않으면 변환 뒤 오류가 날 수 있어요. 예를 들어 값이 둘 이상인 Observable에 `asSingle()`을 적용하면 성공 하나로 축약되지 않아요. 먼저 `take(1)`이나 `single()`처럼 의도한 선택 규칙을 표현하세요.
+
+## Completable이 끝난 뒤 다음 작업을 시작해요
+
+<!-- rxswift-operator: andThen -->
+
+### `andThen(_:)`
+
+Completable이 정상 완료하면 두 번째 `Completable`, `Single`, `Maybe` 또는 Observable을 구독해요. 첫 작업이 실패하면 두 번째 작업은 시작하지 않고 오류를 전달해요.
+
+```swift
+let refreshedUser: Single<User> = refreshToken()
+  .andThen(loadCurrentUser())
+```
+
+인증 토큰 저장 뒤 사용자 조회, 파일 쓰기 뒤 인덱싱처럼 **첫 단계의 값은 없고 성공 여부만 다음 단계의 시작 조건**일 때 적합해요. 일반 Observable의 `concat`과 비슷하지만 첫 시퀀스의 성공 값이 없다는 계약이 타입에 드러나요.
+
+## 성공 값을 다른 Trait 작업으로 바꿔요
+
+<!-- rxswift-operator: flatMapCompletable -->
+
+### `flatMapCompletable(_:)`
+
+`Single`의 성공 값을 받아 `Completable` 작업을 만들어요.
+
+```swift
+let saved: Completable = loadDraft()
+  .flatMapCompletable { draft in
+    repository.save(draft)
+  }
+```
+
+원본 Single이나 내부 Completable이 실패하면 그 오류를 전달해요. 성공 값에서 후속 작업의 성공 여부만 필요할 때 사용하세요.
+
+<!-- rxswift-operator: flatMapMaybe -->
+
+### `flatMapMaybe(_:)`
+
+`Single`의 성공 값을 `Maybe`로 바꿔 결과가 없을 수도 있는 후속 조회를 표현해요.
+
+```swift
+let cachedProfile: Maybe<Profile> = currentUserID()
+  .flatMapMaybe { id in
+    cache.profile(id: id)
+  }
+```
+
+원본 Single이나 내부 Maybe가 실패하면 결과도 실패해요. 값이 반드시 하나여야 하면 `flatMap`, 값 없이 성공 여부만 필요하면 `flatMapCompletable`을 선택하세요.
+
+## Trait 구독 API를 사용해요
+
+각 Trait은 가능한 이벤트만 받는 구독 오버로드를 제공해요.
+
+```swift
+userSingle
+  .subscribe(
+    onSuccess: { user in
+      print(user.name)
+    },
+    onFailure: { error in
+      print(error)
+    }
+  )
+  .disposed(by: disposeBag)
+
+saveCompletable
+  .subscribe(
+    onCompleted: {
+      print("저장 완료")
+    },
+    onError: { error in
+      print(error)
+    }
+  )
+  .disposed(by: disposeBag)
+```
+
+`Maybe`는 `onSuccess`, `onError`, `onCompleted`를, `Infallible`은 오류 처리 없이 `onNext`와 `onCompleted`를 사용해요. Trait 전용 구독은 호출부에서 가능한 종료 상태를 더 분명하게 보여 줘요.
+
+## RxCocoa의 UI Traits를 알아둬요
+
+RxCocoa는 UI 바인딩에 맞춘 `Driver`와 `Signal`을 제공해요.
+
+| Trait    | 오류 | 전달 스케줄러 | 새 구독자에게 최근 값 재생 |
+| -------- | ---- | ------------- | -------------------------- |
+| `Driver` | 없음 | 메인 스케줄러 | 1개                        |
+| `Signal` | 없음 | 메인 스케줄러 | 없음                       |
+
+화면 상태처럼 최근 값이 필요한 흐름은 `Driver`, 탭이나 일회성 알림처럼 과거 값을 다시 보내면 안 되는 흐름은 `Signal`이 잘 맞아요. 두 타입은 RxCocoa의 공유 시퀀스이므로 이 문서의 RxSwift 핵심 Observable 연산자 목록과는 범위가 달라요.
+
+## 폐기된 이름을 최신 API로 바꿔요
+
+RxSwift 6은 여러 연산자 이름과 인자 레이블을 Swift API Design Guidelines에 맞게 정리했어요. 폐기 API는 당장 컴파일될 수 있어도 경고가 발생하고 이후 버전에서 제거될 수 있으므로 새 코드에서는 최신 이름을 사용하세요.
+
+<!-- rxswift-operator: catchError -->
+
+<!-- rxswift-operator: catchErrorJustReturn -->
+
+<!-- rxswift-operator: elementAt -->
+
+<!-- rxswift-operator: observeOn -->
+
+<!-- rxswift-operator: retryWhen -->
+
+<!-- rxswift-operator: skipUntil -->
+
+<!-- rxswift-operator: skipWhile -->
+
+<!-- rxswift-operator: subscribeOn -->
+
+<!-- rxswift-operator: takeUntil -->
+
+<!-- rxswift-operator: takeWhile -->
+
+| 폐기된 호출                | 최신 호출               | 의미                                           |
+| -------------------------- | ----------------------- | ---------------------------------------------- |
+| `catchError(_:)`           | `catch(_:)`             | 오류를 대체 Observable로 바꿔요.               |
+| `catchErrorJustReturn(_:)` | `catchAndReturn(_:)`    | 오류 때 대체 값 하나를 보내요.                 |
+| `elementAt(_:)`            | `element(at:)`          | 지정한 인덱스의 값을 선택해요.                 |
+| `observeOn(_:)`            | `observe(on:)`          | 이후 이벤트 전달 스케줄러를 정해요.            |
+| `retryWhen(_:)`            | `retry(when:)`          | 오류 알림으로 재시도 정책을 만들어요.          |
+| `skipUntil(_:)`            | `skip(until:)`          | 다른 Observable이 값을 보낼 때까지 건너뛰어요. |
+| `skipWhile(_:)`            | `skip(while:)`          | 조건이 참인 앞부분을 건너뛰어요.               |
+| `subscribeOn(_:)`          | `subscribe(on:)`        | 구독과 해제 스케줄러를 정해요.                 |
+| `takeUntil(_:)`            | `take(until:)`          | 다른 Observable의 이벤트 전까지만 받아요.      |
+| `takeUntil(_:predicate:)`  | `take(until:behavior:)` | 조건 경계를 포함할지 정해 받아요.              |
+| `takeWhile(_:)`            | `take(while:)`          | 조건이 참인 앞부분만 받아요.                   |
+| `take(_:scheduler:)`       | `take(for:scheduler:)`  | 지정 시간 동안만 받아요.                       |
+
+```swift
+// 이전
+source
+  .catchErrorJustReturn([])
+  .observeOn(MainScheduler.instance)
+
+// 현재
+source
+  .catchAndReturn([])
+  .observe(on: MainScheduler.instance)
+```
+
+이름만 바뀐 API는 동작을 새로 설계할 필요 없이 호출을 교체할 수 있어요. 다만 `take(until:behavior:)`처럼 오버로드가 여러 개인 경우 컴파일러의 자동 수정만 믿지 말고, 다른 Observable을 경계로 쓰는지 조건 클로저를 쓰는지 확인하세요.
+
+## 선택 기준을 정리해요
+
+| 요구사항                                 | 선택                 |
+| ---------------------------------------- | -------------------- |
+| 값 하나가 반드시 성공하거나 실패해요     | `Single`             |
+| 값이 없을 수도 있는 한 번의 작업이에요   | `Maybe`              |
+| 값 없이 성공 또는 실패만 알려요          | `Completable`        |
+| 여러 값이 오지만 오류는 계약상 없어요    | `Infallible`         |
+| Completable 성공 뒤 다른 작업을 시작해요 | `andThen`            |
+| 성공 값을 값 없는 후속 작업으로 바꿔요   | `flatMapCompletable` |
+| Single 성공 값을 선택적 결과로 바꿔요    | `flatMapMaybe`       |
+
+## 참고 자료
+
+- [PrimitiveSequence 공식 API](https://docs.rxswift.org/rxswift/traits/primitivesequence)
+- [Infallible 공식 API](https://docs.rxswift.org/rxswift/traits/infallible)
+- [Traits 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md)
+- [RxSwift 6.0 마이그레이션 가이드](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/CompilerWarnings.md)

--- a/docs/guide/rxswift/operators-transform-filter.md
+++ b/docs/guide/rxswift/operators-transform-filter.md
@@ -1,0 +1,270 @@
+---
+title: RxSwift 연산자 — 변환과 필터링
+description: map, compactMap, filter, distinctUntilChanged, scan, reduce, groupBy, materialize와 withUnretained로 Observable 값을 안전하게 변환하는 방법을 설명합니다.
+---
+
+# RxSwift 연산자 — 변환과 필터링
+
+> **면접 답변 한 줄 요약:** 변환 연산자는 각 값의 형태나 누적 상태를 바꾸고, 필터링 연산자는 전달할 값의 개수를 줄이며, RxSwift에서는 연산자 클로저가 던진 오류도 Observable의 `.error` 이벤트가 돼요.
+
+RxSwift의 `map`, `filter`, `scan` 클로저는 `throws`일 수 있어요. 별도의 `tryMap` 이름을 사용하는 Combine과 달리, 일반 연산자의 클로저에서 던지면 시퀀스가 오류로 종료돼요.
+
+## 값을 다른 형태로 바꿔요
+
+<!-- rxswift-operator: map -->
+
+### `map(_:)`
+
+각 입력을 클로저가 반환한 값으로 바꿔요. 값 개수는 유지되고 `Element` 타입은 달라질 수 있어요.
+
+```swift
+Observable.of(1, 2, 3)
+  .map { "상품 \($0)" }
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+```
+
+클로저가 오류를 던지면 이후 입력은 전달되지 않고 `.error`로 끝나요.
+
+<!-- rxswift-operator: compactMap -->
+
+### `compactMap(_:)`
+
+각 입력을 옵셔널 결과로 바꾸고 `nil`은 버리며, 값이 있는 결과만 옵셔널을 벗겨 보내요.
+
+```swift
+Observable.of("10", "없음", "30")
+  .compactMap(Int.init)
+// 10, 30
+```
+
+파싱 실패를 무시해도 될 때 적합해요. 잘못된 입력에서 흐름을 중단해야 한다면 `map`의 클로저에서 의미 있는 오류를 던지세요.
+
+<!-- rxswift-operator: enumerated -->
+
+### `enumerated()`
+
+각 값에 0부터 시작하는 인덱스를 붙여 `(index, element)` 튜플로 보내요.
+
+```swift
+Observable.of("A", "B")
+  .enumerated()
+  .subscribe(onNext: { index, value in
+    print(index, value)
+  })
+```
+
+이 인덱스는 현재 구독에서 이벤트가 도착한 순서예요. 데이터의 안정적인 식별자나 컬렉션의 영구 위치로 사용하면 안 돼요.
+
+## 조건에 맞는 값만 보내요
+
+<!-- rxswift-operator: filter -->
+
+### `filter(_:)`
+
+조건 클로저가 `true`를 반환한 값만 보내요.
+
+```swift
+Observable.of(1, 2, 3, 4)
+  .filter { $0.isMultiple(of: 2) }
+// 2, 4
+```
+
+조건이 `false`인 것은 오류가 아니라 단순히 전달하지 않는 값이에요. 조건 계산 중 던진 오류는 시퀀스를 종료해요.
+
+<!-- rxswift-operator: distinctUntilChanged -->
+
+### `distinctUntilChanged(...)`
+
+바로 앞에서 통과시킨 값과 중복인 연속 값을 제거해요. 전체 이력을 기억하는 집합 연산이 아니므로 `1, 2, 1`은 모두 통과해요.
+
+```swift
+Observable.of(1, 1, 2, 2, 1)
+  .distinctUntilChanged()
+// 1, 2, 1
+```
+
+오버로드는 중복 기준을 다르게 표현해요.
+
+| 형태                                           | 비교 기준                      |
+| ---------------------------------------------- | ------------------------------ |
+| `distinctUntilChanged()`                       | `Element: Equatable`의 `==`    |
+| `distinctUntilChanged(comparer)`               | 두 `Element`를 비교하는 클로저 |
+| `distinctUntilChanged(keySelector)`            | 각 값에서 뽑은 `Equatable` 키  |
+| `distinctUntilChanged(keySelector, comparer:)` | 키와 사용자 정의 비교 클로저   |
+| `distinctUntilChanged(at: keyPath)`            | `Equatable` 프로퍼티의 키 경로 |
+
+```swift
+struct Product {
+  let id: Int
+  let name: String
+}
+
+products
+  .distinctUntilChanged(at: \.id)
+```
+
+검색어, 화면 상태처럼 같은 값으로 반복 작업할 필요가 없을 때 유용해요. 비교 대상이 큰 값이면 전체 값보다 작은 식별 키를 고르세요.
+
+## 입력마다 누적 상태를 보내요
+
+<!-- rxswift-operator: scan -->
+
+### `scan(_:accumulator:)`와 `scan(into:accumulator:)`
+
+초기값과 현재 입력으로 새 누적값을 만들고 **입력마다 중간 결과**를 보내요.
+
+```swift
+Observable.of(10, -3, 5)
+  .scan(0, accumulator: +)
+// 10, 7, 12
+```
+
+`scan(into:)`는 누적값을 `inout`으로 수정해요.
+
+```swift
+Observable.of("A", "B", "C")
+  .scan(into: [String]()) { result, value in
+    result.append(value)
+  }
+// ["A"], ["A", "B"], ["A", "B", "C"]
+```
+
+참조 타입을 누적하거나 외부에서 같은 값을 공유하면 과거 출력도 함께 바뀌는 것처럼 보일 수 있어요. 각 출력이 독립적인 상태 스냅샷이어야 하는지 확인하세요.
+
+<!-- rxswift-operator: reduce -->
+
+### `reduce(_:accumulator:)`와 `reduce(_:accumulator:mapResult:)`
+
+모든 입력을 누적한 뒤 원본이 정상 완료하면 마지막 결과 하나를 보내요.
+
+```swift
+Observable.of(10, -3, 5)
+  .reduce(0, accumulator: +)
+// 정상 완료 뒤 12
+```
+
+`mapResult` 오버로드는 최종 누적값을 한 번 더 다른 결과로 바꿔요.
+
+```swift
+Observable.of(10, 20, 30)
+  .reduce(
+    (sum: 0, count: 0),
+    accumulator: { state, value in
+      (state.sum + value, state.count + 1)
+    },
+    mapResult: { state in
+      Double(state.sum) / Double(state.count)
+    }
+  )
+```
+
+끝나지 않는 Observable은 최종 결과를 확정할 수 없으므로 `reduce`도 값을 보내지 않아요. 중간 결과가 필요하면 `scan`을 사용하세요.
+
+## 키별 Observable로 나눠요
+
+<!-- rxswift-operator: groupBy -->
+
+### `groupBy(keySelector:)`
+
+각 값에서 키를 뽑아 같은 키의 값을 `GroupedObservable<Key, Element>`로 묶어요. 바깥 Observable은 그룹을 보내고, 각 그룹 Observable은 해당 키의 값을 계속 보내요.
+
+```swift
+struct Message {
+  let roomID: Int
+  let text: String
+}
+
+messages
+  .groupBy { $0.roomID }
+  .flatMap { room in
+    room
+      .map { "[\(room.key)] \($0.text)" }
+  }
+```
+
+키 종류가 계속 늘고 그룹이 오래 끝나지 않으면 그룹별 상태와 구독도 많아질 수 있어요. 유한한 키 공간인지, 그룹을 언제 종료할지 고려하세요.
+
+## 이벤트 자체를 값으로 바꿔요
+
+<!-- rxswift-operator: materialize -->
+
+### `materialize()`
+
+`.next`, `.error`, `.completed`를 `Event<Element>` 값으로 바꿔 일반 `.next`로 보내요. 원본 오류도 값이 되므로 materialized Observable 자체는 해당 오류로 실패하지 않고 이벤트를 보낸 뒤 정상 완료해요.
+
+```swift
+Observable<Int>.error(LoadError.offline)
+  .materialize()
+  .subscribe(onNext: { event in
+    print(event)
+  })
+// error(LoadError.offline)라는 Event 값을 받고 completed
+```
+
+오류와 완료까지 하나의 값 흐름으로 검사하거나 테스트할 때 유용해요.
+
+<!-- rxswift-operator: dematerialize -->
+
+### `dematerialize()`
+
+`EventConvertible` 값을 다시 실제 Observable 이벤트로 복원해요.
+
+```swift
+let events = Observable.of(
+  Event.next(1),
+  Event.next(2),
+  Event.completed
+)
+
+events.dematerialize()
+// 1, 2, completed
+```
+
+`materialize`로 이벤트를 값처럼 가공한 뒤 다시 원래 의미로 되돌릴 때 사용해요. 종료 이벤트 뒤의 값은 전달될 수 없어요.
+
+## 객체를 강하게 소유하지 않고 함께 전달해요
+
+<!-- rxswift-operator: withUnretained -->
+
+### `withUnretained(_:)`와 `withUnretained(_:resultSelector:)`
+
+객체를 약하게 참조하면서 각 값과 안전한 객체 참조를 튜플 또는 선택 결과로 보내요. 객체가 해제되면 시퀀스가 정상 완료해요.
+
+```swift
+query
+  .withUnretained(self)
+  .subscribe(onNext: { owner, query in
+    owner.search(query)
+  })
+  .disposed(by: disposeBag)
+```
+
+결과 선택 오버로드는 튜플을 만들지 않고 원하는 값으로 바로 바꿔요.
+
+```swift
+query.withUnretained(self) { owner, query in
+  owner.makeRequest(query)
+}
+```
+
+`withUnretained` 뒤에 `share(replay: 1)`처럼 값을 보관하는 연산자를 두면 replay 버퍼가 객체가 포함된 결과를 강하게 보관할 수 있어요. 가능한 한 replay·buffer 뒤에서 `withUnretained`를 적용하거나 결과에서 객체를 제거하세요.
+
+## 비슷한 연산자를 비교해요
+
+| 원하는 결과                            | 연산자                 |
+| -------------------------------------- | ---------------------- |
+| 모든 입력을 새 값으로 바꿔요           | `map`                  |
+| 변환 결과가 없는 입력을 버려요         | `compactMap`           |
+| 조건에 맞는 원본 입력만 보내요         | `filter`               |
+| 연속된 같은 상태를 한 번만 보내요      | `distinctUntilChanged` |
+| 입력마다 누적 상태를 보내요            | `scan`                 |
+| 정상 완료 뒤 최종 누적값만 보내요      | `reduce`               |
+| 값·오류·완료를 모두 값처럼 처리해요    | `materialize`          |
+| 객체를 강하게 잡지 않고 값과 함께 써요 | `withUnretained`       |
+
+## 참고 자료
+
+- [ObservableType 공식 API](https://docs.rxswift.org/protocols/observabletype)
+- [RxSwift 연산자 구현](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxSwift/Observables)
+- [withUnretained 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxSwift/Observables/WithUnretained.swift)

--- a/docs/guide/swift/_meta.json
+++ b/docs/guide/swift/_meta.json
@@ -8,5 +8,20 @@
     "type": "file",
     "name": "closures",
     "label": "클로저"
+  },
+  {
+    "type": "file",
+    "name": "property-wrappers",
+    "label": "Property Wrapper"
+  },
+  {
+    "type": "file",
+    "name": "result-builders",
+    "label": "Result Builder"
+  },
+  {
+    "type": "file",
+    "name": "macros",
+    "label": "매크로"
   }
 ]

--- a/docs/guide/swift/macros.md
+++ b/docs/guide/swift/macros.md
@@ -1,0 +1,736 @@
+---
+title: Swift로 이해하는 매크로
+description: Swift 매크로가 컴파일 시점에 코드를 생성하는 원리와 freestanding·attached 역할, SwiftSyntax 구현, 확장 결과 테스트와 적용 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 매크로
+
+> **면접 답변 한 줄 요약:** Swift 매크로는 소스 코드를 컴파일하는 동안 입력 구문을 다른 Swift 코드로 펼쳐, 반복 코드를 직접 작성하지 않고도 타입 검사를 받는 코드를 만들게 하는 기능이에요.
+
+앱에서 같은 형태의 프로퍼티나 메서드를 여러 타입에 반복해서 작성하다 보면 복사한 코드를 빠뜨리거나 서로 다르게 고치기 쉬워요. 함수와 제네릭으로 실행 로직을 재사용할 수 있지만, 작성된 표현식 자체를 읽거나 선언에 새 멤버를 추가해야 하는 문제는 함수만으로 해결하기 어려워요.
+
+Swift 매크로는 이런 반복을 **컴파일 시점의 소스 코드 변환**으로 다뤄요. 이 문서에서는 매크로를 사용하는 입장에서 확장 결과를 읽는 방법부터 시작해, Swift Package Manager로 작은 매크로를 만들고 테스트하는 과정까지 설명해요.
+
+## 먼저 알아둘 매크로 용어
+
+| 용어                   | 쉬운 뜻                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 컴파일 시점            | Swift 소스 코드를 앱이나 라이브러리로 만드는 때예요. 문법과 타입을 검사하고 실행 가능한 결과를 준비해요.                                                     |
+| 런타임                 | 빌드가 끝난 프로그램을 실제로 실행하는 때예요. 사용자 입력, 네트워크 응답처럼 실행 중에만 알 수 있는 값은 런타임에 다뤄요.                                   |
+| 반복 코드(boilerplate) | 규칙은 같지만 타입이나 이름이 달라 여러 곳에 되풀이해서 작성하는 코드예요.                                                                                   |
+| 구문(syntax)           | 코드가 작성된 구조예요. `price * count`가 어떤 연산자와 피연산자로 이루어졌는지처럼 소스의 모양을 나타내요.                                                  |
+| 추상 구문 트리(AST)    | Abstract Syntax Tree의 줄임말이에요. 컴파일러가 소스 코드를 선언, 표현식, 연산자 같은 구조의 트리로 표현한 것이에요.                                         |
+| 매크로 호출            | `#stringify(price * count)`나 `@AddTypeName`처럼 매크로 사용을 요청하는 코드예요.                                                                            |
+| 매크로 확장            | 매크로 호출을 매크로가 생성한 Swift 코드로 펼치는 과정이에요. 생성된 결과도 다시 문법과 타입 검사를 받아요.                                                  |
+| freestanding 매크로    | 다른 선언에 붙지 않고 `#`으로 독립적으로 호출하는 매크로예요. 표현식이나 선언을 만들 수 있어요.                                                              |
+| attached 매크로        | 타입, 프로퍼티, 함수 같은 선언에 `@`으로 붙이는 매크로예요. 붙은 위치에 멤버, 접근자, 확장 등을 추가할 수 있어요.                                            |
+| 매크로 역할(role)      | 매크로가 어디에서 사용되고 어떤 종류의 코드를 만들 수 있는지 정한 범위예요. `expression`, `member`, `peer` 등이 있어요.                                      |
+| SwiftSyntax            | Swift 소스 코드를 구조화된 구문 트리로 읽고 만드는 공식 라이브러리예요. 사용자 정의 매크로 구현은 SwiftSyntax가 제공하는 타입을 이용해 입력과 출력을 다뤄요. |
+| 컴파일러 플러그인      | 컴파일러가 빌드 도중 실행해 매크로 확장을 요청하는 별도 프로그램이에요. 매크로 구현 타입을 등록해 컴파일러와 연결해요.                                       |
+| 진단(diagnostic)       | 컴파일러가 코드의 문제를 알려 주는 오류, 경고, 수정 제안이에요. 매크로도 잘못된 사용 위치에 직접 진단을 만들 수 있어요.                                      |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- 함수와 매크로가 해결하는 문제의 차이
+- 매크로 호출이 일반 Swift 코드로 확장되는 과정
+- freestanding 매크로와 attached 매크로의 역할
+- 매크로 선언, 구현, 컴파일러 플러그인을 나누는 이유
+- SwiftSyntax로 `#stringify`와 `@AddTypeName`을 구현하는 방법
+- 확장 결과와 잘못된 입력을 테스트하는 방법
+- 매크로를 적용할 때 얻는 이점과 감수해야 할 비용
+
+## 함수는 값의 계산을 재사용하지만 소스의 모양은 알 수 없어요
+
+상품 가격과 수량을 계산하면서 어떤 계산식이 사용됐는지 함께 기록한다고 가정해 볼게요.
+
+```swift
+let price = 12_000
+let count = 3
+
+let total = price * count
+let log = "price * count = \(total)"
+```
+
+이 코드는 값과 계산식 문자열을 따로 작성해요. 계산을 `price * count + deliveryFee`로 바꾸고 문자열은 그대로 두면 기록이 실제 코드와 달라져요.
+
+함수로 묶으면 계산 결과를 재사용할 수 있지만 호출부에 작성된 표현식의 모양까지 얻을 수는 없어요.
+
+```swift
+func record<T>(
+  value: T,
+  expression: String
+) -> (value: T, expression: String) {
+  (value, expression)
+}
+
+let recorded = record(
+  value: price * count,
+  expression: "price * count"
+)
+```
+
+`record(value:expression:)`이 받는 것은 계산이 끝난 값과 별도로 작성한 문자열이에요. 함수가 `price * count`라는 원래 소스 구문을 되찾을 수는 없어요.
+
+매크로는 컴파일러가 읽은 구문을 입력으로 받기 때문에 값의 계산식과 소스 표현을 한 호출에서 만들 수 있어요.
+
+```swift
+let recorded = #stringify(price * count)
+
+print(recorded.0)
+// 36000
+
+print(recorded.1)
+// price * count
+```
+
+`#stringify`는 런타임에 표현식을 분석하는 함수가 아니에요. 컴파일할 때 다음과 비슷한 일반 Swift 코드로 확장돼요.
+
+```swift
+let recorded = (price * count, "price * count")
+```
+
+계산식은 한 번만 작성하므로 값과 설명이 서로 달라질 가능성이 줄어요. 매크로가 생성한 튜플 표현식도 다른 Swift 코드처럼 문법과 타입 검사를 받아요.
+
+## 매크로는 구문을 받아 Swift 코드로 펼쳐요
+
+Swift 공식 [Macros 문서](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/)가 설명하는 확장 흐름을 단순하게 정리하면 다음과 같아요.
+
+```text
+Swift 소스
+   │
+   ▼
+컴파일러가 구문 트리를 만듦
+   │
+   ▼
+매크로 구현이 필요한 구문을 입력받음
+   │
+   ▼
+새 Swift 구문을 만들어 반환함
+   │
+   ▼
+컴파일러가 확장 결과의 문법과 타입을 검사함
+   │
+   ▼
+일반 Swift 코드와 함께 빌드함
+```
+
+이 과정에서 구분해야 할 점이 두 가지 있어요.
+
+첫째, **매크로 구현이 실행되는 시점**과 **생성된 코드가 실행되는 시점**은 달라요. 매크로 구현은 컴파일 중에 구문을 만들고, 생성된 코드의 실제 동작은 앱을 실행할 때 일어나요.
+
+```swift
+let result = #stringify(loadProduct())
+```
+
+컴파일 중에는 `loadProduct()`를 호출하지 않아요. 매크로는 호출 구문을 다음과 비슷하게 펼칠 뿐이에요.
+
+```swift
+let result = (loadProduct(), "loadProduct()")
+```
+
+`loadProduct()`는 완성된 프로그램이 이 줄을 실행할 때 호출돼요.
+
+둘째, 매크로는 역할이 허용한 범위의 코드만 만들 수 있어요. 표현식 매크로는 표현식을 반환하고, 멤버 매크로는 타입 안에 멤버를 추가해요. 매크로 선언에 역할과 생성할 이름을 적기 때문에 호출부에서 어떤 종류의 변화가 생길지 제한할 수 있어요.
+
+## freestanding과 attached는 호출 위치가 달라요
+
+Swift 매크로는 호출 형태에 따라 크게 두 종류로 나뉘어요.
+
+| 종류                | 호출 형태                    | 입력이 되는 코드                        | 대표적인 결과                                |
+| ------------------- | ---------------------------- | --------------------------------------- | -------------------------------------------- |
+| freestanding 매크로 | `#macroName(...)`            | 매크로 호출과 인자                      | 표현식, 선언, 컴파일 시점 진단               |
+| attached 매크로     | `@MacroName` 또는 `@Macro()` | 매크로가 붙은 타입, 프로퍼티, 함수 선언 | 새 멤버, 접근자, 같은 범위의 선언, 타입 확장 |
+
+freestanding 매크로는 코드 안에서 독립적으로 보여요. Swift가 기본으로 제공하는 `#function`은 현재 선언의 이름을 만들고, `#warning`은 컴파일 중 경고를 발생시켜요.
+
+```swift
+func loadProducts() {
+  print("실행 중인 함수: \(#function)")
+  #warning("실제 상품 API를 연결해야 해요.")
+}
+```
+
+attached 매크로는 선언 바로 앞에 속성처럼 붙어요.
+
+```swift
+@AddTypeName
+struct Product {
+  let name: String
+}
+```
+
+`@AddTypeName`이 멤버 역할을 가진 매크로라면 `Product` 안에 새 프로퍼티를 생성할 수 있어요. 호출 문법만 봐도 독립적으로 값을 만드는지, 특정 선언을 확장하는지 구분할 수 있어요.
+
+## 역할은 매크로가 만들 수 있는 코드의 위치를 정해요
+
+매크로 선언에는 `@freestanding` 또는 `@attached` 속성으로 역할을 표시해요. 자주 사용하는 역할을 먼저 살펴볼게요.
+
+| 선언에 적는 역할             | 구현 프로토콜          | 생성할 수 있는 코드                                   |
+| ---------------------------- | ---------------------- | ----------------------------------------------------- |
+| `@freestanding(expression)`  | `ExpressionMacro`      | 호출 위치를 대신할 하나의 표현식                      |
+| `@freestanding(declaration)` | `DeclarationMacro`     | 호출 위치에 놓일 하나 이상의 선언                     |
+| `@attached(peer)`            | `PeerMacro`            | 붙은 선언과 같은 범위의 새 선언                       |
+| `@attached(member)`          | `MemberMacro`          | 붙은 타입이나 확장 내부의 프로퍼티, 메서드, 중첩 타입 |
+| `@attached(memberAttribute)` | `MemberAttributeMacro` | 붙은 타입 내부의 멤버에 적용할 속성                   |
+| `@attached(accessor)`        | `AccessorMacro`        | 프로퍼티의 getter, setter 같은 접근자                 |
+| `@attached(extension)`       | `ExtensionMacro`       | 타입의 확장, 프로토콜 준수, 확장 내부의 선언          |
+| `@attached(body)`            | `BodyMacro`            | 함수나 접근자의 본문                                  |
+
+예를 들어 비동기 함수 옆에 completion handler 버전의 함수를 만든다면 `peer`가 어울리고, 구조체 안에 프로퍼티를 추가한다면 `member`가 어울려요. 여러 위치를 함께 생성해야 하는 매크로는 역할을 여러 개 선언할 수도 있어요.
+
+초기 매크로 자료에서는 프로토콜 준수를 `conformance` 역할로 설명하기도 해요. [SE-0402 Extension Macros](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0402-extension-macros.md) 이후에는 새 매크로에서 더 일반적인 `extension` 역할과 `conformances:` 인자를 사용해 타입 확장과 프로토콜 준수를 표현해요.
+
+모든 역할을 외우기보다 **생성하려는 코드가 문법적으로 어디에 놓여야 하는가**를 먼저 물어보세요. 그 답이 역할과 구현 프로토콜을 결정해요.
+
+## 매크로 선언과 구현은 서로 다른 책임을 가져요
+
+일반 함수는 선언과 본문을 한곳에 작성할 수 있지만, 사용자 정의 매크로는 세 부분으로 나뉘어요.
+
+```text
+매크로 라이브러리
+  └─ public macro 선언
+       │ 이름, 인자, 결과 타입, 역할을 공개
+       ▼
+매크로 구현 타깃
+  └─ ExpressionMacro 같은 프로토콜 구현
+       │ 입력 구문을 출력 구문으로 변환
+       ▼
+컴파일러 플러그인
+  └─ 구현 타입을 컴파일러에 등록
+```
+
+매크로를 사용하는 앱이나 라이브러리는 공개된 매크로 선언을 가져와요. 컴파일러는 선언의 `#externalMacro(module:type:)` 정보를 따라 별도로 빌드된 구현 타입에 확장을 요청해요.
+
+구현을 분리하는 이유는 매크로 구현이 매크로 사용 코드를 빌드하는 동안 컴파일러가 실행할 프로그램이기 때문이에요. 앱의 런타임 코드와 매크로 구현의 실행 환경은 같지 않아요.
+
+## Swift Package Manager 템플릿으로 시작해요
+
+Swift 5.9 이상 도구 모음에서는 다음 명령으로 실행 가능한 예제와 테스트가 포함된 매크로 패키지를 만들 수 있어요.
+
+```sh
+mkdir LearningMacros
+cd LearningMacros
+swift package init --type macro
+```
+
+현재 도구 모음의 템플릿은 대체로 다음과 같은 구조를 만들어요. 실제 이름은 패키지 이름에 따라 달라져요.
+
+```text
+LearningMacros/
+├─ Package.swift
+├─ Sources/
+│  ├─ LearningMacros/
+│  │  └─ LearningMacros.swift
+│  ├─ LearningMacrosMacros/
+│  │  └─ LearningMacrosMacro.swift
+│  └─ LearningMacrosClient/
+│     └─ main.swift
+└─ Tests/
+   └─ LearningMacrosTests/
+      └─ LearningMacrosTests.swift
+```
+
+각 폴더의 역할은 다음과 같아요.
+
+| 위치                   | 책임                                                      |
+| ---------------------- | --------------------------------------------------------- |
+| `LearningMacros`       | 사용하는 코드에 공개할 `public macro` 선언                |
+| `LearningMacrosMacros` | SwiftSyntax로 작성한 확장 구현과 컴파일러 플러그인 진입점 |
+| `LearningMacrosClient` | 매크로를 실제로 호출해 보는 실행 예제                     |
+| `LearningMacrosTests`  | 입력 소스와 예상 확장 결과를 비교하는 테스트              |
+
+`Package.swift`에서는 `CompilerPluginSupport`를 가져오고 `.macro` 타깃을 선언해요. 아래 코드는 핵심 관계만 보여 주는 일부예요.
+
+```swift
+import PackageDescription
+import CompilerPluginSupport
+
+let package = Package(
+  name: "LearningMacros",
+  products: [
+    .library(
+      name: "LearningMacros",
+      targets: ["LearningMacros"]
+    ),
+  ],
+  dependencies: [
+    .package(
+      url: "https://github.com/swiftlang/swift-syntax.git",
+      from: "<현재 Swift 도구 모음과 호환되는 버전>"
+    ),
+  ],
+  targets: [
+    .macro(
+      name: "LearningMacrosMacros",
+      dependencies: [
+        .product(
+          name: "SwiftSyntaxMacros",
+          package: "swift-syntax"
+        ),
+        .product(
+          name: "SwiftCompilerPlugin",
+          package: "swift-syntax"
+        ),
+      ]
+    ),
+    .target(
+      name: "LearningMacros",
+      dependencies: ["LearningMacrosMacros"]
+    ),
+  ]
+)
+```
+
+SwiftSyntax는 Swift 컴파일러의 구문과 함께 변하므로 임의의 최신 버전을 고르지 않는 편이 좋아요. `swift package init --type macro`가 현재 도구 모음에 맞춰 생성한 의존성 버전을 출발점으로 사용하고, 도구 모음을 올릴 때 함께 호환성을 확인하세요.
+
+## freestanding 표현식 매크로를 선언해요
+
+앞에서 사용한 `#stringify`를 만들어 볼게요. 먼저 `Sources/LearningMacros/LearningMacros.swift`에 사용하는 코드가 볼 공개 선언을 작성해요.
+
+```swift
+@freestanding(expression)
+public macro stringify<T>(
+  _ value: T
+) -> (T, String) = #externalMacro(
+  module: "LearningMacrosMacros",
+  type: "StringifyMacro"
+)
+```
+
+선언을 한 부분씩 읽어 보면 다음과 같아요.
+
+- `@freestanding(expression)`은 `#stringify(...)`가 하나의 표현식으로 확장된다는 뜻이에요.
+- `public macro stringify<T>`는 매크로의 이름과 제네릭 매개변수를 선언해요.
+- `(_ value: T) -> (T, String)`은 호출 인자와 확장 결과의 타입 계약이에요.
+- `#externalMacro`는 실제 구현이 있는 모듈과 타입을 컴파일러에 알려 줘요.
+
+매크로 선언은 함수 시그니처와 비슷해요. 컴파일러는 이 정보를 이용해 호출 인자와 사용 위치의 타입을 검사할 수 있어요.
+
+```swift
+let result: (Int, String) = #stringify(20 + 22)
+```
+
+`20 + 22`와 확장 결과가 선언의 타입 계약을 만족해야 빌드가 계속돼요.
+
+## SwiftSyntax로 표현식 확장을 구현해요
+
+이제 `LearningMacrosMacros` 타깃에 `StringifyMacro` 구현을 작성해요.
+
+```swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct StringifyMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    guard let argument = node.arguments.first?.expression else {
+      throw MacroExpansionErrorMessage(
+        "#stringify에는 표현식 하나가 필요해요."
+      )
+    }
+
+    return "(\(argument), \(literal: argument.description))"
+  }
+}
+```
+
+`ExpressionMacro`가 요구하는 `expansion(of:in:)`은 매크로 호출 구문을 받고 새 `ExprSyntax`를 반환해요.
+
+```swift
+#stringify(price * count)
+```
+
+위 호출에서 `node.arguments.first?.expression`은 `price * count` 구문이에요. 반환문의 두 보간은 역할이 달라요.
+
+```swift
+return "(\(argument), \(literal: argument.description))"
+```
+
+- `\(argument)`는 입력 구문을 코드로 삽입해요.
+- `\(literal: argument.description)`은 입력 구문의 텍스트를 안전한 Swift 문자열 리터럴로 만들어요.
+
+따라서 결과는 다음 표현식과 같아요.
+
+```swift
+(price * count, "price * count")
+```
+
+구문 노드를 무조건 일반 문자열로 조립하면 따옴표나 문자열 보간 같은 문자를 잘못 이스케이프할 수 있어요. 기존 구문은 구문 노드로, 새 문자열 값은 `literal:` 보간으로 구분하면 의도가 분명해져요.
+
+## 컴파일러 플러그인에 구현 타입을 등록해요
+
+구현 타입을 만들었더라도 컴파일러 플러그인의 목록에 등록하지 않으면 컴파일러가 찾을 수 없어요.
+
+```swift
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct LearningMacrosPlugin: CompilerPlugin {
+  let providingMacros: [Macro.Type] = [
+    StringifyMacro.self,
+  ]
+}
+```
+
+`providingMacros`에는 이 타깃이 제공하는 매크로 구현 타입을 모두 넣어요. 공개 선언의 `type: "StringifyMacro"`와 등록한 타입 이름이 일치해야 해요.
+
+이제 클라이언트 타깃에서 라이브러리를 가져와 사용할 수 있어요.
+
+```swift
+import LearningMacros
+
+let price = 12_000
+let count = 3
+let (total, expression) = #stringify(price * count)
+
+print("\(expression) = \(total)")
+// price * count = 36000
+```
+
+## attached 멤버 매크로는 타입 안에 코드를 추가해요
+
+이번에는 타입 이름을 보여 주는 계산 프로퍼티를 추가하는 `@AddTypeName`을 만들어 볼게요. 실무 기능보다는 attached 매크로의 입력과 출력 위치를 확인하기 위한 작은 예제예요.
+
+매크로 라이브러리에 공개 선언을 추가해요.
+
+```swift
+@attached(member, names: named(typeName))
+public macro AddTypeName() = #externalMacro(
+  module: "LearningMacrosMacros",
+  type: "AddTypeNameMacro"
+)
+```
+
+`@attached(member)`는 붙은 타입 안에 멤버를 생성한다는 뜻이에요. `names: named(typeName)`은 생성할 선언의 이름이 `typeName`이라고 컴파일러와 사용자에게 알려 줘요.
+
+구현 타입은 `MemberMacro`를 따르고 `[DeclSyntax]`를 반환해요.
+
+```swift
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct AddTypeNameMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard declaration.is(StructDeclSyntax.self) else {
+      throw MacroExpansionErrorMessage(
+        "@AddTypeName은 구조체에만 사용할 수 있어요."
+      )
+    }
+
+    return [
+      """
+      var typeName: String {
+        String(describing: Self.self)
+      }
+      """,
+    ]
+  }
+}
+```
+
+`declaration`에는 매크로가 붙은 선언의 구문이 들어와요. 이 예제는 구조체만 허용하고, 다른 선언에 붙으면 생성된 코드의 모호한 오류 대신 매크로가 직접 사용 방법을 알려 줘요.
+
+플러그인 목록에도 새 구현을 등록해요.
+
+```swift
+@main
+struct LearningMacrosPlugin: CompilerPlugin {
+  let providingMacros: [Macro.Type] = [
+    StringifyMacro.self,
+    AddTypeNameMacro.self,
+  ]
+}
+```
+
+호출부는 다음처럼 작성해요.
+
+```swift
+@AddTypeName
+struct Product {
+  let name: String
+}
+
+let product = Product(name: "키보드")
+print(product.typeName)
+// Product
+```
+
+개념적으로는 다음 코드가 추가된 것처럼 동작해요.
+
+```swift
+struct Product {
+  let name: String
+
+  var typeName: String {
+    String(describing: Self.self)
+  }
+}
+```
+
+매크로가 생성한 코드는 숨겨진 특별한 런타임 기능이 아니에요. 확장 뒤에는 다른 프로퍼티와 같은 Swift 코드가 되고, 같은 접근 제어와 타입 검사 규칙을 따라요.
+
+## names는 생성할 이름의 범위를 공개해요
+
+`peer`, `member`처럼 선언을 생성하는 역할은 매크로 선언의 `names:` 인자로 생성 가능한 이름을 알려 줘요.
+
+| 이름 지정 방식    | 사용할 때                                          |
+| ----------------- | -------------------------------------------------- |
+| `named(typeName)` | 생성할 이름이 정확히 `typeName`으로 정해져 있을 때 |
+| `overloaded`      | 붙은 선언과 같은 이름의 오버로드를 만들 때         |
+| `prefixed(fetch)` | 기존 이름 앞에 정해진 접두사를 붙일 때             |
+| `suffixed(Async)` | 기존 이름 뒤에 정해진 접미사를 붙일 때             |
+| `arbitrary`       | 입력을 읽기 전에는 생성할 이름을 알 수 없을 때     |
+
+가능하면 `arbitrary`보다 정확한 이름이나 규칙을 선언하세요. 사용하는 사람은 매크로 구현을 열지 않고도 어떤 심벌이 생길지 예상할 수 있고, 컴파일러도 구현이 선언한 범위를 벗어난 이름을 만들지 검사할 수 있어요.
+
+## 확장 실패는 호출 위치에 진단해야 해요
+
+매크로는 구문을 입력받기 때문에 기대한 형태가 아닐 수 있어요. 이때 잘못된 코드를 억지로 생성하면 사용자는 확장 결과 안에서 발생한 낯선 컴파일 오류를 보게 돼요.
+
+```swift
+guard declaration.is(StructDeclSyntax.self) else {
+  throw MacroExpansionErrorMessage(
+    "@AddTypeName은 구조체에만 사용할 수 있어요."
+  )
+}
+```
+
+제약을 확인한 위치에서 오류를 던지면 매크로 호출부에 구체적인 진단이 표시돼요.
+
+더 세밀한 안내가 필요하면 `MacroExpansionContext`의 `diagnose(_:)`를 이용해 다음 정보를 제공할 수 있어요.
+
+- 무엇이 잘못됐는지 설명하는 오류나 경고
+- 문제가 발생한 정확한 구문 위치
+- 사용자가 적용할 수 있는 수정 제안
+
+매크로 구현의 `fatalError`는 “선언의 타입 계약을 통과했다면 절대 생길 수 없는 컴파일러 또는 구현 내부 오류”처럼 정말 복구할 수 없는 경우로 제한하세요. 사용자가 잘못된 선언에 매크로를 붙인 상황은 진단 가능한 입력 오류예요.
+
+## 확장 테스트는 입력과 생성 코드를 비교해요
+
+매크로 테스트의 핵심은 특정 입력이 예상한 Swift 코드로 확장되는지 확인하는 거예요. Swift Package Manager의 매크로 템플릿은 `SwiftSyntaxMacrosTestSupport`를 이용한 테스트 예제를 만들어요.
+
+`#stringify`의 정상 입력을 테스트해 볼게요.
+
+```swift
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(LearningMacrosMacros)
+import LearningMacrosMacros
+
+let testMacros: [String: Macro.Type] = [
+  "stringify": StringifyMacro.self,
+  "AddTypeName": AddTypeNameMacro.self,
+]
+#endif
+
+final class LearningMacrosTests: XCTestCase {
+  func testStringify() throws {
+    #if canImport(LearningMacrosMacros)
+    assertMacroExpansion(
+      """
+      #stringify(price * count)
+      """,
+      expandedSource: """
+      (price * count, "price * count")
+      """,
+      macros: testMacros
+    )
+    #else
+    throw XCTSkip(
+      "매크로 구현은 호스트 플랫폼에서만 테스트할 수 있어요."
+    )
+    #endif
+  }
+}
+```
+
+매크로 구현은 빌드를 수행하는 호스트용 프로그램이에요. 다른 플랫폼으로 교차 컴파일할 때 구현 모듈을 테스트 프로세스에서 가져올 수 없을 수 있으므로 템플릿은 `#if canImport(...)` 조건을 사용해요.
+
+attached 매크로도 같은 방식으로 확장 전체를 비교할 수 있어요.
+
+```swift
+final class AddTypeNameMacroTests: XCTestCase {
+  func testAddTypeName() throws {
+    #if canImport(LearningMacrosMacros)
+    assertMacroExpansion(
+      """
+      @AddTypeName
+      struct Product {
+        let name: String
+      }
+      """,
+      expandedSource: """
+      struct Product {
+        let name: String
+
+        var typeName: String {
+          String(describing: Self.self)
+        }
+      }
+      """,
+      macros: testMacros,
+      indentationWidth: .spaces(2)
+    )
+    #else
+    throw XCTSkip(
+      "매크로 구현은 호스트 플랫폼에서만 테스트할 수 있어요."
+    )
+    #endif
+  }
+}
+```
+
+정상 확장만 확인하면 중요한 경계가 빠져요. 실제 매크로에서는 다음 테스트도 함께 작성하세요.
+
+- 인자가 없거나 개수가 잘못된 호출
+- 지원하지 않는 선언에 attached 매크로를 붙인 경우
+- 빈 타입, 제네릭 타입, 중첩 타입처럼 구조가 달라지는 입력
+- 문자열 리터럴, 주석, 줄바꿈처럼 구문 표현이 달라지는 입력
+- 예상한 오류 메시지와 오류 위치
+
+매크로는 입력 구문에서 출력 구문을 만드는 변환이므로 런타임 상태 없이 작은 단위로 검증하기 좋아요. 다만 확장 문자열 테스트만으로 실제 타입 검사가 성공한다고 보장할 수는 없어요. 공개 예제나 클라이언트 타깃도 빌드해 생성된 코드가 주변 코드와 함께 컴파일되는지 확인하세요.
+
+## Xcode에서 확장 결과를 먼저 확인해요
+
+매크로를 사용할 때는 이름만 보고 동작을 추측하지 말고 생성 코드를 확인하세요. Xcode의 **Expand Macro** 기능은 호출 위치에 생성되는 Swift 코드를 편집기에서 보여 줘요. Apple의 [What’s new in Swift](https://developer.apple.com/videos/play/wwdc2023/10164/)도 확장 코드를 확인하고 디버거로 들어갈 수 있다고 설명해요.
+
+확장 결과에서는 다음을 살펴보세요.
+
+1. 어떤 프로퍼티, 메서드, 확장이 추가되는지 확인해요.
+2. 생성된 선언의 접근 수준과 격리 속성을 확인해요.
+3. 원래 선언과 이름이 충돌하지 않는지 확인해요.
+4. 입력 표현식이 한 번만 평가되는지 확인해요.
+5. 오류가 생성 코드가 아니라 매크로 호출부에서 이해하기 쉽게 표시되는지 확인해요.
+
+특히 매크로가 입력 표현식을 여러 번 삽입하면 부수 효과도 여러 번 발생할 수 있어요.
+
+```swift
+let result = #someMacro(loadProduct())
+```
+
+확장 결과가 다음과 같다면 `loadProduct()`는 두 번 호출돼요.
+
+```swift
+(loadProduct(), loadProduct())
+```
+
+호출 횟수가 중요한 매크로는 임시 값을 만들어 입력을 한 번만 평가하도록 확장을 설계해야 해요. 사용하는 입장에서도 확장 결과를 확인해야 이런 비용을 알 수 있어요.
+
+## 함수, 프로퍼티 래퍼, 매크로는 해결 위치가 달라요
+
+프로퍼티 래퍼는 `@propertyWrapper`로 선언한 타입을 프로퍼티에 붙여 저장과 접근 규칙을 재사용하는 Swift 기능이에요. 매크로와 같은 `@` 문법을 사용할 수 있지만 해결하는 문제와 작동 방식은 달라요.
+
+| 도구             | 주로 작동하는 시점    | 입력으로 다루는 것                  | 잘 맞는 문제                                                |
+| ---------------- | --------------------- | ----------------------------------- | ----------------------------------------------------------- |
+| 함수와 제네릭    | 런타임                | 타입이 있는 값                      | 계산과 동작 재사용                                          |
+| 프로퍼티 래퍼    | 컴파일·런타임         | 프로퍼티의 저장과 접근 규칙         | 값 검증, 저장소 위임, 접근 시 공통 동작                     |
+| 매크로           | 컴파일 시점           | 작성된 Swift 구문                   | 선언에서 파생되는 반복 코드와 컴파일 시점 진단              |
+| 외부 코드 생성기 | 빌드 전후의 별도 단계 | 파일, 스키마, 네트워크 등 외부 입력 | API 스키마처럼 Swift 파일 바깥의 큰 입력으로 여러 파일 생성 |
+
+값만 받으면 해결되는 문제에는 함수를 먼저 고려하세요. 프로퍼티 하나의 저장과 접근 정책을 타입으로 표현할 수 있다면 프로퍼티 래퍼가 더 단순할 수 있어요. 매크로는 작성된 선언이나 표현식의 구문을 읽어야 하고, 그 구조에서 코드를 파생해야 할 때 의미가 있어요.
+
+매크로 구현은 제한된 환경에서 실행되므로 네트워크나 파일 시스템의 현재 상태를 읽는 코드 생성 작업에는 맞지 않아요. 외부 스키마나 리소스가 입력이라면 명시적인 빌드 도구나 코드 생성기를 검토하세요.
+
+## 언제 사용해야 하나요
+
+다음 조건이 겹칠수록 매크로가 잘 맞아요.
+
+- 여러 타입에서 같은 규칙으로 프로퍼티, 메서드, 프로토콜 준수를 반복하고 있어요.
+- 생성할 코드가 붙은 선언이나 호출 표현식의 구문에서 결정돼요.
+- 잘못된 사용을 컴파일 시점에 발견하고 구체적인 진단을 제공하고 싶어요.
+- 매크로 이름과 확장 결과가 수동으로 작성한 코드보다 의도를 더 잘 보여 줘요.
+- 확장 결과와 진단을 테스트할 수 있을 만큼 생성 규칙이 명확해요.
+
+다음 상황에서는 매크로를 도입하지 않아도 돼요.
+
+- 짧은 함수나 제네릭으로 중복을 충분히 제거할 수 있어요.
+- 실행 중의 값이나 외부 시스템 상태에 따라 동작을 바꿔야 해요.
+- 반복 코드가 적고 자주 바뀌어 매크로 API를 유지하는 비용이 더 커요.
+- 생성되는 코드가 너무 많거나 예측하기 어려워 호출부만 보고 동작을 이해하기 힘들어요.
+- 팀이 SwiftSyntax 버전 호환성, 진단, 확장 테스트를 관리할 여력이 없어요.
+
+매크로는 런타임 리플렉션 비용을 자동으로 만드는 기능은 아니에요. 확장 뒤에는 일반 Swift 코드가 되므로 런타임 성능은 생성된 코드가 무엇을 하는지에 달려 있어요. 반면 매크로 플러그인 실행과 생성 코드의 타입 검사는 빌드 시간에 영향을 줄 수 있고, 같은 큰 코드를 여러 곳에 만들면 바이너리 크기와 탐색 비용도 늘 수 있어요.
+
+## 매크로를 도입하는 순서를 정리해요
+
+1. 반복되는 코드를 모아 입력 선언에서 기계적으로 파생되는 부분인지 확인해요.
+2. 값의 재사용이면 함수, 저장과 접근 정책이면 프로퍼티 래퍼로 먼저 해결할 수 있는지 검토해요.
+3. 생성 코드가 놓일 위치를 기준으로 freestanding 또는 attached 역할을 선택해요.
+4. 호출부에서 보일 매크로 이름, 인자, 결과 타입과 생성 이름을 먼저 선언해요.
+5. 가장 작은 정상 입력 하나를 SwiftSyntax로 확장하고, Xcode에서 생성 결과를 확인해요.
+6. 지원하지 않는 입력에는 호출 위치를 가리키는 진단을 추가해요.
+7. 정상 확장, 경계 입력, 오류 진단을 테스트하고 실제 클라이언트 빌드도 확인해요.
+
+매크로 구현부터 크게 만들기보다 **호출부와 예상 확장 코드를 먼저 나란히 작성하는 방식**이 좋아요. 생성 규칙이 한 문장으로 설명되지 않는다면 매크로 하나가 너무 많은 책임을 맡고 있을 수 있어요.
+
+## 흔한 오해를 정리해요
+
+### 매크로는 실행 속도가 더 빠른 함수인가요?
+
+아니에요. 함수는 런타임에 값을 받아 동작하고, 매크로 구현은 컴파일 시점에 구문을 받아 Swift 코드를 만들어요. 매크로가 생성한 코드의 런타임 성능은 그 코드의 내용에 따라 달라져요.
+
+### 매크로 안에서 앱의 네트워크 요청을 미리 실행하나요?
+
+아니에요. 매크로는 입력 구문을 변환할 뿐이고, 생성된 함수 호출은 앱이 해당 코드를 실행할 때 일어나요. 매크로 구현도 현재 파일 시스템이나 네트워크 상태에 의존하지 않도록 제한된 환경에서 실행돼요.
+
+### `@`으로 시작하면 모두 attached 매크로인가요?
+
+아니에요. `@MainActor` 같은 선언 속성과 `@State` 같은 프로퍼티 래퍼도 `@` 문법을 사용해요. 정의로 이동하거나 확장 결과를 확인해 어떤 언어 기능인지 구분해야 해요.
+
+### 매크로가 생성한 코드는 타입 검사를 피하나요?
+
+아니에요. 입력과 확장 결과 모두 문법과 타입 검사를 받아요. 매크로 구현에 문제가 있으면 생성된 코드에서 컴파일 오류가 발생할 수 있으므로 확장 테스트와 실제 클라이언트 빌드가 필요해요.
+
+### 반복 코드는 모두 매크로로 없애야 하나요?
+
+아니에요. 매크로는 별도 타깃, SwiftSyntax 의존성, 빌드 시간, 디버깅 비용을 추가해요. 반복이 작거나 함수로 의도가 더 잘 드러난다면 직접 작성한 코드가 더 단순해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### freestanding 매크로와 attached 매크로의 차이는 무엇인가요?
+
+freestanding 매크로는 `#`으로 독립 호출해 표현식이나 선언을 만들고, attached 매크로는 `@`으로 특정 선언에 붙어 멤버, 접근자, 확장처럼 그 선언과 관련된 코드를 만들어요. 생성 결과가 놓일 문법 위치가 가장 큰 차이예요.
+
+### 매크로 선언과 구현을 왜 분리하나요?
+
+선언은 사용하는 코드가 볼 이름, 인자, 결과 타입, 역할을 공개하고 구현은 컴파일 도중 별도 프로그램으로 실행되어 구문을 변환해요. 컴파일러가 매크로를 사용하는 모듈을 빌드하면서 구현 플러그인을 실행해야 하므로 두 부분을 별도 타깃으로 구성해요.
+
+### SwiftSyntax는 매크로에서 어떤 역할을 하나요?
+
+SwiftSyntax는 Swift 소스를 문자열 덩어리가 아닌 선언과 표현식으로 구성된 구문 트리로 다루게 해요. 매크로 구현은 SwiftSyntax 노드로 입력을 검사하고, 역할에 맞는 새 구문 노드를 만들어 컴파일러에 반환해요.
+
+### 매크로 구현에서 오류를 어떻게 전달하나요?
+
+지원하지 않는 입력을 발견한 위치에서 오류를 던지거나 `MacroExpansionContext`에 진단을 전달해요. 생성 코드가 나중에 실패하게 두기보다 매크로 호출 위치에 원인과 수정 방법을 보여 주는 편이 좋아요.
+
+### 매크로의 단점은 무엇인가요?
+
+생성 코드가 호출부에서 바로 보이지 않아 탐색과 디버깅이 어려울 수 있고, 플러그인 실행과 추가 타입 검사로 빌드 시간이 늘 수 있어요. SwiftSyntax와 도구 모음의 버전 호환성, 진단 품질, 확장 테스트도 계속 관리해야 해요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Macros](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/)
+- [The Swift Programming Language — Attributes](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/)
+- [Apple Developer — Write Swift macros](https://developer.apple.com/videos/play/wwdc2023/10166/)
+- [Apple Developer — Expand on Swift macros](https://developer.apple.com/videos/play/wwdc2023/10167/)
+- [SwiftSyntax 공식 저장소](https://github.com/swiftlang/swift-syntax)
+- [SE-0382 Expression Macros](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0382-expression-macros.md)
+- [SE-0389 Attached Macros](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0389-attached-macros.md)
+- [SE-0397 Freestanding Declaration Macros](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0397-freestanding-declaration-macros.md)
+- [SE-0402 Extension Macros](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0402-extension-macros.md)
+- [SE-0415 Function Body Macros](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0415-function-body-macros.md)

--- a/docs/guide/swift/property-wrappers.md
+++ b/docs/guide/swift/property-wrappers.md
@@ -1,0 +1,671 @@
+---
+title: Swift로 이해하는 Property Wrapper
+description: Swift Property Wrapper의 wrappedValue, 초기화 규칙, projectedValue와 저장 구조를 예제로 이해하고 재사용 가능한 프로퍼티 정책의 적용 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Property Wrapper
+
+> **면접 답변 한 줄 요약:** Property Wrapper는 프로퍼티 값을 저장하고 읽고 쓰는 공통 규칙을 별도 타입의 `wrappedValue`로 정의해, 여러 프로퍼티에 같은 저장 정책을 `@Wrapper` 문법으로 재사용하는 Swift 기능이에요.
+
+앱을 만들다 보면 할인율은 0~100 사이로 제한하고, 사용자 이름은 앞뒤 공백을 제거하고, 설정값은 특정 저장소에서 읽도록 만드는 규칙이 반복돼요. 각 프로퍼티에 계산 프로퍼티와 별도 저장 공간을 직접 작성할 수도 있지만, 같은 규칙을 여러 곳에서 유지하기는 어려워요.
+
+Property Wrapper(프로퍼티 래퍼)는 프로퍼티의 **저장 공간과 접근 규칙**을 하나의 타입으로 묶어요. 이 문서에서는 할인율을 제한하는 작은 예제에서 시작해 `wrappedValue`, 초기화 문법, `_` 저장 공간, `$` 투영 값이 어떻게 연결되는지 단계적으로 설명해요.
+
+## 먼저 알아둘 Property Wrapper 용어
+
+| 용어                         | 쉬운 뜻                                                                                                                                                     |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 저장 프로퍼티                | 인스턴스 안에 실제 값을 보관하는 프로퍼티예요. 구조체와 클래스가 가질 수 있어요.                                                                            |
+| 계산 프로퍼티                | 값을 직접 보관하지 않고 getter와 선택적인 setter로 값을 계산하거나 다른 저장 공간에 전달하는 프로퍼티예요.                                                  |
+| getter와 setter              | getter는 프로퍼티를 읽을 때 값을 돌려주고, setter는 새 값을 대입할 때 저장 방식을 정해요.                                                                   |
+| 프로퍼티 관찰자              | `willSet`과 `didSet`처럼 값이 바뀌기 전후에 추가 동작을 실행하는 문법이에요. 저장 자체를 대신하지는 않아요.                                                 |
+| Property Wrapper             | 프로퍼티의 실제 저장 공간과 읽기·쓰기 규칙을 재사용 가능한 타입으로 정의하는 Swift 기능이에요.                                                              |
+| `@propertyWrapper`           | 클래스, 구조체, 열거형을 Property Wrapper 타입으로 선언하는 속성이에요.                                                                                     |
+| `wrappedValue`               | 사용하는 코드가 일반 프로퍼티 이름으로 읽고 쓰게 되는 주 값이에요. 모든 Property Wrapper 타입에 반드시 있어야 해요.                                         |
+| backing storage              | 래퍼 인스턴스를 보관하기 위해 컴파일러가 만드는 실제 저장 프로퍼티예요. 원래 이름 앞에 `_`가 붙고 `private` 접근 수준을 가져요.                             |
+| projected value              | 래퍼가 주 값 외에 추가 기능이나 상태를 공개하는 선택적인 값이에요. `projectedValue`를 정의하면 사용하는 쪽에서 `$프로퍼티이름`으로 접근해요.                |
+| 문법적 설탕(syntactic sugar) | 더 긴 코드를 읽기 쉬운 짧은 문법으로 표현하는 기능이에요. `@Percentage var rate`는 래퍼 저장 공간과 전달 프로퍼티를 컴파일러가 만들어 주는 짧은 표현이에요. |
+| 값 타입과 참조 타입          | 구조체는 복사할 때 독립된 값처럼 동작하고, 클래스는 복사한 참조가 같은 인스턴스를 가리켜요. 래퍼를 어떤 타입으로 만드는지에 따라 복사 의미도 달라져요.      |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- 계산 프로퍼티를 반복해서 작성할 때 생기는 문제
+- `@propertyWrapper`와 `wrappedValue`로 저장 규칙을 재사용하는 방법
+- 컴파일러가 만드는 `_프로퍼티` 저장 공간과 전달 getter·setter
+- `init()`, `init(wrappedValue:)`, 래퍼 인자의 초기화 규칙
+- `$프로퍼티`로 추가 상태를 공개하는 `projectedValue`
+- 구조체 래퍼와 클래스 래퍼의 복사 의미
+- 계산 프로퍼티, 관찰자, Result Builder, 매크로와의 차이
+- Property Wrapper가 적합한 경우와 피해야 할 경우
+
+## 계산 프로퍼티로도 값을 제한할 수 있어요
+
+상품 할인율은 0보다 작거나 100보다 클 수 없다고 가정해 볼게요. 별도의 저장 프로퍼티와 계산 프로퍼티를 사용하면 이 규칙을 구현할 수 있어요.
+
+```swift
+struct Product {
+  let name: String
+
+  private var storedDiscountRate = 0
+
+  var discountRate: Int {
+    get {
+      storedDiscountRate
+    }
+    set {
+      storedDiscountRate = min(max(newValue, 0), 100)
+    }
+  }
+}
+```
+
+`discountRate`에 어떤 값을 대입해도 실제 저장값은 0~100 사이로 조정돼요.
+
+```swift
+var keyboard = Product(name: "키보드")
+
+keyboard.discountRate = 20
+print(keyboard.discountRate)
+// 20
+
+keyboard.discountRate = 140
+print(keyboard.discountRate)
+// 100
+```
+
+한 프로퍼티만 관리한다면 이 코드로 충분해요. 문제는 같은 규칙이 `Coupon`, `Promotion`, `MemberBenefit` 같은 여러 타입에 반복될 때 생겨요.
+
+```swift
+struct Coupon {
+  private var storedDiscountRate = 0
+
+  var discountRate: Int {
+    get {
+      storedDiscountRate
+    }
+    set {
+      storedDiscountRate = min(max(newValue, 0), 100)
+    }
+  }
+}
+```
+
+저장 프로퍼티 이름, getter, setter, 범위 제한식이 모두 반복돼요. 한쪽만 0~80으로 잘못 고치거나 초기값에는 제한을 적용하지 않는 실수도 생길 수 있어요.
+
+## Property Wrapper는 저장 규칙을 타입으로 묶어요
+
+반복되는 0~100 제한을 `Percentage`라는 타입으로 옮겨 볼게요.
+
+```swift
+@propertyWrapper
+struct Percentage {
+  private var value: Int
+
+  var wrappedValue: Int {
+    get {
+      value
+    }
+    set {
+      value = Self.clamp(newValue)
+    }
+  }
+
+  init() {
+    value = 0
+  }
+
+  init(wrappedValue: Int) {
+    value = Self.clamp(wrappedValue)
+  }
+
+  private static func clamp(_ value: Int) -> Int {
+    min(max(value, 0), 100)
+  }
+}
+```
+
+`@propertyWrapper`를 붙인 타입에는 `wrappedValue` 인스턴스 프로퍼티가 반드시 필요해요. 이 예제에서 `wrappedValue`의 getter는 실제 저장값을 돌려주고 setter는 새 값을 제한한 뒤 저장해요.
+
+초기화할 때도 같은 `clamp(_:)`를 사용해요. 생성 시점과 이후 대입 시점에 서로 다른 규칙이 적용되는 문제를 막을 수 있어요.
+
+이제 프로퍼티 앞에 래퍼 타입을 속성처럼 붙여요.
+
+```swift
+struct Product {
+  let name: String
+
+  @Percentage var discountRate = 0
+}
+```
+
+사용하는 코드는 래퍼를 직접 호출하지 않고 일반 프로퍼티처럼 읽고 써요.
+
+```swift
+var keyboard = Product(name: "키보드")
+
+keyboard.discountRate = 25
+print(keyboard.discountRate)
+// 25
+
+keyboard.discountRate = 140
+print(keyboard.discountRate)
+// 100
+```
+
+`Product`는 할인율을 어떤 저장 프로퍼티에 넣고 어떻게 제한하는지 몰라도 돼요. 그 정책은 `Percentage`가 맡고, `Product`에는 이 프로퍼티가 퍼센트 규칙을 따른다는 선언만 남아요.
+
+## wrappedValue가 사용하는 코드에 보이는 값이에요
+
+Property Wrapper에는 두 관점의 값이 있어요.
+
+```swift
+@Percentage var discountRate = 10
+```
+
+- `discountRate`는 사용하는 코드에 보이는 `Int` 값이에요.
+- 실제 저장 공간에는 `Percentage` 래퍼 인스턴스가 들어 있어요.
+
+Swift 공식 [Properties 문서](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/properties/#Property-Wrappers)가 설명하는 변환을 단순화하면 위 선언은 다음 코드와 비슷해요.
+
+```swift
+private var _discountRate =
+  Percentage(wrappedValue: 10)
+
+var discountRate: Int {
+  get {
+    _discountRate.wrappedValue
+  }
+  set {
+    _discountRate.wrappedValue = newValue
+  }
+}
+```
+
+컴파일러는 원래 프로퍼티 이름 앞에 `_`를 붙인 backing storage를 만들어요. `_discountRate`가 `Percentage` 인스턴스를 저장하고, `discountRate`의 getter와 setter는 그 인스턴스의 `wrappedValue`로 접근을 전달해요.
+
+흐름을 정리하면 다음과 같아요.
+
+```text
+keyboard.discountRate = 140
+            │
+            ▼
+discountRate의 합성 setter
+            │
+            ▼
+_discountRate.wrappedValue = 140
+            │
+            ▼
+Percentage가 100으로 조정해 저장
+```
+
+Property Wrapper가 특별한 전역 저장소를 자동으로 만드는 것은 아니에요. 기본적으로 래퍼 인스턴스는 이 backing storage에 들어 있고, 각 `Product` 인스턴스가 자신의 래퍼를 가져요.
+
+## 초기값 문법은 래퍼의 이니셜라이저를 선택해요
+
+Property Wrapper를 적용한 프로퍼티의 작성 방식에 따라 컴파일러가 호출하는 래퍼 이니셜라이저가 달라져요.
+
+### 초기값이 없으면 init()을 사용해요
+
+```swift
+struct EmptyPromotion {
+  @Percentage var discountRate: Int
+}
+```
+
+`Percentage`가 `init()`을 제공하므로 래퍼의 기본값인 0으로 시작해요. 개념적으로 다음 초기화가 사용돼요.
+
+```swift
+private var _discountRate = Percentage()
+```
+
+래퍼에 `init()`이 없다면 초기값 없이 위 문법을 사용할 수 없어요.
+
+### 대입한 초기값은 init(wrappedValue:)로 전달해요
+
+```swift
+struct LaunchPromotion {
+  @Percentage var discountRate = 15
+}
+```
+
+오른쪽의 `15`는 `Percentage.init(wrappedValue:)`로 전달돼요.
+
+```swift
+private var _discountRate =
+  Percentage(wrappedValue: 15)
+```
+
+초기값이 150이라면 생성 시점부터 100으로 제한돼요.
+
+```swift
+struct InvalidPromotion {
+  @Percentage var discountRate = 150
+}
+
+let promotion = InvalidPromotion()
+print(promotion.discountRate)
+// 100
+```
+
+### 속성 인자는 나머지 이니셜라이저 인자로 전달해요
+
+0~100뿐 아니라 원하는 범위를 지정하려면 제네릭 `Clamped` 래퍼로 확장할 수 있어요.
+
+```swift
+@propertyWrapper
+struct Clamped<Value: Comparable> {
+  private var value: Value
+  private let range: ClosedRange<Value>
+
+  var wrappedValue: Value {
+    get {
+      value
+    }
+    set {
+      value = Self.clamp(newValue, to: range)
+    }
+  }
+
+  init(
+    wrappedValue: Value,
+    _ range: ClosedRange<Value>
+  ) {
+    self.range = range
+    value = Self.clamp(wrappedValue, to: range)
+  }
+
+  private static func clamp(
+    _ value: Value,
+    to range: ClosedRange<Value>
+  ) -> Value {
+    min(
+      max(value, range.lowerBound),
+      range.upperBound
+    )
+  }
+}
+```
+
+`Value: Comparable`은 `Value` 값을 범위의 최솟값·최댓값과 비교할 수 있다는 뜻이에요. `ClosedRange<Value>`는 양 끝을 모두 포함하는 `0...100` 같은 범위 타입이에요.
+
+사용할 때 초기값은 `wrappedValue`로, 속성의 `0...100`은 두 번째 인자로 전달돼요.
+
+```swift
+struct ProductPricing {
+  @Clamped(0...100)
+  var discountRate = 10
+
+  @Clamped(0...1_000_000)
+  var salePrice = 120_000
+}
+```
+
+두 선언은 개념적으로 다음 래퍼 초기화를 사용해요.
+
+```swift
+Clamped(
+  wrappedValue: 10,
+  0...100
+)
+
+Clamped(
+  wrappedValue: 120_000,
+  0...1_000_000
+)
+```
+
+공식 [Attributes 문서](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#propertyWrapper)는 `= 초기값`이 `wrappedValue` 인자가 되고, 속성 괄호의 인자는 나머지 래퍼 이니셜라이저 인자로 전달된다고 설명해요.
+
+## projectedValue는 주 값 밖의 기능을 공개해요
+
+값이 범위를 벗어나 조정됐는지 호출하는 쪽에 알려 주고 싶다고 가정해 볼게요. `wrappedValue`는 최종 `Int` 값을 공개하는 자리이므로, 추가 상태는 `projectedValue`로 분리할 수 있어요.
+
+```swift
+@propertyWrapper
+struct Clamped<Value: Comparable> {
+  private var value: Value
+  private let range: ClosedRange<Value>
+
+  private(set) var projectedValue: Bool
+
+  var wrappedValue: Value {
+    get {
+      value
+    }
+    set {
+      let adjusted = Self.clamp(newValue, to: range)
+      projectedValue = adjusted != newValue
+      value = adjusted
+    }
+  }
+
+  init(
+    wrappedValue: Value,
+    _ range: ClosedRange<Value>
+  ) {
+    self.range = range
+
+    let adjusted =
+      Self.clamp(wrappedValue, to: range)
+
+    value = adjusted
+    projectedValue = adjusted != wrappedValue
+  }
+
+  private static func clamp(
+    _ value: Value,
+    to range: ClosedRange<Value>
+  ) -> Value {
+    min(
+      max(value, range.lowerBound),
+      range.upperBound
+    )
+  }
+}
+```
+
+래퍼가 `projectedValue`를 제공하면 컴파일러는 원래 프로퍼티 이름 앞에 `$`를 붙인 접근점을 만들어요.
+
+```swift
+var pricing = ProductPricing()
+
+pricing.discountRate = 30
+print(pricing.$discountRate)
+// false
+
+pricing.discountRate = 140
+print(pricing.discountRate)
+// 100
+
+print(pricing.$discountRate)
+// true
+```
+
+이 예제의 `$discountRate`는 “마지막 대입값이 조정됐는가”를 나타내는 `Bool`이에요. `$` 값이 항상 래퍼 자체이거나 특정 프레임워크 타입인 것은 아니에요. 래퍼 작성자가 `projectedValue`에 어떤 타입과 의미를 부여하는지에 따라 달라져요.
+
+`projectedValue`는 어떤 타입도 반환할 수 있어요.
+
+- 검증 결과나 변경 여부 같은 상태
+- 래퍼가 제공하는 메서드를 모은 프록시 객체
+- 원래 값의 다른 읽기·쓰기 방식
+- 래퍼 인스턴스 자체인 `Self`
+
+SwiftUI는 Apple 플랫폼의 UI를 선언형으로 작성하는 프레임워크예요. SwiftUI의 `@State`에서 `$state`가 `Binding`을 돌려주는 것도 `projectedValue`를 활용한 사례예요. 하지만 모든 `$프로퍼티`가 `Binding`인 것은 아니므로 래퍼의 정의를 확인해야 해요.
+
+## _, 일반 이름, $는 서로 다른 값을 가리켜요
+
+세 이름의 역할을 한 번에 비교하면 혼동이 줄어요.
+
+| 작성 형태               | 가리키는 값                  | 접근 범위와 용도                                                                |
+| ----------------------- | ---------------------------- | ------------------------------------------------------------------------------- |
+| `pricing.discountRate`  | `wrappedValue`의 `Int`       | 사용하는 코드가 읽고 쓰는 주 값이에요.                                          |
+| `pricing.$discountRate` | `projectedValue`의 `Bool`    | 래퍼가 선택적으로 공개하는 추가 상태나 기능이에요.                              |
+| `_discountRate`         | `Clamped<Int>` 래퍼 인스턴스 | 컴파일러가 만든 `private` backing storage이며 해당 타입 구현 안에서만 접근해요. |
+
+`_discountRate`는 래퍼의 내부 상태를 직접 바꿔야 하는 특별한 초기화나 구현에서 사용할 수 있지만, 타입 외부에 공개되지 않아요. 외부 API가 필요한 경우 `projectedValue`로 의도를 드러내는 편이 좋아요.
+
+```swift
+struct ProductPricing {
+  @Clamped(0...100)
+  var discountRate = 10
+
+  init(discountRate: Int) {
+    _discountRate = Clamped(
+      wrappedValue: discountRate,
+      0...100
+    )
+  }
+}
+```
+
+이 코드는 래퍼 인스턴스 전체를 직접 초기화해요. `discountRate`의 값만 바꾸는 것과 래퍼의 범위·상태까지 새로 구성하는 것은 다른 작업이에요.
+
+## 래퍼는 var에 적용하고 저장 위치의 제약을 따라요
+
+Property Wrapper는 값을 읽고 쓰는 접근을 감싸므로 `let` 상수가 아니라 `var`에 적용해요.
+
+```swift
+@Percentage var discountRate = 10
+```
+
+현재 Swift의 공식 속성 규칙에서 Property Wrapper는 다음 위치에 사용할 수 있어요.
+
+- 클래스와 구조체의 저장 인스턴스 프로퍼티
+- 저장 타입 프로퍼티
+- 함수 안의 저장 지역 변수
+- Property Wrapper 매개변수를 지원하는 함수와 클로저의 매개변수
+
+반대로 다음 선언에는 사용할 수 없어요.
+
+- `let` 상수
+- getter와 setter를 직접 작성한 계산 프로퍼티
+- 전역 변수
+
+래퍼가 적용된 프로퍼티에는 `willSet`과 `didSet` 관찰자를 추가할 수 있지만, getter와 setter는 컴파일러가 합성하므로 직접 다시 작성할 수 없어요.
+
+함수 매개변수의 Property Wrapper는 호출자가 래퍼를 전달하는 문법이 아니에요. 호출자는 원래 값 타입을 전달하고, 함수 안에서 래퍼가 그 매개변수 접근을 감싸요.
+
+```swift
+func printDiscount(
+  @Percentage rate: Int
+) {
+  print(rate)
+}
+
+printDiscount(rate: 140)
+// 100
+```
+
+매개변수 지원은 [SE-0293](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md)에서 도입됐어요. 함수 시그니처만 보고 값이 변환된다는 사실을 놓치기 쉬우므로, 단순한 한 번의 검증이라면 명시적인 함수 호출이 더 읽기 쉬운지도 비교하세요.
+
+## 구조체 래퍼와 클래스 래퍼는 복사 의미가 달라요
+
+앞에서 만든 `Percentage`와 `Clamped`는 구조체예요. 래퍼를 사용하는 바깥 구조체를 복사하면 래퍼도 값처럼 복사돼요.
+
+```swift
+var original = ProductPricing()
+var copied = original
+
+copied.discountRate = 40
+
+print(original.discountRate)
+// 10
+
+print(copied.discountRate)
+// 40
+```
+
+반대로 클래스 래퍼는 참조를 저장해요.
+
+```swift
+@propertyWrapper
+final class Shared<Value> {
+  var wrappedValue: Value
+
+  init(wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+struct Counter {
+  @Shared var count = 0
+}
+
+var first = Counter()
+var second = first
+
+second.count = 1
+
+print(first.count)
+// 1
+```
+
+`Counter`는 구조체지만 복사된 두 값의 `_count`가 같은 `Shared<Int>` 인스턴스를 가리켜요. 그래서 `second.count`를 바꾸면 `first.count`에서도 변경이 보여요.
+
+클래스 래퍼가 잘못이라는 뜻은 아니에요. 여러 소유자가 같은 저장소를 공유해야 한다면 의도에 맞을 수 있어요. 하지만 바깥 타입의 값 의미를 예상과 다르게 만들 수 있으므로 다음 질문으로 선택하세요.
+
+- 바깥 구조체를 복사할 때 래퍼 상태도 독립적으로 복사돼야 하나요?
+- 여러 프로퍼티나 인스턴스가 같은 저장소를 의도적으로 공유해야 하나요?
+- 래퍼가 가진 참조의 수명과 동시 접근을 누가 관리하나요?
+
+## Property Wrapper 자체는 스레드 안전을 보장하지 않아요
+
+공통 저장 로직을 래퍼에 모았다고 해서 여러 스레드나 동시 작업의 접근이 자동으로 안전해지는 것은 아니에요. 락을 사용하는 래퍼를 만들더라도 읽기와 쓰기 한 번만 보호할지, 여러 단계를 하나의 원자적인 작업으로 보호할지 별도로 설계해야 해요.
+
+예를 들어 다음 코드는 읽기와 쓰기가 결합된 작업이에요.
+
+```swift
+counter.count += 1
+```
+
+여러 작업이 동시에 실행되면 둘 다 같은 이전 값을 읽고 같은 새 값을 쓸 수 있어요. getter와 setter 각각에 락을 거는 것만으로 전체 증가 연산이 안전하다고 단정할 수 없어요.
+
+동시 접근이 핵심 문제라면 actor, 격리 규칙, 락으로 보호한 명시적인 메서드처럼 작업 전체의 경계를 표현하는 방법을 먼저 검토하세요. Property Wrapper는 그런 동시성 정책을 재사용하는 표현 수단일 수는 있지만, 정책의 정확성을 대신 증명하지는 않아요.
+
+## 계산 프로퍼티, 관찰자, Result Builder, 매크로와 역할이 달라요
+
+비슷해 보이는 기능을 “어떤 코드를 재사용하는가”로 나누면 선택이 쉬워져요.
+
+| 기능               | 주로 해결하는 문제                         | 생성되거나 실행되는 위치                     | 적합한 예                   |
+| ------------------ | ------------------------------------------ | -------------------------------------------- | --------------------------- |
+| 계산 프로퍼티      | 한 프로퍼티의 읽기·쓰기 방식을 직접 정의   | 해당 프로퍼티의 getter·setter                | 다른 두 값에서 합계를 계산  |
+| `willSet`·`didSet` | 값이 바뀌기 전후에 반응                    | 원래 프로퍼티의 저장 전후                    | 변경 로그 남기기            |
+| Property Wrapper   | 여러 프로퍼티의 저장·접근 정책 재사용      | 래퍼 인스턴스와 합성 getter·setter           | 범위 제한, 외부 저장소 연결 |
+| Result Builder     | 블록 안의 여러 표현식을 하나의 결과로 조합 | 컴파일러가 변환한 `build` 메서드 호출        | 선언형 목록이나 트리 만들기 |
+| 매크로             | 작성된 Swift 구문에서 다양한 코드를 생성   | 컴파일 시점에 역할이 허용한 표현식·멤버·확장 | 선언에서 반복 멤버 생성     |
+
+여러 표현식을 하나의 값으로 만드는 문제는 [Result Builder](./result-builders)가 다루고, 프로퍼티를 넘어 선언 전체를 분석해 코드를 추가하는 문제는 [매크로](./macros)가 다뤄요. Property Wrapper는 프로퍼티 하나의 저장과 접근이라는 더 좁고 명확한 지점에 특화돼 있어요.
+
+## 테스트에서는 주 값과 투영 값을 함께 확인해요
+
+Property Wrapper의 테스트는 두 층으로 나눌 수 있어요.
+
+1. 래퍼 타입을 직접 생성해 `wrappedValue` 규칙을 확인해요.
+2. 실제 프로퍼티에 적용해 합성된 접근 문법과 `projectedValue`를 확인해요.
+
+Swift Testing은 `@Test`와 `#expect`로 테스트를 선언하고 결과를 검증하는 Swift 공식 테스트 라이브러리예요. `Clamped`를 적용한 타입을 다음처럼 테스트할 수 있어요.
+
+```swift
+import Testing
+
+@Test
+func clampsDiscountRate() {
+  var pricing = ProductPricing()
+
+  pricing.discountRate = 140
+
+  #expect(pricing.discountRate == 100)
+  #expect(pricing.$discountRate)
+}
+
+@Test
+func keepsValidDiscountRate() {
+  var pricing = ProductPricing()
+
+  pricing.discountRate = 30
+
+  #expect(pricing.discountRate == 30)
+  #expect(pricing.$discountRate == false)
+}
+```
+
+경계값도 따로 확인하세요.
+
+- 범위의 최솟값과 최댓값
+- 범위 바로 바깥의 값
+- 선언에 작성한 초기값이 범위를 벗어난 경우
+- 유효한 값 이후 잘못된 값을 넣거나 그 반대 순서
+- 복사 뒤 상태가 독립적이어야 하는 구조체 래퍼
+
+`projectedValue`가 “마지막 대입 결과”처럼 상태를 기억한다면 여러 대입의 순서도 테스트해야 해요.
+
+## 언제 사용해야 하나요
+
+다음 조건이 겹칠수록 Property Wrapper가 잘 맞아요.
+
+- 여러 프로퍼티가 같은 저장 또는 접근 규칙을 반복해요.
+- 사용하는 쪽에는 원래 값 타입처럼 간단한 읽기·쓰기 문법을 보여 주고 싶어요.
+- 규칙에 필요한 상태와 옵션을 래퍼 인스턴스가 자연스럽게 소유할 수 있어요.
+- 주 값 외의 추가 기능을 `projectedValue`라는 명확한 API로 제공할 수 있어요.
+- 래퍼 이름만 읽어도 적용되는 정책을 예상할 수 있어요.
+
+다음 상황에서는 다른 방법이 더 분명할 수 있어요.
+
+- 규칙을 한 프로퍼티 한 곳에서만 사용해 계산 프로퍼티로 충분해요.
+- 잘못된 값을 조용히 바꾸지 않고 오류로 돌려줘야 해요.
+- 여러 프로퍼티를 함께 검증해야 해서 프로퍼티 하나만 보면 규칙을 결정할 수 없어요.
+- 값 변경이 네트워크 요청처럼 실패 가능한 큰 작업을 일으켜요.
+- 호출부에서 변환이나 부수 효과가 일어난다는 사실이 숨겨져 코드를 이해하기 어려워져요.
+- 동시성 안전성이나 객체 수명처럼 타입 전체의 설계가 더 중요한 문제예요.
+
+프로퍼티 setter는 `throws`로 선언할 수 없어요. 따라서 유효하지 않은 입력을 호출자가 반드시 처리해야 한다면 `updateDiscountRate(_:) throws` 같은 명시적인 메서드가 더 적합할 수 있어요.
+
+## Property Wrapper를 적용하는 순서를 정리해요
+
+1. 여러 프로퍼티에서 실제로 반복되는 저장·접근 코드를 찾으세요.
+2. 관찰만 필요한지, 저장 방식 자체를 바꿔야 하는지 구분하세요.
+3. 사용하는 코드에 보여 줄 `wrappedValue`의 타입과 읽기·쓰기 가능 여부를 먼저 정하세요.
+4. 초기값과 옵션이 어떤 래퍼 이니셜라이저로 들어오는지 설계하세요.
+5. 추가 API가 꼭 필요할 때만 의미가 분명한 `projectedValue`를 제공하세요.
+6. 바깥 타입을 복사할 때 상태가 독립적이어야 하는지 확인해 구조체와 클래스를 선택하세요.
+7. 경계값, 초기화, 투영 값, 복사 의미를 테스트하고 호출부가 정책을 충분히 드러내는지 검토하세요.
+
+처음에는 하나의 작고 구체적인 규칙만 래퍼에 넣으세요. 범위 제한, 저장소 접근, 로그, 검증, 네트워크 동기화를 한 래퍼가 모두 맡으면 이름만으로 동작을 예측하기 어려워져요.
+
+## 흔한 오해를 정리해요
+
+### Property Wrapper는 값을 감싸는 프로토콜인가요?
+
+아니에요. `PropertyWrapper`라는 프로토콜을 따르는 방식이 아니라 클래스, 구조체, 열거형 선언에 `@propertyWrapper`를 붙이고 `wrappedValue`를 제공하는 언어 규칙이에요.
+
+### 프로퍼티 이름으로 읽으면 래퍼 인스턴스가 나오나요?
+
+아니에요. `discountRate`는 래퍼의 `wrappedValue`를 돌려줘요. 래퍼 인스턴스는 `_discountRate` backing storage에 들어 있고, 추가 공개 값은 래퍼가 정의한 `$discountRate`를 통해 접근해요.
+
+### `$프로퍼티`는 항상 원래 값을 변경하는 Binding인가요?
+
+아니에요. `$프로퍼티`의 타입과 의미는 `projectedValue`가 정해요. SwiftUI의 일부 래퍼가 `Binding`을 반환할 뿐, 사용자 정의 래퍼는 `Bool`, 프록시, 래퍼 자신 등 어떤 타입도 선택할 수 있어요.
+
+### Property Wrapper를 쓰면 입력값 검증이 항상 안전해지나요?
+
+아니에요. 범위를 벗어난 값을 조용히 조정하면 호출자의 오류를 숨길 수도 있어요. 잘못된 입력을 거부하고 이유를 전달해야 한다면 실패 가능한 이니셜라이저나 `throws` 메서드를 사용하세요.
+
+### 클래스 래퍼를 구조체에 쓰면 구조체도 값 타입으로 복사되나요?
+
+구조체 자체는 복사되지만 내부 래퍼 참조는 같은 클래스 인스턴스를 가리킬 수 있어요. 두 복사본의 상태가 독립적이어야 한다면 구조체 래퍼를 사용하거나 명시적인 복사 정책을 설계해야 해요.
+
+### Property Wrapper를 쓰면 여러 스레드에서 안전한가요?
+
+아니에요. 래퍼가 정확한 동기화 정책을 구현했을 때만 해당 정책만큼 안전해요. 읽기와 쓰기를 결합한 연산, 참조 타입의 내부 변경, 래퍼 복사 의미까지 함께 검토해야 해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### wrappedValue는 어떤 역할을 하나요?
+
+`wrappedValue`는 래퍼를 적용한 프로퍼티의 getter와 setter가 전달하는 주 값이에요. 사용하는 코드는 일반 프로퍼티 이름으로 접근하지만 실제 읽기와 쓰기는 backing storage의 `wrappedValue`를 거쳐요.
+
+### _프로퍼티와 $프로퍼티의 차이는 무엇인가요?
+
+`_프로퍼티`는 컴파일러가 래퍼 인스턴스를 보관하기 위해 만든 `private` backing storage예요. `$프로퍼티`는 래퍼가 `projectedValue`를 정의했을 때 추가 상태나 기능을 공개하는 합성 프로퍼티예요.
+
+### init(wrappedValue:)는 언제 호출되나요?
+
+래퍼가 적용된 프로퍼티 선언에 `= 초기값`을 작성하면 그 값이 `wrappedValue` 인자로 전달돼요. 속성 괄호에 다른 인자가 있으면 초기값과 함께 해당 인자를 받는 래퍼 이니셜라이저가 선택돼요.
+
+### Property Wrapper와 계산 프로퍼티의 차이는 무엇인가요?
+
+계산 프로퍼티는 한 선언에 getter와 setter를 직접 작성하고, Property Wrapper는 그 저장·접근 규칙을 별도 타입으로 만들어 여러 프로퍼티에서 재사용해요. 한 곳에서만 필요한 계산이라면 계산 프로퍼티가 더 단순할 수 있어요.
+
+### Property Wrapper의 단점은 무엇인가요?
+
+저장과 변환 동작이 짧은 속성 문법 뒤에 숨을 수 있고, 초기화·복사·접근 제어·동시성 의미가 래퍼 타입에 따라 달라져요. 래퍼가 많아지면 실제 저장 위치와 부수 효과를 찾는 비용도 커질 수 있어요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Properties](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/properties/)
+- [The Swift Programming Language — Attributes](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/)
+- [Swift Compiler Diagnostics — Property wrapper implementation requirements](https://docs.swift.org/compiler/documentation/diagnostics/property-wrapper-requirements/)
+- [SE-0258 Property Wrappers](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0258-property-wrappers.md)
+- [SE-0293 Extend Property Wrappers to Function and Closure Parameters](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md)

--- a/docs/guide/swift/result-builders.md
+++ b/docs/guide/swift/result-builders.md
@@ -1,0 +1,634 @@
+---
+title: Swift로 이해하는 Result Builder
+description: Swift Result Builder가 여러 표현식을 하나의 값으로 조합하는 원리와 @resultBuilder 구현, 조건문·반복문 지원, 적용 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Result Builder
+
+> **면접 답변 한 줄 요약:** Result Builder는 특별한 속성이 붙은 코드 블록의 표현식을 컴파일러가 정해진 `build` 메서드 호출로 바꿔 하나의 결과로 조합하고, 목록이나 트리 구조를 선언형 문법으로 작성하게 하는 Swift 기능이에요.
+
+SwiftUI에서 `VStack` 안에 여러 View를 나란히 적거나 조건에 따라 View를 추가하는 코드를 본 적이 있다면 이미 Result Builder를 사용한 경험이 있을 수 있어요. 여러 줄인데도 쉼표와 `return` 없이 하나의 결과가 만들어지는 이유가 Result Builder의 변환 규칙에 있어요.
+
+이 문서에서는 설정 화면의 행 목록을 만드는 작은 예제로 직접 배열을 조립할 때의 불편부터 살펴봐요. 이어서 `@resultBuilder` 타입을 만들고, 컴파일러가 표현식과 조건문, 반복문을 어떤 메서드 호출로 바꾸는지 단계적으로 설명해요.
+
+## 먼저 알아둘 Swift 용어
+
+| 용어                 | 쉬운 뜻                                                                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 클로저               | 실행할 코드를 값처럼 전달하고 저장할 수 있는 Swift 기능이에요. 자세한 기본 문법은 [클로저](./closures) 문서에서 확인할 수 있어요.                   |
+| trailing closure     | 함수의 마지막 클로저 인자를 소괄호 밖에 `{ ... }`로 작성하는 호출 문법이에요.                                                                       |
+| 속성(attribute)      | `@resultBuilder`처럼 선언이나 타입에 특별한 의미를 더하는 `@` 문법이에요.                                                                           |
+| 선언형 문법          | 처리 순서를 하나씩 명령하기보다 최종 결과의 구조가 어떤 모습이어야 하는지 중심으로 작성하는 방식이에요.                                             |
+| DSL                  | Domain-Specific Language의 줄임말이에요. 설정, UI, 테스트처럼 특정 문제 영역을 간결하게 표현하도록 만든 작은 전용 문법이에요.                       |
+| 컴파일러 변환        | 작성한 코드를 컴파일러가 의미가 같은 다른 형태로 해석하는 과정이에요. Result Builder 블록은 `build` 메서드 호출로 변환돼요.                         |
+| 표현식(expression)   | 실행하면 값을 만드는 코드예요. `.action(title: "일반")`은 `SettingsRow` 값을 만드는 표현식이에요.                                                   |
+| 부분 결과(component) | Result Builder가 각 표현식을 바꾸고 합치는 중간 값이에요. 이 문서에서는 `[SettingsRow]` 배열을 부분 결과로 사용해요.                                |
+| 결과 조합 메서드     | `buildBlock`, `buildOptional`, `buildArray`처럼 컴파일러가 블록의 문법에 맞춰 호출하는 `static` 메서드예요. 개발자가 호출부에서 직접 부르지 않아요. |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- 배열을 직접 조립할 때 조건과 반복 코드가 흩어지는 이유
+- `@resultBuilder`와 `buildExpression`, `buildBlock`의 역할
+- 컴파일러가 여러 표현식을 하나의 결과로 조합하는 과정
+- `if`, `if-else`, `switch`, `for`를 지원하는 방법
+- Result Builder와 일반 배열, Builder 디자인 패턴의 차이
+- Result Builder가 잘 맞는 경우와 사용하지 않아도 되는 경우
+- 오류가 생겼을 때 빠진 결과 조합 메서드를 찾는 방법
+
+## 배열을 직접 조립해도 올바르게 동작해요
+
+먼저 설정 화면에 표시할 행을 배열로 만들어 볼게요.
+
+```swift
+enum SettingsRow: Equatable {
+  case action(title: String)
+  case account(name: String)
+  case divider
+}
+
+enum UserRole: Equatable {
+  case member
+  case administrator
+}
+
+func makeSettingsWithoutBuilder(
+  showsAdvanced: Bool,
+  role: UserRole,
+  accountNames: [String]
+) -> [SettingsRow] {
+  var rows: [SettingsRow] = [
+    .action(title: "일반"),
+  ]
+
+  if showsAdvanced {
+    rows.append(.action(title: "고급"))
+  }
+
+  if role == .administrator {
+    rows.append(.action(title: "관리자 도구"))
+  } else {
+    rows.append(.action(title: "도움말"))
+  }
+
+  rows.append(.divider)
+
+  for name in accountNames {
+    rows.append(.account(name: name))
+  }
+
+  return rows
+}
+```
+
+이 코드는 명확하고 특별한 문법도 필요하지 않아요. 한두 곳에서 짧은 배열을 만든다면 이 방식으로 충분해요.
+
+하지만 같은 종류의 목록을 여러 API에서 반복해서 만든다면 실제 항목보다 `var`, `append`, `return` 같은 조립 코드가 더 눈에 띌 수 있어요. 중첩된 목록이나 트리를 만들 때는 어느 값이 어느 부모에 속하는지 파악하기도 어려워져요.
+
+우리가 표현하고 싶은 핵심 구조는 다음과 같은 모습이에요.
+
+```swift
+makeSettings {
+  .action(title: "일반")
+
+  if showsAdvanced {
+    .action(title: "고급")
+  }
+
+  if role == .administrator {
+    .action(title: "관리자 도구")
+  } else {
+    .action(title: "도움말")
+  }
+
+  .divider
+
+  for name in accountNames {
+    .account(name: name)
+  }
+}
+```
+
+Result Builder를 사용하면 Swift의 조건문과 반복문을 유지하면서, 행을 배열에 넣는 반복 작업은 별도의 Builder 타입에 맡길 수 있어요.
+
+## Result Builder는 코드 블록의 값을 모아 하나의 결과를 만들어요
+
+Result Builder는 런타임에 생성해서 상태를 쌓는 객체가 아니에요. `@resultBuilder`를 붙인 타입에 `static` 메서드를 정의하면, 컴파일러가 Builder 블록을 그 메서드 호출로 변환해요.
+
+가장 작은 `SettingsBuilder`부터 만들어 볼게요.
+
+```swift
+@resultBuilder
+struct SettingsBuilder {
+  typealias Component = [SettingsRow]
+
+  static func buildExpression(
+    _ expression: SettingsRow
+  ) -> Component {
+    [expression]
+  }
+
+  static func buildBlock(
+    _ components: Component...
+  ) -> Component {
+    components.flatMap { $0 }
+  }
+}
+```
+
+두 메서드는 서로 다른 일을 담당해요.
+
+- `buildExpression(_:)`은 블록에 적은 `SettingsRow` 하나를 부분 결과인 `[SettingsRow]`로 바꿔요.
+- `buildBlock(_:)`은 같은 블록에서 만들어진 여러 부분 결과를 하나의 배열로 합쳐요.
+
+이 Builder를 클로저 매개변수에 적용해요.
+
+```swift
+func makeSettings(
+  @SettingsBuilder content: () -> [SettingsRow]
+) -> [SettingsRow] {
+  content()
+}
+```
+
+`content` 앞의 `@SettingsBuilder`가 호출부의 클로저에 Builder 변환을 적용해요. 이제 쉼표와 `return` 없이 여러 행을 나란히 작성할 수 있어요.
+
+```swift
+let basicRows = makeSettings {
+  .action(title: "일반")
+  .divider
+  .action(title: "앱 정보")
+}
+```
+
+`basicRows`에는 다음 배열이 들어 있어요.
+
+```swift
+[
+  .action(title: "일반"),
+  .divider,
+  .action(title: "앱 정보"),
+]
+```
+
+Result Builder 타입은 특정 프로토콜을 따르지 않아요. 컴파일러가 이름과 시그니처가 맞는 `static` 메서드를 찾아 사용하므로 `SettingsBuilder()` 인스턴스를 만들 필요도 없어요.
+
+## 컴파일러는 표현식을 build 메서드 호출로 바꿔요
+
+다음 Builder 블록을 기준으로 변환 과정을 살펴볼게요.
+
+```swift
+let rows = makeSettings {
+  .action(title: "일반")
+  .divider
+}
+```
+
+개념적으로 컴파일러는 각 표현식을 `buildExpression(_:)`에 전달한 뒤 `buildBlock(_:)`으로 합쳐요.
+
+```swift
+let first = SettingsBuilder.buildExpression(
+  .action(title: "일반")
+)
+let second = SettingsBuilder.buildExpression(
+  .divider
+)
+
+let combined = SettingsBuilder.buildBlock(
+  first,
+  second
+)
+```
+
+실제 컴파일러 구현이 위 이름의 지역 변수를 그대로 만드는 것은 아니에요. 어떤 값이 어떤 결과 조합 메서드로 전달되는지 이해하기 위한 개념적인 표현이에요.
+
+이 변환을 알면 “여러 줄의 클로저가 어떻게 `[SettingsRow]` 하나를 반환하나요?”라는 질문에 답할 수 있어요. 각 줄이 자동으로 반환되는 것이 아니라, **각 표현식이 부분 결과가 되고 Builder가 부분 결과를 최종 값으로 조합해요.**
+
+Swift 공식 문서의 [Result Builders](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/advancedoperators/#Result-Builders)도 Result Builder를 목록이나 트리 같은 중첩 데이터를 선언형 방식으로 만들기 위한 타입으로 설명해요.
+
+## if만 있는 조건은 buildOptional로 처리해요
+
+앞의 `SettingsBuilder`는 여러 표현식을 합칠 수 있지만 아직 `if`를 처리할 방법은 정의하지 않았어요. `if`에 `else`가 없어 결과가 없을 수도 있는 경우에는 `buildOptional(_:)`을 추가해요.
+
+```swift
+extension SettingsBuilder {
+  static func buildOptional(
+    _ component: Component?
+  ) -> Component {
+    component ?? []
+  }
+}
+```
+
+조건이 참이면 `if` 블록에서 만든 부분 결과가 전달되고, 거짓이면 `nil`이 전달돼요. 이 예제에서는 `nil`을 빈 배열로 바꿔 전체 결과에서 해당 행을 생략해요.
+
+```swift
+let showsAdvanced = true
+
+let rows = makeSettings {
+  .action(title: "일반")
+
+  if showsAdvanced {
+    .action(title: "고급")
+  }
+}
+```
+
+`showsAdvanced`가 `true`이면 `고급` 행이 포함되고, `false`이면 `일반` 행만 남아요. Result Builder가 조건을 미리 계산하는 것은 아니며, 실행 시점에는 원래 `if` 조건이 그대로 평가돼요.
+
+## if-else와 switch는 buildEither로 처리해요
+
+두 갈래 이상에서 하나의 결과를 선택하려면 `buildEither(first:)`와 `buildEither(second:)`을 함께 정의해요.
+
+```swift
+extension SettingsBuilder {
+  static func buildEither(
+    first component: Component
+  ) -> Component {
+    component
+  }
+
+  static func buildEither(
+    second component: Component
+  ) -> Component {
+    component
+  }
+}
+```
+
+첫 번째 갈래가 선택되면 `first`, 두 번째 갈래가 선택되면 `second` 메서드가 호출돼요. 이 Builder에서는 어느 쪽이든 이미 `[SettingsRow]`이므로 값을 그대로 돌려줘요.
+
+```swift
+let role = UserRole.administrator
+
+let rows = makeSettings {
+  if role == .administrator {
+    .action(title: "관리자 도구")
+  } else {
+    .action(title: "도움말")
+  }
+}
+```
+
+`switch`도 같은 두 메서드를 사용해 여러 갈래의 결과를 하나의 부분 결과로 합쳐요.
+
+```swift
+let rows = makeSettings {
+  switch role {
+  case .member:
+    .action(title: "고객 지원")
+  case .administrator:
+    .action(title: "관리자 도구")
+  }
+}
+```
+
+메서드 이름만 보면 두 갈래만 지원하는 것처럼 보이지만, 컴파일러가 여러 `case`를 `first`와 `second` 호출의 트리로 구성해요.
+
+## for 반복은 buildArray로 처리해요
+
+`for`의 각 반복에서 만들어진 부분 결과는 배열로 모인 뒤 `buildArray(_:)`에 전달돼요.
+
+```swift
+extension SettingsBuilder {
+  static func buildArray(
+    _ components: [Component]
+  ) -> Component {
+    components.flatMap { $0 }
+  }
+}
+```
+
+이 문서의 `Component`는 이미 `[SettingsRow]`이므로 `components` 타입은 `[[SettingsRow]]`이에요. `flatMap`으로 한 단계 펼치면 최종 `[SettingsRow]`을 얻을 수 있어요.
+
+```swift
+let accountNames = ["Blob", "Mango"]
+
+let rows = makeSettings {
+  .action(title: "일반")
+  .divider
+
+  for name in accountNames {
+    .account(name: name)
+  }
+}
+```
+
+결과에는 `일반`, 구분선, `Blob`, `Mango` 행이 순서대로 들어가요. 반복마다 만든 행을 개발자가 직접 `append`하지 않아도 Builder가 모아서 합쳐요.
+
+## 완성된 SettingsBuilder를 한 번에 살펴봐요
+
+지금까지 추가한 기능을 한 타입에 모으면 다음과 같아요.
+
+```swift
+@resultBuilder
+struct SettingsBuilder {
+  typealias Component = [SettingsRow]
+
+  static func buildExpression(
+    _ expression: SettingsRow
+  ) -> Component {
+    [expression]
+  }
+
+  static func buildBlock(
+    _ components: Component...
+  ) -> Component {
+    components.flatMap { $0 }
+  }
+
+  static func buildOptional(
+    _ component: Component?
+  ) -> Component {
+    component ?? []
+  }
+
+  static func buildEither(
+    first component: Component
+  ) -> Component {
+    component
+  }
+
+  static func buildEither(
+    second component: Component
+  ) -> Component {
+    component
+  }
+
+  static func buildArray(
+    _ components: [Component]
+  ) -> Component {
+    components.flatMap { $0 }
+  }
+}
+```
+
+이제 처음에 배열로 작성했던 설정 목록을 Builder 문법으로 표현할 수 있어요.
+
+```swift
+func makeSettings(
+  @SettingsBuilder content: () -> [SettingsRow]
+) -> [SettingsRow] {
+  content()
+}
+
+let showsAdvanced = true
+let role = UserRole.administrator
+let accountNames = ["Blob", "Mango"]
+
+let rows = makeSettings {
+  .action(title: "일반")
+
+  if showsAdvanced {
+    .action(title: "고급")
+  }
+
+  if role == .administrator {
+    .action(title: "관리자 도구")
+  } else {
+    .action(title: "도움말")
+  }
+
+  .divider
+
+  for name in accountNames {
+    .account(name: name)
+  }
+}
+```
+
+호출부에는 설정 목록의 구조만 남고, 각 표현식을 배열로 바꾸고 합치는 규칙은 `SettingsBuilder` 한곳에 모였어요.
+
+## 문법마다 필요한 결과 조합 메서드가 달라요
+
+Result Builder는 사용하려는 모든 문법을 자동으로 지원하지 않아요. Builder 타입에 어떤 메서드가 있느냐에 따라 블록에서 사용할 수 있는 문법이 정해져요.
+
+| 결과 조합 메서드                                                     | 지원하거나 담당하는 역할                                                                                                    |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `buildBlock(_:)`                                                     | 같은 블록의 여러 부분 결과를 한 번에 합쳐요.                                                                                |
+| `buildPartialBlock(first:)`와 `buildPartialBlock(accumulated:next:)` | 부분 결과를 첫 값부터 하나씩 누적해요. 두 메서드를 함께 구현하면 `buildBlock(_:)` 대신 기본 조합 방식으로 사용할 수 있어요. |
+| `buildExpression(_:)`                                                | 블록에 적은 표현식을 Builder 내부의 `Component` 타입으로 바꿔요. 서로 다른 입력 타입을 받도록 오버로드할 수도 있어요.       |
+| `buildOptional(_:)`                                                  | `else`가 없는 `if`처럼 결과가 없을 수도 있는 갈래를 처리해요.                                                               |
+| `buildEither(first:)`, `buildEither(second:)`                        | `if-else`와 `switch`의 여러 갈래 중 선택된 부분 결과를 합쳐요. 두 메서드를 함께 구현해요.                                   |
+| `buildArray(_:)`                                                     | `for`의 각 반복에서 나온 부분 결과를 모아 하나로 합쳐요.                                                                    |
+| `buildFinalResult(_:)`                                               | 마지막 `Component`를 외부에 공개할 최종 반환 타입으로 바꾸거나 후처리해요.                                                  |
+| `buildLimitedAvailability(_:)`                                       | `if #available` 안의 구체 타입 정보가 바깥으로 퍼지지 않도록 처리할 때 사용해요.                                            |
+
+현재 Swift 언어 규칙에서는 `buildBlock(_:)` 또는 두 `buildPartialBlock` 메서드가 기본 블록 조합을 담당해야 해요. 나머지 메서드는 Builder가 제공하려는 문법과 타입 변환에 따라 선택해요.
+
+모든 메서드를 미리 구현할 필요는 없어요. 정적인 목록만 만든다면 `buildExpression`과 기본 블록 조합만으로 충분할 수 있어요. 필요한 문법이 생길 때 해당 메서드를 추가하면 Builder의 허용 범위도 API 의도에 맞게 유지할 수 있어요.
+
+전체 메서드 시그니처와 정확한 변환 규칙은 Swift 언어 참조의 [`resultBuilder` 속성](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#resultBuilder)에서 확인할 수 있어요.
+
+## buildExpression은 입력 문법의 범위를 정해요
+
+`buildExpression(_:)`을 오버로드하면 같은 Builder 블록에서 여러 입력 타입을 받을 수 있어요. 예를 들어 `String`을 계정 행으로 바꾸는 규칙을 추가할 수 있어요.
+
+```swift
+extension SettingsBuilder {
+  static func buildExpression(
+    _ name: String
+  ) -> Component {
+    [.account(name: name)]
+  }
+}
+```
+
+그러면 다음 문자열도 `SettingsRow`와 함께 사용할 수 있어요.
+
+```swift
+let rows = makeSettings {
+  .action(title: "일반")
+  "Blob"
+  "Mango"
+}
+```
+
+문법은 짧아지지만 문자열이 계정 행으로 바뀐다는 규칙을 모르는 독자에게는 의미가 숨겨질 수 있어요. 입력 타입이 역할을 충분히 설명하지 못한다면 `.account(name:)`처럼 의도가 드러나는 표현을 유지하는 편이 좋아요.
+
+Result Builder의 목적은 가장 짧은 문법을 만드는 것이 아니에요. 반복되는 구조를 안전하게 조합하면서 호출부가 문제 영역의 의미를 잘 보여 주게 만드는 것이 중요해요.
+
+## Builder 속성은 클로저 외의 선언에도 붙일 수 있어요
+
+가장 흔한 사용 위치는 함수 타입의 매개변수예요.
+
+```swift
+func makeSettings(
+  @SettingsBuilder content: () -> [SettingsRow]
+) -> [SettingsRow] {
+  content()
+}
+```
+
+Result Builder 속성은 함수 본문이나 값을 계산하는 프로퍼티의 getter에도 적용할 수 있어요.
+
+```swift
+@SettingsBuilder
+func defaultSettings() -> [SettingsRow] {
+  SettingsRow.action(title: "일반")
+  SettingsRow.action(title: "앱 정보")
+}
+
+@SettingsBuilder
+var supportSettings: [SettingsRow] {
+  SettingsRow.action(title: "자주 묻는 질문")
+  SettingsRow.action(title: "문의하기")
+}
+```
+
+subscript의 getter에도 적용할 수 있지만, 일반적인 API에서는 Builder를 받는 클로저 매개변수가 호출부의 범위와 목적을 가장 분명하게 보여 줘요.
+
+## SwiftUI도 같은 원리로 View를 조합해요
+
+SwiftUI는 Apple 플랫폼의 사용자 인터페이스를 선언형으로 만드는 프레임워크예요. 다음처럼 `VStack` 안에 여러 View와 조건문을 작성할 수 있어요.
+
+```swift
+VStack {
+  Text("프로필")
+
+  if isLoggedIn {
+    Text("로그인됨")
+  }
+}
+```
+
+이 형태도 Result Builder가 표현식과 조건문의 결과를 하나의 콘텐츠로 조합하기 때문에 가능해요. Apple의 [`ViewBuilder`](https://developer.apple.com/documentation/swiftui/viewbuilder) 문서는 이를 클로저에서 View를 구성하는 사용자 정의 매개변수 속성으로 설명해요.
+
+SDK와 API에 따라 사용하는 구체적인 Builder 타입과 제약은 달라질 수 있어요. 직접 `buildBlock`을 호출하려고 하지 말고, 사용하는 SwiftUI API의 현재 시그니처에서 어떤 Builder 속성을 요구하는지 확인해야 해요.
+
+## Result Builder와 비슷해 보이는 개념을 구분해요
+
+| 방식                | 핵심 질문                                    | 값이 만들어지는 방법                                                               | 잘 맞는 상황                                              |
+| ------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| 일반 배열·클로저    | 값을 어떤 순서로 직접 추가할까요?            | `append`, 배열 리터럴, `return`을 개발자가 직접 작성해요.                          | 짧고 한 번만 사용하는 단순 목록이에요.                    |
+| Result Builder      | 블록의 여러 표현식을 어떤 규칙으로 합칠까요? | 컴파일러가 블록을 `static build...` 메서드 호출로 변환해요.                        | 반복해서 만드는 목록·트리와 선언형 DSL이에요.             |
+| Builder 디자인 패턴 | 복잡한 객체의 생성 단계를 어떻게 나눌까요?   | 상태를 가진 Builder 객체에 설정 메서드를 차례로 호출하고 마지막에 결과를 만들어요. | 선택 항목이 많고 단계적인 객체 생성 과정이 필요할 때예요. |
+
+이름은 비슷하지만 Result Builder와 Builder 디자인 패턴은 같은 기능이 아니에요. Result Builder는 Swift 컴파일러가 특정 코드 블록을 변환하는 **언어 기능**이고, Builder 디자인 패턴은 객체 생성 책임을 분리하는 **설계 방식**이에요.
+
+또한 Result Builder는 임의의 Swift 코드를 생성하는 매크로가 아니에요. 컴파일러가 언어에 정해진 규칙으로 블록을 분석하고, Builder 타입이 제공한 결과 조합 메서드를 호출하는 제한된 변환이에요.
+
+## Builder 블록에서 모든 제어문을 사용할 수 있는 것은 아니에요
+
+Result Builder가 처리하는 문법은 결과 조합 메서드와 언어의 변환 규칙에 의해 제한돼요.
+
+- `if`, `if-else`, `switch`, `for`는 대응하는 결과 조합 메서드가 있을 때 사용할 수 있어요.
+- `let`과 `var` 같은 지역 선언은 변환되지 않으므로 중간 값을 계산하는 데 사용할 수 있어요.
+- `return`, `break`, `continue`, `defer`, `guard`, `while`, `do-catch`는 Result Builder가 변환하는 블록에서 사용할 수 없어요.
+- 대입 표현식은 `Void`를 만들기 때문에 `buildExpression(_:)`이 `Void`를 받지 않으면 오류가 날 수 있어요. Builder 블록은 부수 효과보다 결과 구성에 집중하는 편이 좋아요.
+- 클로저 인자로 전달한 블록에 명시적인 `return`을 넣으면 Builder 변환이 적용되지 않아 여러 표현식을 조합할 수 없게 돼요.
+
+예를 들어 조건을 만족하지 않으면 일찍 끝내기 위해 `guard`를 쓰기보다, Builder 밖에서 입력을 검증하거나 `if`로 포함할 항목을 선택할 수 있어요.
+
+```swift
+let validNames = accountNames.filter {
+  !$0.isEmpty
+}
+
+let rows = makeSettings {
+  for name in validNames {
+    .account(name: name)
+  }
+}
+```
+
+Builder가 지원하지 않는 문법을 억지로 추가하기보다 계산과 검증은 일반 Swift 코드에 두고, Builder 블록은 결과 구조를 표현하는 역할로 좁히면 읽기 쉬워져요.
+
+## 오류에서는 사용한 문법과 build 메서드를 연결해 봐요
+
+Result Builder 오류는 변환된 코드를 떠올리면 원인을 찾기 쉬워요.
+
+| 증상                                            | 먼저 확인할 부분                                                                                          |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `if`를 추가한 뒤 컴파일되지 않아요.             | `else`가 없으면 `buildOptional(_:)`, `else`가 있으면 두 `buildEither` 메서드가 있는지 확인해요.           |
+| `switch`를 추가한 뒤 컴파일되지 않아요.         | `buildEither(first:)`와 `buildEither(second:)`이 함께 있는지 확인해요.                                    |
+| `for`를 추가한 뒤 컴파일되지 않아요.            | `buildArray(_:)`이 있고 반환 타입이 `Component`와 맞는지 확인해요.                                        |
+| 특정 표현식만 Builder가 받지 못해요.            | 해당 입력 타입을 받는 `buildExpression(_:)` 오버로드가 있는지 확인해요.                                   |
+| 여러 표현식의 타입이 서로 맞지 않아요.          | 모든 경로가 Builder의 `Component`로 변환되는지 확인해요.                                                  |
+| `return`을 추가한 뒤 여러 줄을 조합하지 못해요. | 명시적 `return`을 제거하고 각 줄에 결과 표현식을 작성해 Builder 변환이 적용되게 해요.                     |
+| 타입 검사 오류가 지나치게 복잡해요.             | 큰 Builder 블록을 의미 있는 하위 함수나 프로퍼티로 나누고, 과도한 제네릭 오버로드와 암시적 변환을 줄여요. |
+
+컴파일러 오류가 `buildEither`나 `buildExpression`을 직접 언급하지 않더라도, 오류가 시작된 문법과 필요한 메서드를 먼저 연결하면 범위를 빠르게 좁힐 수 있어요.
+
+## 언제 사용해야 하나요
+
+다음 조건이 여러 개 맞는다면 Result Builder가 도움이 될 수 있어요.
+
+- 같은 종류의 목록이나 트리 구조를 여러 호출부에서 반복해서 만들어요.
+- 조건과 반복을 포함한 구조를 선언형으로 보여 주는 것이 중요해요.
+- 호출부에서 허용할 표현식 타입과 조합 규칙을 명확히 제한할 수 있어요.
+- `append`, 중첩 배열, 괄호보다 문제 영역의 이름이 코드에서 더 잘 드러나게 만들고 싶어요.
+- Builder 구현과 오류 메시지를 유지할 비용보다 호출부가 단순해지는 이점이 커요.
+
+다음 상황에서는 일반 Swift 코드가 더 나을 수 있어요.
+
+- 짧은 배열을 한 번 만들고 끝나요.
+- `guard`, `while`, 조기 `return`처럼 Builder가 지원하지 않는 제어 흐름이 핵심이에요.
+- 조합 규칙보다 값이 변경되는 순서와 부수 효과가 더 중요해요.
+- 암시적인 타입 변환이 많아 호출부만 보고 실제 결과를 예상하기 어려워요.
+- 팀이 Builder의 변환 규칙을 이해하기 위해 들이는 비용이 반복 코드보다 커요.
+
+Result Builder는 복잡성을 없애지 않아요. 호출부의 조립 복잡성을 Builder 타입으로 옮겨 재사용하는 기능이에요. 재사용할 구조와 규칙이 충분하지 않다면 배열과 일반 함수가 더 단순해요.
+
+## 적용 순서를 정리해요
+
+1. 먼저 배열, 튜플, 트리처럼 최종으로 만들 값의 타입을 정해요.
+2. 한 줄의 표현식 타입과 Builder 내부에서 합칠 `Component` 타입을 구분해요.
+3. 가장 작은 `buildExpression(_:)`과 `buildBlock(_:)` 또는 두 `buildPartialBlock` 메서드로 정적인 예제를 만들어요.
+4. `@Builder`를 클로저 매개변수나 getter에 적용하고 호출부의 반환 타입을 확인해요.
+5. 실제 호출부에 필요한 조건문과 반복문만 골라 `buildOptional`, `buildEither`, `buildArray`를 추가해요.
+6. 각 갈래와 반복 결과가 같은 `Component` 타입으로 합쳐지는지 테스트해요.
+7. 축약 문법이 문제 영역의 의미를 숨기지 않는지 다른 개발자의 관점에서 읽어 봐요.
+8. 단순 배열 구현과 비교해 Builder를 유지할 만큼 반복과 계층 구조가 있는지 다시 판단해요.
+
+## 흔한 오해를 정리해요
+
+### Result Builder는 여러 값을 튜플로 반환하나요?
+
+항상 튜플을 만드는 것은 아니에요. 최종 타입은 Builder의 결과 조합 메서드가 결정해요. 이 문서의 Builder는 `[SettingsRow]`을 만들고, SwiftUI의 Builder는 View 콘텐츠에 맞는 타입을 조합해요.
+
+### buildBlock을 개발자가 직접 호출해야 하나요?
+
+아니요. 일반적인 호출부에서는 Builder 블록만 작성하고 컴파일러가 필요한 메서드를 호출해요. 메서드를 직접 호출하는 코드는 변환 원리를 설명하거나 Builder 구현을 독립적으로 테스트할 때만 필요할 수 있어요.
+
+### @resultBuilder만 붙이면 if와 for를 모두 사용할 수 있나요?
+
+아니요. `if`와 `for`에 대응하는 `buildOptional`, `buildEither`, `buildArray`가 Builder 타입에 있어야 해요. Result Builder가 제공하는 메서드 집합이 DSL에서 허용할 문법을 결정해요.
+
+### Result Builder와 Builder 디자인 패턴은 같은가요?
+
+아니요. Result Builder는 컴파일러가 코드 블록을 변환하는 Swift 언어 기능이에요. Builder 디자인 패턴은 보통 상태를 가진 객체가 생성 단계를 저장했다가 복잡한 객체를 만드는 설계 방식이에요.
+
+### Result Builder를 사용하면 코드가 항상 더 읽기 쉬워지나요?
+
+아니요. 목록이나 트리의 구조가 반복되고 조합 규칙이 명확할 때 효과가 커요. 한 번 쓰는 짧은 배열이나 순차적인 상태 변경 코드에서는 암시적인 변환 때문에 오히려 이해하기 어려울 수 있어요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Result Builder는 어떻게 동작하나요?
+
+컴파일러가 Result Builder 속성이 적용된 블록의 표현식과 제어문을 Builder 타입의 `static build...` 메서드 호출로 변환해요. 각 표현식에서 만든 부분 결과를 합쳐 클로저나 getter의 최종 반환값을 만들어요.
+
+### buildExpression과 buildBlock의 차이는 무엇인가요?
+
+`buildExpression(_:)`은 블록의 개별 표현식을 Builder 내부의 `Component`로 바꿔요. `buildBlock(_:)`은 같은 블록에서 만들어진 여러 `Component`를 하나의 `Component`로 합쳐요.
+
+### if와 for를 지원하려면 무엇이 필요한가요?
+
+`else` 없는 `if`에는 `buildOptional(_:)`, `if-else`와 `switch`에는 두 `buildEither` 메서드, `for`에는 `buildArray(_:)`이 필요해요. 각 메서드는 해당 제어문에서 만들어진 부분 결과를 Builder의 `Component`로 합쳐요.
+
+### Result Builder의 장점과 비용은 무엇인가요?
+
+반복되는 목록이나 트리 구성을 선언형이고 타입 안전한 문법으로 표현할 수 있다는 장점이 있어요. 반면 변환 규칙을 알아야 오류를 해석할 수 있고, 지원할 제어문과 타입 변환을 Builder가 직접 설계하고 유지해야 하는 비용이 있어요.
+
+### Result Builder는 언제 만들지 않는 편이 좋은가요?
+
+짧은 배열을 한 번 만들거나 조기 반환과 상태 변경이 핵심이라면 일반 함수와 배열이 더 직접적이에요. 호출부의 반복되는 조립 코드가 충분하고, 허용할 표현식과 조합 규칙이 명확할 때 Result Builder를 검토하는 편이 좋아요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Result Builders](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/advancedoperators/#Result-Builders)
+- [The Swift Programming Language — resultBuilder](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#resultBuilder)
+- [Swift Evolution SE-0289 — Result Builders](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0289-result-builders.md)
+- [Apple Developer — ViewBuilder](https://developer.apple.com/documentation/swiftui/viewbuilder)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "rspress build",
     "dev": "rspress dev",
+    "docs:check-combine-operators": "node scripts/check-combine-operator-coverage.mjs",
     "docs:check-collection-views": "node scripts/check-collection-view-coverage.mjs",
     "format": "prettier --write .",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "rspress dev",
     "docs:check-combine-operators": "node scripts/check-combine-operator-coverage.mjs",
     "docs:check-collection-views": "node scripts/check-collection-view-coverage.mjs",
+    "docs:check-rxswift-operators": "node scripts/check-rxswift-operator-coverage.mjs",
     "format": "prettier --write .",
     "lint": "eslint .",
     "preview": "rspress preview"

--- a/scripts/check-combine-operator-coverage.mjs
+++ b/scripts/check-combine-operator-coverage.mjs
@@ -1,0 +1,98 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const docsDirectory = path.resolve('docs/guide/combine');
+
+// Apple Publisher DocC의 연산자 이름과 ConnectablePublisher.autoconnect()을
+// 이름 단위로 관리해 오버로드를 한 항목에서 함께 설명할 수 있게 해요.
+const expectedOperators = [
+  'allSatisfy',
+  'append',
+  'assertNoFailure',
+  'assign',
+  'autoconnect',
+  'breakpoint',
+  'breakpointOnError',
+  'buffer',
+  'catch',
+  'collect',
+  'combineLatest',
+  'compactMap',
+  'contains',
+  'count',
+  'debounce',
+  'decode',
+  'delay',
+  'drop',
+  'dropFirst',
+  'encode',
+  'eraseToAnyPublisher',
+  'filter',
+  'first',
+  'flatMap',
+  'handleEvents',
+  'ignoreOutput',
+  'last',
+  'makeConnectable',
+  'map',
+  'mapError',
+  'max',
+  'measureInterval',
+  'merge',
+  'min',
+  'multicast',
+  'output',
+  'prefix',
+  'prepend',
+  'print',
+  'receive',
+  'reduce',
+  'removeDuplicates',
+  'replaceEmpty',
+  'replaceError',
+  'replaceNil',
+  'retry',
+  'scan',
+  'setFailureType',
+  'share',
+  'sink',
+  'subscribe',
+  'switchToLatest',
+  'throttle',
+  'timeout',
+  'tryAllSatisfy',
+  'tryCatch',
+  'tryCompactMap',
+  'tryContains',
+  'tryDrop',
+  'tryFilter',
+  'tryFirst',
+  'tryLast',
+  'tryMap',
+  'tryMax',
+  'tryMin',
+  'tryPrefix',
+  'tryReduce',
+  'tryRemoveDuplicates',
+  'tryScan',
+  'zip',
+];
+
+const files = (await readdir(docsDirectory))
+  .filter((name) => name.endsWith('.md'))
+  .map((name) => path.join(docsDirectory, name));
+
+const contents = await Promise.all(files.map((file) => readFile(file, 'utf8')));
+const combined = contents.join('\n');
+const missing = expectedOperators.filter(
+  (name) => !combined.includes(`<!-- combine-operator: ${name} -->`),
+);
+
+if (missing.length > 0) {
+  console.error(`설명하지 않은 Combine 연산자: ${missing.join(', ')}`);
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Combine 연산자 ${expectedOperators.length}개의 설명 표식을 모두 확인했습니다.`,
+  );
+}

--- a/scripts/check-rxswift-operator-coverage.mjs
+++ b/scripts/check-rxswift-operator-coverage.mjs
@@ -1,0 +1,117 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const docsDirectory = path.resolve('docs/guide/rxswift');
+
+// RxSwift 6.10.2 공개 심볼에서 ObservableType, ConnectableObservableType,
+// 비동기 브리지와 PrimitiveSequence 전용 이름을 추출한 목록이에요.
+const expectedOperators = [
+  'amb',
+  'andThen',
+  'asCompletable',
+  'asInfallible',
+  'asMaybe',
+  'asObservable',
+  'asSingle',
+  'buffer',
+  'catch',
+  'catchAndReturn',
+  'catchError',
+  'catchErrorJustReturn',
+  'combineLatest',
+  'compactMap',
+  'concat',
+  'concatMap',
+  'connect',
+  'create',
+  'debounce',
+  'debug',
+  'decode',
+  'deferred',
+  'delay',
+  'delaySubscription',
+  'dematerialize',
+  'distinctUntilChanged',
+  'do',
+  'element',
+  'elementAt',
+  'empty',
+  'enumerated',
+  'error',
+  'filter',
+  'first',
+  'flatMap',
+  'flatMapCompletable',
+  'flatMapFirst',
+  'flatMapLatest',
+  'flatMapMaybe',
+  'from',
+  'generate',
+  'groupBy',
+  'ifEmpty',
+  'ignoreElements',
+  'interval',
+  'just',
+  'map',
+  'materialize',
+  'merge',
+  'multicast',
+  'never',
+  'observe',
+  'observeOn',
+  'of',
+  'publish',
+  'range',
+  'reduce',
+  'refCount',
+  'repeatElement',
+  'replay',
+  'replayAll',
+  'retry',
+  'retryWhen',
+  'sample',
+  'scan',
+  'share',
+  'single',
+  'skip',
+  'skipUntil',
+  'skipWhile',
+  'startWith',
+  'subscribe',
+  'subscribeOn',
+  'switchLatest',
+  'take',
+  'takeLast',
+  'takeUntil',
+  'takeWhile',
+  'throttle',
+  'timeout',
+  'timer',
+  'toArray',
+  'using',
+  'value',
+  'values',
+  'window',
+  'withLatestFrom',
+  'withUnretained',
+  'zip',
+];
+
+const files = (await readdir(docsDirectory))
+  .filter((name) => name.endsWith('.md'))
+  .map((name) => path.join(docsDirectory, name));
+
+const contents = await Promise.all(files.map((file) => readFile(file, 'utf8')));
+const combined = contents.join('\n');
+const missing = expectedOperators.filter(
+  (name) => !combined.includes(`<!-- rxswift-operator: ${name} -->`),
+);
+
+if (missing.length > 0) {
+  console.error(`설명하지 않은 RxSwift 연산자: ${missing.join(', ')}`);
+  process.exitCode = 1;
+} else {
+  console.log(
+    `RxSwift 공개 연산자 ${expectedOperators.length}개의 설명 표식을 모두 확인했습니다.`,
+  );
+}


### PR DESCRIPTION
## Summary

Swift Result Builder를 중심으로 매크로와 Property Wrapper까지 단계적으로 학습할 수 있는 Swift 언어 기능 문서를 추가합니다.

Combine과 RxSwift는 입문 개요와 공개 연산자를 역할별 문서로 나누고, 설명 누락을 자동으로 검사하는 검증 스크립트와 함께 추가합니다.

## Changes

- Result Builder의 변환 과정, 필수 메서드, 조건문·반복문 처리와 DSL 설계 기준을 예제로 설명했습니다.
- Swift 매크로의 역할별 종류, 선언과 구현 구조, 진단·테스트 방법 및 적용 기준을 정리했습니다.
- Property Wrapper의 `wrappedValue`, `projectedValue`, 초기화 규칙과 저장 구조를 단계별 예제로 설명했습니다.
- Combine 개요와 생성·변환·필터링·결합·시간·오류·생명주기 관련 연산자 70개를 역할별 문서로 구성했습니다.
- RxSwift 6.10.2의 Observable, Subjects, Traits, 공유, 스케줄러, 오류 처리와 폐기 API를 설명하고 공개 연산자 이름 89개를 역할별 문서로 구성했습니다.
- Swift, Combine, RxSwift 문서를 Rspress 내비게이션과 사이드바에 연결했습니다.
- `docs:check-combine-operators`와 `docs:check-rxswift-operators` 명령을 추가해 연산자 설명 누락을 검사하도록 했습니다.

## Testing

- `npm run format`
- `npm run lint`
- `npm run build`
- `npm run docs:check-combine-operators`
- `npm run docs:check-rxswift-operators`
- Swift 6.3으로 Property Wrapper 대표 예제를 컴파일하고 실행했습니다.
- RxSwift 6.10.2 모듈로 대표 연산자와 Trait 예제를 타입 검사했습니다.
- RxSwift 문서의 frontmatter, 내부 링크와 연산자 표식 중복을 검사했습니다.
- `git diff --check`

## Related Issues

Closes #17

## Notes

- 빌드 산출물은 커밋하지 않았습니다.
