### PR TITLE
[#23] SwiftUI와 UIKit 통합 학습 문서 섹션을 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -6,6 +6,12 @@
     "position": "left"
   },
   {
+    "text": "SwiftUI",
+    "link": "/guide/swiftui/uikit-integration/index",
+    "activeMatch": "/guide/swiftui/",
+    "position": "left"
+  },
+  {
     "text": "UIKit",
     "link": "/guide/uikit/collection-views/index",
     "activeMatch": "/guide/uikit/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "swiftui",
+    "label": "SwiftUI"
+  },
+  {
+    "type": "dir-section-header",
     "name": "uikit",
     "label": "UIKit"
   },

--- a/docs/guide/swiftui/_meta.json
+++ b/docs/guide/swiftui/_meta.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "dir",
+    "name": "uikit-integration",
+    "label": "UIKit 통합",
+    "collapsible": true,
+    "collapsed": false
+  }
+]

--- a/docs/guide/swiftui/uikit-integration/_meta.json
+++ b/docs/guide/swiftui/uikit-integration/_meta.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "custom-link",
+    "label": "한눈에 보기",
+    "link": "/guide/swiftui/uikit-integration/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "UIKit에 SwiftUI 넣기",
+    "link": "/guide/swiftui/uikit-integration/swiftui-in-uikit"
+  },
+  {
+    "type": "custom-link",
+    "label": "SwiftUI에 UIKit 넣기",
+    "link": "/guide/swiftui/uikit-integration/uikit-in-swiftui"
+  },
+  {
+    "type": "custom-link",
+    "label": "상태·레이아웃·생명주기",
+    "link": "/guide/swiftui/uikit-integration/data-layout-lifecycle"
+  },
+  {
+    "type": "custom-link",
+    "label": "제스처·환경·애니메이션",
+    "link": "/guide/swiftui/uikit-integration/gestures-environment-animation"
+  }
+]

--- a/docs/guide/swiftui/uikit-integration/data-layout-lifecycle.md
+++ b/docs/guide/swiftui/uikit-integration/data-layout-lifecycle.md
@@ -1,0 +1,372 @@
+---
+title: 통합 화면의 상태·레이아웃·생명주기
+description: SwiftUI와 UIKit 통합 경계에서 단일 데이터 원천을 유지하고 반복 update, 피드백 루프, 크기 충돌, containment와 메모리 누수를 예방하는 기준을 설명합니다.
+---
+
+# 통합 화면의 상태·레이아웃·생명주기
+
+> **면접 답변 한 줄 요약:** SwiftUI와 UIKit 통합 경계에서는 상태 원본과 레이아웃 소유자를 하나씩 정하고, `make`는 생성, `update`는 반복 가능한 동기화, `dismantle`은 외부 연결 정리에만 사용해야 갱신 루프와 생명주기 오류를 피할 수 있어요.
+
+`UIHostingController`나 Representable로 화면을 표시하는 것까지는 어렵지 않아요. 실전 문제는 그다음에 생겨요.
+
+- UIKit과 SwiftUI 중 어느 값이 최신인지 알 수 없어요.
+- `updateUIView`가 예상보다 자주 호출돼 네트워크 요청이 반복돼요.
+- slider나 text field 이벤트가 다시 update를 불러 피드백 루프가 생겨요.
+- SwiftUI와 UIKit이 모두 `frame`을 바꾸면서 레이아웃이 흔들려요.
+- 화면을 닫았는데 hosting controller나 Coordinator가 해제되지 않아요.
+
+이 문서는 API 사용법보다 **경계의 책임을 설계하고 점검하는 방법**에 집중해요.
+
+## 먼저 알아둘 상태와 생명주기 용어
+
+| 용어             | 쉬운 뜻                                                                                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 상태(state)      | 현재 화면 결과를 결정하는 값이에요. 독서 완료 시간, 선택한 색, 로딩 여부가 예예요.                                                         |
+| 단일 데이터 원천 | 같은 의미의 값을 한 곳에서만 원본으로 저장하고 다른 화면은 읽거나 변경 요청만 보내는 원칙이에요.                                           |
+| 입력(input)      | 바깥 프레임워크에서 통합 경계 안으로 들어오는 값이에요. `Binding`, 관찰 모델, environment가 예예요.                                        |
+| 출력(output)     | UIKit 사용자 이벤트가 SwiftUI로 나가는 통로예요. Coordinator가 호출하는 binding 쓰기나 클로저가 예예요.                                    |
+| 피드백 루프      | 입력을 UIKit에 반영한 일이 새 출력 이벤트를 만들고, 그 출력이 다시 같은 입력 갱신을 끝없이 일으키는 흐름이에요.                            |
+| identity         | SwiftUI가 이전 요소와 새 요소를 같은 화면 요소로 볼지 판단하는 정체성이에요. 정체성이 바뀌면 기존 UIKit 객체를 버리고 새로 만들 수 있어요. |
+| layout proposal  | 부모가 자식에게 “이 범위 안에서 크기를 정해 보세요”라고 제안하는 값이에요. SwiftUI와 UIKit은 브리지에서 이 제안과 선호 크기를 주고받아요.  |
+| 생명주기 메서드  | Representable의 `make`는 UIKit 객체 생성, `update`는 최신 상태 반영, `dismantle`은 외부 연결 정리를 맡아요.                                |
+| retain cycle     | 객체들이 서로를 강하게 참조해 화면에서 제거된 뒤에도 메모리에서 해제되지 않는 소유 관계예요.                                               |
+| MainActor        | UI 상태와 화면 변경을 메인 실행 영역에 격리하는 Swift 동시성 규칙이에요. UIKit과 SwiftUI 화면 작업은 메인 actor에서 수행해야 해요.         |
+
+## 같은 상태를 양쪽에 복사하면 기준이 두 개가 돼요
+
+UIKit 화면이 `completedMinutes`를 저장하고 SwiftUI 카드도 별도 `@State`에 같은 값을 저장한다고 가정할게요.
+
+```swift
+final class ReadingViewController: UIViewController {
+  var completedMinutes = 20
+}
+
+struct ReadingProgressView: View {
+  @State private var completedMinutes = 20
+
+  var body: some View {
+    Text("\(completedMinutes)분")
+  }
+}
+```
+
+처음에는 값이 같아요. 하지만 UIKit 버튼이 한쪽 값만 바꾸거나 SwiftUI가 자체 상태를 변경하면 두 화면이 다른 값을 표시해요. 동기화 코드를 더 추가할수록 “어느 변경이 원본인가요?”라는 문제가 커져요.
+
+원본을 하나로 모으세요.
+
+```swift
+import Combine
+
+@MainActor
+final class ReadingGoalStore: ObservableObject {
+  @Published var completedMinutes = 20
+  @Published var targetMinutes = 30
+
+  func addSession(minutes: Int) {
+    completedMinutes += minutes
+  }
+}
+```
+
+UIKit과 SwiftUI는 같은 인스턴스를 전달받아요.
+
+```text
+UIKit 버튼 ── 변경 요청 ──> ReadingGoalStore <── 관찰 ── SwiftUI View
+UIKit 라벨 <──── 읽기 ───── ReadingGoalStore ─── 알림 ──> SwiftUI 갱신
+```
+
+`ReadingGoalStore`는 UIKit이나 SwiftUI 화면을 소유하지 않아요. 도메인 상태와 변경 동작만 제공해 두 화면 기술이 같은 값을 사용할 수 있게 해요.
+
+## 경계를 지나는 네 가지 흐름을 구분해요
+
+| 흐름                        | 권장 통로                                  | 예시                                                       |
+| --------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| UIKit 상태 → SwiftUI 표시   | 공유 관찰 모델 또는 새 `rootView` 입력     | UIKit이 독서 시간을 바꾸면 SwiftUI 진행률 카드가 갱신돼요. |
+| SwiftUI 이벤트 → UIKit 동작 | 명시적인 클로저                            | SwiftUI 버튼이 UIKit 편집 화면 present를 요청해요.         |
+| SwiftUI 상태 → UIKit 표시   | Representable의 프로퍼티와 `update`        | `@State` 목표 시간이 `UISlider.value`에 반영돼요.          |
+| UIKit 이벤트 → SwiftUI 상태 | Coordinator → `Binding` 또는 이벤트 클로저 | slider의 `.valueChanged`가 SwiftUI의 목표 시간을 바꿔요.   |
+
+한 경계에서 입력과 출력을 이름으로 구분하면 순환 흐름을 찾기 쉬워요. 예를 들어 `value`와 `onValueChanged`처럼 읽는 값과 발생한 사건을 따로 표현하세요.
+
+## `make`, `update`, `dismantle`의 책임을 섞지 않아요
+
+Representable의 생명주기를 다음처럼 생각할 수 있어요.
+
+| 단계        | 해야 할 일                                               | 피해야 할 일                                              |
+| ----------- | -------------------------------------------------------- | --------------------------------------------------------- |
+| `make`      | UIKit 객체 생성, 고정 설정, target·delegate 연결         | 현재 입력이 영원히 유지된다고 가정하기                    |
+| `update`    | 최신 입력과 environment를 기존 객체에 반영               | 네트워크 요청 시작, observer 중복 등록, 자식 뷰 계속 추가 |
+| `dismantle` | delegate·observer 해제, 타이머·Task 취소, 외부 자원 정리 | 앱의 원본 도메인 상태 삭제                                |
+
+`update`는 렌더링 callback처럼 생각하세요. 호출 횟수는 앱 로직의 사건 횟수와 같지 않아요. 부모가 다시 계산되거나 environment가 바뀌어도 호출될 수 있어요.
+
+### 비동기 작업을 `update`에서 바로 시작하지 않아요
+
+다음 코드는 update 횟수만큼 이미지 요청을 시작할 수 있어요.
+
+```swift
+func updateUIView(_ imageView: UIImageView, context: Context) {
+  Task {
+    imageView.image = await imageLoader.load(url)
+  }
+}
+```
+
+이미지 로딩은 화면 모델이나 별도 로더가 URL identity와 취소를 관리하게 하고, update는 준비된 결과를 반영하는 편이 안전해요. 어댑터 안에서 작업해야 한다면 Coordinator가 현재 요청의 identity와 `Task`를 보관하고, URL이 실제로 바뀔 때만 이전 작업을 취소한 뒤 시작하세요.
+
+```swift
+final class Coordinator {
+  var loadingURL: URL?
+  var task: Task<Void, Never>?
+
+  func cancel() {
+    task?.cancel()
+    task = nil
+    loadingURL = nil
+  }
+
+  deinit {
+    task?.cancel()
+  }
+}
+```
+
+그리고 `dismantleUIView`에서 명시적으로 취소해요.
+
+```swift
+static func dismantleUIView(
+  _ imageView: UIImageView,
+  coordinator: Coordinator
+) {
+  coordinator.cancel()
+}
+```
+
+## 입력 반영과 사용자 이벤트를 구분해 피드백 루프를 막아요
+
+text field를 예로 들어 볼게요.
+
+1. SwiftUI의 `text`가 바뀌어 `updateUIView`가 호출돼요.
+2. update가 `textField.text`를 설정해요.
+3. UIKit이 편집 이벤트를 알리고 Coordinator가 같은 값을 binding에 기록해요.
+4. SwiftUI 상태가 다시 바뀌었다고 판단하면 update가 반복돼요.
+
+가장 기본적인 방어는 실제 차이가 있을 때만 속성을 바꾸는 거예요.
+
+```swift
+func updateUIView(_ textField: UITextField, context: Context) {
+  context.coordinator.text = $text
+
+  guard textField.text != text else {
+    return
+  }
+
+  textField.text = text
+}
+```
+
+복잡한 컨트롤에서는 입력 반영 중인지 나타내는 플래그가 필요할 수도 있어요. 하지만 먼저 다음 순서로 단순화하세요.
+
+1. 같은 값 쓰기를 건너뛰어요.
+2. 프로그램 변경과 사용자 사건을 구분할 수 있는 UIKit API를 사용해요.
+3. 이벤트를 연속 값과 완료 값으로 나눌 필요가 있는지 확인해요.
+4. 마지막 수단으로 Coordinator에 재진입 방지 상태를 둬요.
+
+모든 callback을 막는 플래그는 실제 사용자 이벤트까지 잃게 할 수 있어요. 어떤 사건을 차단하는지 좁게 정의하세요.
+
+## SwiftUI identity가 바뀌면 UIKit 객체도 새로 만들어질 수 있어요
+
+Representable 값이 다시 만들어졌다고 해서 `makeUIView`가 매번 호출되는 것은 아니에요. SwiftUI가 같은 identity라고 판단하면 기존 UIKit 객체를 유지하고 `updateUIView`를 호출해요.
+
+반대로 `.id(...)` 값이 바뀌거나 조건 분기에서 다른 뷰로 교체되면 기존 객체를 정리하고 새 객체를 만들 수 있어요.
+
+```swift
+MinutesSlider(minutes: $targetMinutes)
+  .id(selectedGoalID)
+```
+
+이 코드는 `selectedGoalID`가 바뀔 때 slider identity도 바꿔요. 목표가 바뀔 때 UIKit 내부 상태까지 초기화하려는 의도라면 맞지만, 단지 update를 강제로 호출하려고 `.id`를 계속 바꾸면 focus, 스크롤 위치, delegate 상태를 불필요하게 잃어요.
+
+### 생성 횟수에 의존하는 로직을 넣지 않아요
+
+- `make`가 정확히 한 번 실행된다고 가정하지 마세요.
+- `update`가 특정 횟수만 실행된다고 가정하지 마세요.
+- 사용자 입력처럼 비즈니스 의미가 있는 사건은 Coordinator나 모델의 명시적인 메서드로 다루세요.
+- 객체 재생성이 기능을 깨뜨리지 않도록 외부 자원을 정리하세요.
+
+## 레이아웃 소유자는 바깥 프레임워크예요
+
+통합 방향에 따라 크기를 주도하는 쪽이 달라요.
+
+| 바깥 화면     | 크기를 주도하는 방식                                                                                 | 안쪽 구현이 할 일                                                     |
+| ------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| UIKit         | `UIHostingController.view`에 Auto Layout 제약을 주거나 컨테이너가 `preferredContentSize`를 사용해요. | SwiftUI root view는 제안된 공간에서 layout을 구성해요.                |
+| SwiftUI       | SwiftUI layout이 Representable에 크기를 제안하고 최종 frame을 정해요.                                | UIKit 객체는 intrinsic size 또는 `sizeThatFits`로 선호 크기를 알려요. |
+| UIKit 목록 셀 | 셀의 self-sizing과 content configuration이 크기를 계산해요.                                          | `UIHostingConfiguration` 내용과 margins를 선언해요.                   |
+
+Representable이 관리하는 UIKit 뷰의 아래 프로퍼티는 SwiftUI가 제어해요.
+
+- `center`
+- `bounds`
+- `frame`
+- `transform`
+
+Apple의 `UIViewRepresentable`과 `UIViewControllerRepresentable` 문서는 이 값을 직접 설정하면 SwiftUI 레이아웃과 충돌해 정의되지 않은 동작이 생길 수 있다고 경고해요. 안쪽 UIKit 뷰의 서브뷰 제약은 UIKit 코드로 관리할 수 있지만, 바깥에서 받은 자신의 frame을 다시 정하려고 하면 안 돼요.
+
+## 크기 협상 API는 필요한 곳에만 사용해요
+
+| API                                          | 도입 버전 | 역할                                                                      |
+| -------------------------------------------- | --------- | ------------------------------------------------------------------------- |
+| `UIViewRepresentable.sizeThatFits`           | iOS 16    | SwiftUI의 제안을 보고 UIKit 뷰가 선호하는 크기를 반환해요.                |
+| `UIViewControllerRepresentable.sizeThatFits` | iOS 16    | UIKit 뷰 컨트롤러 내용의 선호 크기를 SwiftUI에 알려요.                    |
+| `UIHostingController.sizeThatFits(in:)`      | iOS 16    | 주어진 최대 크기 안에서 SwiftUI 콘텐츠의 적절한 크기를 계산해요.          |
+| `UIHostingController.sizingOptions`          | iOS 16    | 콘텐츠 변화가 intrinsic 또는 preferred content size에 자동 반영되게 해요. |
+
+측정은 비용이 들어요. 전체 화면처럼 부모 제약이 너비와 높이를 모두 정한다면 이상적인 크기를 반복해서 계산할 이유가 없어요. popover, self-sizing cell, 내용에 따라 높이가 달라지는 작은 container처럼 실제로 선호 크기가 필요한 곳에만 사용하세요.
+
+## Environment와 trait을 중복 변환하지 않아요
+
+Representable의 `context.environment`에는 SwiftUI 환경 값이 들어 있어요. UIKit 객체에 대응 값이 없다면 update에서 명시적으로 변환할 수 있어요.
+
+```swift
+func updateUIView(_ label: UILabel, context: Context) {
+  label.textColor =
+    context.environment.colorScheme == .dark
+      ? .white
+      : .black
+}
+```
+
+하지만 `UIColor.label`처럼 UIKit이 자체 trait으로 이미 처리하는 시스템 값은 그 기능을 그대로 쓰는 편이 좋아요.
+
+```swift
+func makeUIView(context: Context) -> UILabel {
+  let label = UILabel()
+  label.textColor = .label
+  return label
+}
+```
+
+같은 시스템 설정을 SwiftUI environment와 UIKit trait에서 각각 읽어 수동 변환하면 두 경로가 어긋날 수 있어요. 사용자 정의 계층 값은 iOS 17 이상의 `UITraitBridgedEnvironmentKey`를 검토하고, 단순한 직접 입력은 프로퍼티로 전달하세요.
+
+## 소유 관계를 그려 순환 참조를 찾아요
+
+UIKit에 SwiftUI를 넣을 때 자주 생기는 순환은 다음과 같아요.
+
+```text
+ReadingViewController
+└─ 강한 참조 → UIHostingController
+   └─ 강한 참조 → SwiftUI root view
+      └─ 강한 클로저 캡처 → ReadingViewController
+```
+
+root view의 이벤트 클로저는 화면으로 돌아가는 역참조예요. 이 경우 `[weak self]`로 순환을 끊을 수 있어요.
+
+```swift
+hostingController.rootView = ReadingProgressView(
+  store: store,
+  onEdit: { [weak self] in
+    self?.presentGoalEditor()
+  }
+)
+```
+
+Representable 방향에서도 다음을 점검하세요.
+
+- UIKit delegate 프로퍼티가 `weak`인지 확인해요.
+- NotificationCenter의 selector observer와 closure observer를 등록한 위치에서 해제해요.
+- `CADisplayLink`, `Timer`, KVO token, 비동기 `Task`를 Coordinator가 소유한다면 dismantle에서 정리해요.
+- Coordinator가 상위 화면을 꼭 참조해야 한다면 소유 관계를 확인하고 약한 참조나 이벤트 클로저를 사용해요.
+
+`weak`를 무조건 붙이는 것이 정답은 아니에요. 작업이 살아 있는 동안 반드시 유지해야 하는 모델까지 약하게 만들면 중간에 사라질 수 있어요. 화면으로 돌아가는 역참조인지, 어댑터가 실제로 소유해야 하는 자원인지 먼저 구분하세요.
+
+## UI 변경은 메인 actor에서 수행해요
+
+UIKit과 SwiftUI의 화면 객체는 메인 actor에 격리돼요. 네트워크나 디코딩은 백그라운드에서 할 수 있지만 결과를 모델과 UI에 반영하는 코드는 메인 actor로 돌아와야 해요.
+
+```swift
+Task {
+  let minutes = await repository.fetchCompletedMinutes()
+
+  await MainActor.run {
+    store.completedMinutes = minutes
+  }
+}
+```
+
+`UIViewRepresentable`과 `UIHostingController`의 주요 API도 공식 선언에서 `MainActor`로 표시돼요. 동시성 경고를 억지로 피하기보다 데이터 작업과 화면 반영의 실행 영역을 분리하세요.
+
+## 증상으로 경계 문제를 찾아요
+
+| 증상                                      | 먼저 확인할 원인                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------- |
+| 값이 잠깐 바뀌었다가 되돌아와요.          | UIKit과 SwiftUI가 같은 상태를 따로 저장하는지 확인해요.                   |
+| `makeUIView`가 계속 다시 호출돼요.        | `.id`나 조건 분기로 identity가 계속 바뀌는지 확인해요.                    |
+| `updateUIView`마다 요청이 여러 번 나가요. | update에 네트워크, observer 등록, Task 생성을 넣었는지 확인해요.          |
+| 입력 한 번에 callback이 여러 번 와요.     | 같은 값 설정과 target·delegate 중복 등록을 확인해요.                      |
+| 크기가 흔들리거나 제약 경고가 떠요.       | 양쪽이 frame을 정하는지, sizing 옵션과 고정 제약이 충돌하는지 확인해요.   |
+| 화면을 닫아도 `deinit`이 호출되지 않아요. | root view 클로저, Coordinator, observer와 Task의 강한 참조를 그려 보세요. |
+| 회전이나 appearance callback이 빠져요.    | 자식 `UIHostingController` containment 절차를 지켰는지 확인해요.          |
+
+## 테스트는 어댑터 로직과 실제 연결을 나눠요
+
+Representable 자체는 SwiftUI가 생명주기를 호출하므로 순수 단위 테스트만으로 모든 동작을 확인하기 어려워요. 다음 세 층으로 나누면 좋아요.
+
+1. **상태 모델 단위 테스트:** `ReadingGoalStore`의 변경 규칙을 화면 없이 검증해요.
+2. **변환 로직 단위 테스트:** slider 값 반올림이나 UIKit 모델 변환을 순수 함수로 분리해 검증해요.
+3. **통합·UI 테스트:** 실제 hosting/representable 화면에서 입력, 회전, dismiss, 접근성 동작을 확인해요.
+
+예를 들어 분 단위 반올림은 어댑터 안에 숨기지 않고 함수로 분리할 수 있어요.
+
+```swift
+func roundedMinutes(from sliderValue: Float) -> Int {
+  Int(sliderValue.rounded())
+}
+```
+
+```swift
+import Testing
+
+@Test
+func roundsSliderValueToMinutes() {
+  #expect(roundedMinutes(from: 29.6) == 30)
+}
+```
+
+어댑터는 이 함수를 호출하고, 단위 테스트는 SwiftUI 렌더링 없이 규칙을 빠르게 검증해요.
+
+## 적용 순서를 정리해요
+
+1. 통합 경계를 지나는 입력과 출력을 각각 적으세요.
+2. 같은 의미의 상태를 하나의 모델, `State`, 상위 UIKit 중 한 곳에만 저장하세요.
+3. `make`, `update`, `dismantle`에 들어갈 일을 표로 나누세요.
+4. update에서 같은 값 쓰기, 비동기 작업 시작, observer 중복 등록을 제거하세요.
+5. 바깥 프레임워크가 자신의 frame을 정하고 안쪽은 선호 크기만 알리게 하세요.
+6. 강한 참조를 그림으로 그리고 화면 제거 후 `deinit`과 작업 취소를 확인하세요.
+7. 모델 단위 테스트와 실제 통합 화면 테스트를 나눠 실행하세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 통합 화면에서 단일 데이터 원천이 중요한 이유는 무엇인가요?
+
+UIKit과 SwiftUI가 같은 의미의 값을 각각 저장하면 갱신 순서에 따라 화면이 달라질 수 있기 때문이에요. 한쪽 모델이나 상위 상태를 원본으로 두고 다른 쪽은 입력을 반영하거나 변경 사건만 보내야 예측 가능한 단방향 흐름을 만들 수 있어요.
+
+### `updateUIView`에서 네트워크 요청을 시작하면 안 되는 이유는 무엇인가요?
+
+update는 비즈니스 사건이 아니라 렌더링 조건 변화에 따라 여러 번 호출될 수 있기 때문이에요. 요청이 중복되거나 순서가 뒤집힐 수 있으므로 모델이나 identity와 취소를 관리하는 별도 로더에서 작업을 시작하고 update는 결과 반영에 집중하는 편이 안전해요.
+
+### Representable의 UIKit 뷰 frame을 직접 바꾸면 왜 안 되나요?
+
+바깥 SwiftUI layout이 representable의 최종 frame을 소유하기 때문이에요. UIKit 객체가 같은 frame을 다시 바꾸면 두 레이아웃 시스템이 충돌하므로 intrinsic content size나 `sizeThatFits`로 선호 크기만 알려야 해요.
+
+### 화면이 해제되지 않을 때 무엇부터 확인하나요?
+
+hosting controller의 root view 클로저가 부모 UIKit 컨트롤러를 강하게 캡처하는지, Coordinator가 observer·timer·Task를 유지하는지부터 확인해요. 소유 그래프를 그린 뒤 역참조는 약하게 만들고, 어댑터가 만든 외부 연결은 dismantle에서 정리해요.
+
+## 참고 자료
+
+- [UIViewRepresentable](https://developer.apple.com/documentation/swiftui/uiviewrepresentable)
+- [UIViewControllerRepresentable](https://developer.apple.com/documentation/swiftui/uiviewcontrollerrepresentable)
+- [UIViewRepresentableContext](https://developer.apple.com/documentation/swiftui/uiviewrepresentablecontext)
+- [UIHostingControllerSizingOptions](https://developer.apple.com/documentation/swiftui/uihostingcontrollersizingoptions)
+- [Managing user interface state](https://developer.apple.com/documentation/swiftui/managing-user-interface-state)

--- a/docs/guide/swiftui/uikit-integration/gestures-environment-animation.md
+++ b/docs/guide/swiftui/uikit-integration/gestures-environment-animation.md
@@ -1,0 +1,379 @@
+---
+title: UIKit 통합의 제스처·환경·애니메이션
+description: iOS 18의 UIGestureRecognizerRepresentable과 통합 애니메이션, iOS 17의 UIKit trait–SwiftUI environment 브리지를 지원 버전과 대안까지 설명합니다.
+---
+
+# UIKit 통합의 제스처·환경·애니메이션
+
+> **면접 답변 한 줄 요약:** 최신 SwiftUI–UIKit 통합 API는 UIKit 제스처를 SwiftUI에 직접 붙이고, 사용자 정의 trait과 environment를 같은 계층 값으로 공유하며, 하나의 SwiftUI `Animation`으로 양쪽 화면의 타이밍을 맞추되 지원 OS와 더 단순한 대안을 먼저 확인해야 해요.
+
+기본 통합은 `UIHostingController`와 Representable만으로 충분한 경우가 많아요. 하지만 기존 UIKit 제스처 인식기의 세부 기능을 유지하거나, UIKit과 SwiftUI 하위 계층 전체에 앱 테마를 전달하거나, 두 프레임워크의 애니메이션 감각을 맞춰야 할 수 있어요.
+
+Apple의 [UIKit integration](https://developer.apple.com/documentation/swiftui/uikit-integration) 공식 목차는 이런 문제를 위한 최신 API도 함께 제공해요.
+
+| 기능                                 | iOS 도입 버전 | 해결하는 문제                                                                  |
+| ------------------------------------ | ------------- | ------------------------------------------------------------------------------ |
+| `UITraitBridgedEnvironmentKey`       | iOS 17        | UIKit 사용자 정의 trait과 SwiftUI environment가 같은 계층 값을 읽고 쓰게 해요. |
+| `UIGestureRecognizerRepresentable`   | iOS 18        | UIKit gesture recognizer를 SwiftUI 뷰에 직접 붙이고 좌표를 변환해요.           |
+| SwiftUI `Animation`을 받는 UIKit API | iOS 18        | SwiftUI와 UIKit 애니메이션의 타이밍과 spring 특성을 같은 값으로 표현해요.      |
+| `UIHostingSceneDelegate`             | iOS 26        | UIKit scene delegate 생명주기에서 SwiftUI scene을 연결해요.                    |
+| `UIHostingOrnament`, `UIOrnament`    | visionOS 1.0  | UIKit이 소유한 visionOS 인터페이스에 SwiftUI ornament를 호스팅해요.            |
+
+새 API라는 이유만으로 사용할 필요는 없어요. 직접 프로퍼티 하나를 전달하면 되는 화면에 사용자 정의 trait을 만들거나, SwiftUI `LongPressGesture`로 충분한데 UIKit recognizer를 넣으면 경계만 복잡해져요.
+
+## 먼저 알아둘 제스처와 환경 용어
+
+| 용어                  | 쉬운 뜻                                                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| gesture recognizer    | 탭, 길게 누르기, pan처럼 연속된 터치 입력을 하나의 제스처 상태로 해석하는 UIKit 객체예요.                                                   |
+| coordinate space      | 점의 위치를 어느 뷰나 화면을 기준으로 표현하는지 정하는 좌표계예요. 같은 손가락 위치도 전역 화면과 로컬 뷰에서는 다른 숫자가 돼요.          |
+| SwiftUI environment   | 상위 SwiftUI 뷰가 하위 계층에 내려보내는 구성 값 저장소예요. 하위 뷰는 `@Environment`로 필요한 값을 읽어요.                                 |
+| UIKit trait           | 화면 크기, 색상 모드, 접근성 설정, 사용자 정의 값처럼 UIKit 뷰와 뷰 컨트롤러 계층으로 전파되는 구성 정보예요.                               |
+| environment key       | SwiftUI environment에서 특정 값과 기본값을 식별하는 타입이에요.                                                                             |
+| `UITraitDefinition`   | UIKit 사용자 정의 trait의 값 타입과 기본값을 정의하는 프로토콜이에요.                                                                       |
+| animation transaction | 한 상태 변경과 함께 적용할 애니메이션 정보를 담는 SwiftUI 갱신 단위예요. Representable의 `Context`에서 현재 transaction을 확인할 수 있어요. |
+| ornament              | visionOS 창에 붙여 배치하는 보조 인터페이스예요. iOS의 toolbar와 비슷해 보일 수 있지만 3차원 창 주변에 배치되는 visionOS 개념이에요.        |
+
+## UIKit 제스처를 SwiftUI 뷰에 직접 붙여요
+
+iOS 18 이상에서는 `UIGestureRecognizerRepresentable`이 UIKit recognizer의 생성, 갱신, action 처리를 SwiftUI에 연결해요. 독서 앱의 책 표지를 길게 누른 위치에 메뉴를 띄운다고 가정할게요.
+
+```swift
+import SwiftUI
+import UIKit
+
+@available(iOS 18.0, *)
+struct BookLongPressRecognizer: UIGestureRecognizerRepresentable {
+  let onBegan: (CGPoint) -> Void
+
+  func makeUIGestureRecognizer(
+    context: Context
+  ) -> UILongPressGestureRecognizer {
+    let recognizer = UILongPressGestureRecognizer()
+    recognizer.minimumPressDuration = 0.4
+    return recognizer
+  }
+
+  func handleUIGestureRecognizerAction(
+    _ recognizer: UILongPressGestureRecognizer,
+    context: Context
+  ) {
+    guard recognizer.state == .began else {
+      return
+    }
+
+    let location = context.converter.location(in: .local)
+    onBegan(location)
+  }
+}
+```
+
+SwiftUI 뷰에는 `gesture(_:)` modifier로 붙여요.
+
+```swift
+@available(iOS 18.0, *)
+struct BookCoverView: View {
+  @State private var menuLocation: CGPoint?
+
+  var body: some View {
+    Image(systemName: "book.closed.fill")
+      .font(.system(size: 80))
+      .gesture(
+        BookLongPressRecognizer { location in
+          menuLocation = location
+        }
+      )
+  }
+}
+```
+
+SwiftUI가 recognizer에 action target을 자동으로 설치하고, 인식될 때 `handleUIGestureRecognizerAction`을 호출해요. 별도 delegate 메시지나 추가 target이 필요하면 `makeCoordinator(converter:)`로 Coordinator를 제공할 수 있어요.
+
+## 좌표는 converter로 SwiftUI 공간에 맞춰요
+
+UIKit recognizer의 `view`가 SwiftUI에서 생각하는 대상 뷰와 같은 기하 구조를 갖는다고 가정하면 안 돼요. Apple은 context의 coordinate space converter를 사용해 전역 위치를 SwiftUI 계층의 좌표로 변환하라고 안내해요.
+
+```swift
+let localPoint = context.converter.location(in: .local)
+let globalPoint = context.converter.location(in: .global)
+```
+
+메뉴를 책 표지 안의 터치 위치에 배치하려면 `.local`, 여러 형제 뷰가 공유하는 overlay에 배치하려면 이름을 붙인 SwiftUI coordinate space를 사용할 수 있어요.
+
+```swift
+let point = context.converter.location(
+  in: .named("reading-dashboard")
+)
+```
+
+좌표를 UIKit `recognizer.location(in:)`로만 읽으면 실제 recognizer가 붙은 내부 뷰를 기준으로 할 수 있어 SwiftUI 뷰의 로컬 좌표와 다를 수 있어요.
+
+## 기본 SwiftUI gesture로 충분한지 먼저 확인해요
+
+| 요구 사항                                                     | 먼저 고려할 선택                                        |
+| ------------------------------------------------------------- | ------------------------------------------------------- |
+| 탭, 드래그, 길게 누르기 같은 일반 상호작용                    | SwiftUI `TapGesture`, `DragGesture`, `LongPressGesture` |
+| 기존 사용자 정의 `UIGestureRecognizer`를 재사용해요.          | `UIGestureRecognizerRepresentable`                      |
+| UIKit delegate, failure dependency, 세부 recognizer 설정 필요 | `UIGestureRecognizerRepresentable`과 Coordinator        |
+| iOS 17 이하도 지원해야 해요.                                  | SwiftUI gesture 또는 작은 UIKit 뷰 어댑터               |
+
+SwiftUI 기본 gesture는 환경과 상태 흐름에 자연스럽게 참여하고 하위 버전도 지원해요. UIKit recognizer만 제공하는 기능이나 기존 구현을 유지해야 할 때 브리지를 선택하세요.
+
+## UIKit trait과 SwiftUI environment를 같은 값으로 연결해요
+
+UIKit trait과 SwiftUI environment는 모두 상위 계층에서 하위 계층으로 구성 값을 전파해요. iOS 17 이상에서는 사용자 정의 environment key가 `UITraitBridgedEnvironmentKey`를 따르게 해서 같은 값을 양쪽 API로 읽고 쓸 수 있어요.
+
+독서 앱의 화면 분위기를 나타내는 테마를 예로 들어 볼게요.
+
+```swift
+import SwiftUI
+import UIKit
+
+enum ReadingTheme: Int {
+  case standard
+  case calm
+  case focus
+}
+
+@available(iOS 17.0, *)
+struct ReadingThemeTrait: UITraitDefinition {
+  static let defaultValue = ReadingTheme.standard
+}
+
+@available(iOS 17.0, *)
+extension UITraitCollection {
+  var readingTheme: ReadingTheme {
+    self[ReadingThemeTrait.self]
+  }
+}
+
+@available(iOS 17.0, *)
+extension UIMutableTraits {
+  var readingTheme: ReadingTheme {
+    get { self[ReadingThemeTrait.self] }
+    set { self[ReadingThemeTrait.self] = newValue }
+  }
+}
+```
+
+여기까지는 UIKit 사용자 정의 trait이에요. SwiftUI environment key를 같은 값 타입으로 만들어요.
+
+```swift
+struct ReadingThemeKey: EnvironmentKey {
+  static let defaultValue = ReadingTheme.standard
+}
+
+extension EnvironmentValues {
+  var readingTheme: ReadingTheme {
+    get { self[ReadingThemeKey.self] }
+    set { self[ReadingThemeKey.self] = newValue }
+  }
+}
+```
+
+마지막으로 읽기와 쓰기 변환을 연결해요.
+
+```swift
+@available(iOS 17.0, *)
+extension ReadingThemeKey: UITraitBridgedEnvironmentKey {
+  static func read(
+    from traitCollection: UITraitCollection
+  ) -> ReadingTheme {
+    traitCollection.readingTheme
+  }
+
+  static func write(
+    to mutableTraits: inout any UIMutableTraits,
+    value: ReadingTheme
+  ) {
+    mutableTraits.readingTheme = value
+  }
+}
+```
+
+`read`는 UIKit trait 값을 SwiftUI environment로 보내고, `write`는 SwiftUI environment 값을 UIKit의 mutable traits에 반영해요. Apple의 [UITraitBridgedEnvironmentKey](https://developer.apple.com/documentation/uikit/uitraitbridgedenvironmentkey)는 이 두 메서드를 요구해요.
+
+## UIKit에서 설정하고 SwiftUI에서 읽어요
+
+UIKit 계층의 상단에 override를 적용해요.
+
+```swift
+@available(iOS 17.0, *)
+func applyFocusTheme(to windowScene: UIWindowScene) {
+  windowScene.traitOverrides.readingTheme = .focus
+}
+```
+
+이 window scene 아래의 UIKit 뷰, `UIHostingController`, `UIHostingConfiguration` 안에 있는 SwiftUI 뷰까지 값이 내려가요.
+
+```swift
+struct ReadingCardView: View {
+  @Environment(\.readingTheme) private var theme
+
+  var body: some View {
+    Text("집중 독서")
+      .foregroundStyle(theme == .focus ? .orange : .primary)
+  }
+}
+```
+
+Apple의 [Unleash the UIKit trait system](https://developer.apple.com/videos/play/wwdc2023/10057/) 세션은 UIKit window scene의 trait override가 `UIHostingConfiguration` 안 SwiftUI 환경까지 전파되고, 값이 바뀌면 SwiftUI가 의존성을 추적해 화면을 갱신하는 예를 보여 줘요.
+
+## SwiftUI에서 설정하고 UIKit에서 읽어요
+
+반대 방향도 같은 키를 사용해요.
+
+```swift
+struct SettingsView: View {
+  var body: some View {
+    SettingsControllerRepresentable()
+      .environment(\.readingTheme, .calm)
+  }
+}
+```
+
+Representable 안의 UIKit 뷰 컨트롤러는 자신의 trait collection에서 값을 읽어요.
+
+```swift
+final class SettingsViewController: UIViewController {
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
+    view.backgroundColor =
+      traitCollection.readingTheme == .calm
+        ? .systemMint
+        : .systemBackground
+  }
+}
+```
+
+trait은 UIKit 계층을 따라 내려오므로 가장 구체적인 뷰나 뷰 컨트롤러의 `traitCollection`을 읽으세요. iOS 17에서는 뷰가 계층에 들어온 뒤 trait이 최신 상태가 되므로 레이아웃 시점에 사용하는 방식이 안전해요.
+
+## 단순한 값에는 직접 전달을 사용해요
+
+사용자 정의 trait과 environment 브리지는 다음 상황에 적합해요.
+
+- 여러 단계 아래의 UIKit과 SwiftUI 구성 요소가 같은 계층형 설정을 읽어요.
+- 창이나 화면 하위 트리 전체에 테마, 표시 밀도, 기능 모드가 전파돼요.
+- UIKit과 SwiftUI 중 어느 쪽이 바깥 컨테이너가 되어도 같은 값 접근 방식을 유지하고 싶어요.
+
+반면 부모와 자식이 직접 연결되어 있고 값 하나만 전달하면 된다면 프로퍼티나 binding이 더 단순해요.
+
+```swift
+struct ReadingCardView: View {
+  let theme: ReadingTheme
+}
+```
+
+Apple도 custom trait은 계층의 많은 자식이나 멀리 떨어진 구성 요소에 값을 전달할 때 사용하고, 직접 전달할 수 있는 값에는 피하라고 안내해요. trait 변경은 하위 계층 갱신 비용도 만들어요.
+
+## 하나의 SwiftUI `Animation`을 UIKit에서도 사용해요
+
+iOS 18 이상에서는 `UIView.animate`에 SwiftUI `Animation`을 전달할 수 있어요.
+
+```swift
+import SwiftUI
+import UIKit
+
+@available(iOS 18.0, *)
+func emphasize(_ cardView: UIView) {
+  let animation = SwiftUI.Animation.spring(duration: 0.45)
+
+  UIView.animate(animation) {
+    cardView.transform = CGAffineTransform(
+      scaleX: 1.04,
+      y: 1.04
+    )
+  }
+}
+```
+
+SwiftUI 쪽에서도 같은 값을 사용할 수 있어요.
+
+```swift
+let readingAnimation = Animation.spring(duration: 0.45)
+
+withAnimation(readingAnimation) {
+  isExpanded.toggle()
+}
+```
+
+두 프레임워크가 서로 다른 duration과 curve를 따로 관리하는 대신 같은 `Animation` 값으로 움직임의 특성을 맞출 수 있어요. Apple의 [Unifying your app’s animations](https://developer.apple.com/documentation/swiftui/unifying-your-app-s-animations) 문서는 SwiftUI, UIKit, AppKit을 섞은 앱에서 timing 불일치를 줄이는 방법으로 이를 소개해요.
+
+## Representable은 현재 transaction의 애니메이션을 적용할 수 있어요
+
+iOS 18 이상에서 `UIViewRepresentableContext`와 `UIViewControllerRepresentableContext`는 `animate(changes:completion:)`을 제공해요. SwiftUI가 현재 transaction에 넣은 애니메이션으로 UIKit 변경을 실행할 수 있어요.
+
+```swift
+@available(iOS 18.0, *)
+func updateUIView(
+  _ progressView: UIProgressView,
+  context: Context
+) {
+  context.animate {
+    progressView.alpha = isEnabled ? 1 : 0.35
+  }
+}
+```
+
+바깥 SwiftUI 상태가 `withAnimation` 안에서 바뀌면 해당 transaction의 애니메이션이 UIKit 변경에도 사용돼요. 애니메이션이 없는 갱신이라면 즉시 적용돼요.
+
+iOS 17 이하에서는 `context.transaction.animation`을 UIKit이 직접 실행할 수 있는 일반 API가 없어요. 하위 버전에서는 `UIView.animate(withDuration:)` 같은 UIKit 애니메이션을 명시적으로 선택하고, 두 구현의 duration과 curve를 설계 값으로 공유하세요.
+
+## 통합 애니메이션의 제한도 확인해요
+
+Apple은 다음 차이를 안내해요.
+
+- SwiftUI 애니메이션은 앱 프로세스의 백그라운드 스레드에서 값을 계산할 수 있어요.
+- SwiftUI 애니메이션에는 대응하는 `CAAnimation` 객체가 없어요.
+- `UIViewPropertyAnimator`나 UIKit keyframe animation과 호환되지 않아요.
+
+상호작용 가능한 animator를 멈추고 되감거나 복잡한 keyframe을 제어해야 한다면 기존 UIKit 애니메이션이 더 적합할 수 있어요. 단순히 두 프레임워크의 spring과 timing을 맞추려는 경우에 통합 API의 이점이 커요.
+
+## Scene과 visionOS ornament는 별도 범위예요
+
+공식 UIKit integration 목차의 모든 API가 일반 iOS 화면 임베딩용은 아니에요.
+
+- `UIHostingSceneDelegate`는 iOS 26 이상에서 `UISceneDelegate`를 확장해 SwiftUI scene을 연결해요. 한 뷰를 감싸는 `UIHostingController`보다 앱 scene 생명주기에 가까운 고급 마이그레이션 API예요.
+- `UIHostingOrnament`와 `UIOrnament`는 visionOS 1.0 이상 전용이에요. iPhone과 iPad의 toolbar를 위한 대체 API가 아니에요.
+
+현재 문제가 화면이나 셀 하나의 통합이라면 기본 hosting/representable부터 사용하세요. scene이나 공간 인터페이스를 실제로 옮길 때 해당 플랫폼 문서를 별도로 확인하는 편이 안전해요.
+
+## 적용 순서를 정리해요
+
+1. SwiftUI 기본 gesture, 직접 프로퍼티, 각 프레임워크의 기본 애니메이션으로 해결 가능한지 확인하세요.
+2. 앱의 최소 지원 OS와 availability 분기를 정하세요.
+3. UIKit recognizer가 꼭 필요하면 `UIGestureRecognizerRepresentable`로 생성과 action을 연결하세요.
+4. 위치가 필요하면 context converter로 사용할 SwiftUI coordinate space를 명시하세요.
+5. 여러 계층이 공유할 사용자 정의 값만 trait–environment 브리지로 정의하세요.
+6. 양쪽 애니메이션의 timing을 맞출 때 같은 SwiftUI `Animation`이나 representable context를 사용하세요.
+7. 하위 버전 대안과 animation 호환 제한을 실제 기기에서 확인하세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `UIGestureRecognizerRepresentable`은 언제 필요한가요?
+
+SwiftUI 기본 gesture로 표현하기 어려운 기존 사용자 정의 recognizer, delegate 상호작용, UIKit의 세부 제스처 설정을 유지할 때 필요해요. 일반 탭이나 길게 누르기라면 더 단순하고 하위 버전도 지원하는 SwiftUI gesture를 먼저 선택해요.
+
+### UIKit recognizer의 위치를 왜 converter로 읽어야 하나요?
+
+recognizer가 내부적으로 연결된 UIKit 뷰의 좌표계와 사용자가 보는 SwiftUI 뷰의 좌표계가 다를 수 있기 때문이에요. context converter는 전역 위치를 SwiftUI의 로컬, 전역, 이름 있는 좌표 공간으로 변환해 올바른 위치를 제공해요.
+
+### `UITraitBridgedEnvironmentKey`가 직접 프로퍼티 전달보다 좋은 경우는 언제인가요?
+
+창이나 화면의 여러 단계 아래에 있는 UIKit과 SwiftUI 구성 요소가 같은 계층형 설정을 자동으로 물려받아야 할 때 좋아요. 부모와 자식이 직접 연결되어 값 하나만 전달하면 프로퍼티나 binding이 더 단순하고 비용도 적어요.
+
+### SwiftUI `Animation`을 UIKit에서 쓰면 `UIViewPropertyAnimator`를 대신할 수 있나요?
+
+항상 그렇지는 않아요. 같은 spring과 timing을 두 프레임워크에 적용하는 데 유용하지만 대응 `CAAnimation`이 없고 property animator나 keyframe animation과 호환되지 않아요. 중단, 진행률 제어, keyframe이 필요하면 UIKit 전용 animator를 유지하세요.
+
+## 참고 자료
+
+- [UIKit integration](https://developer.apple.com/documentation/swiftui/uikit-integration)
+- [UIGestureRecognizerRepresentable](https://developer.apple.com/documentation/swiftui/uigesturerecognizerrepresentable)
+- [UITraitBridgedEnvironmentKey](https://developer.apple.com/documentation/uikit/uitraitbridgedenvironmentkey)
+- [Providing data to the view hierarchy with custom traits](https://developer.apple.com/documentation/uikit/providing-data-to-the-view-hierarchy-with-custom-traits)
+- [Unleash the UIKit trait system](https://developer.apple.com/videos/play/wwdc2023/10057/)
+- [Unifying your app’s animations](https://developer.apple.com/documentation/swiftui/unifying-your-app-s-animations)
+- [UIHostingSceneDelegate](https://developer.apple.com/documentation/swiftui/uihostingscenedelegate)
+- [UIHostingOrnament](https://developer.apple.com/documentation/swiftui/uihostingornament)

--- a/docs/guide/swiftui/uikit-integration/index.md
+++ b/docs/guide/swiftui/uikit-integration/index.md
@@ -1,0 +1,205 @@
+---
+title: SwiftUI와 UIKit 통합 한눈에 보기
+description: UIHostingController와 Representable 계열의 역할, 지원 버전, 데이터 흐름을 비교하고 UIKit 앱을 SwiftUI로 점진적으로 전환하는 기준을 설명합니다.
+---
+
+# SwiftUI와 UIKit 통합 한눈에 보기
+
+> **면접 답변 한 줄 요약:** SwiftUI와 UIKit 통합은 한 프레임워크의 화면을 다른 프레임워크가 관리할 수 있는 컨테이너나 어댑터로 감싸고, 상태와 이벤트의 소유자를 하나로 유지해 기존 화면을 단계적으로 재사용하거나 전환하는 방법이에요.
+
+이미 UIKit으로 만든 앱을 SwiftUI로 바꾸려면 모든 화면을 한 번에 다시 작성해야 할까요? 그렇지 않아요. Apple은 UIKit 화면 안에 SwiftUI를 넣는 **호스팅(hosting)** API와 SwiftUI 화면 안에 UIKit을 넣는 **Representable** API를 제공해요. 화면 하나나 셀 하나부터 경계를 만들 수 있으므로 기존 기능을 유지하면서 점진적으로 전환할 수 있어요.
+
+반대로 SwiftUI 앱에서도 웹 뷰, 복잡한 UIKit 컨트롤, 기존 사내 컴포넌트를 바로 버릴 필요가 없어요. 필요한 UIKit 객체만 감싸서 SwiftUI의 상태와 레이아웃 흐름에 참여시킬 수 있어요.
+
+이 섹션에서는 독서 목표 앱을 예로 들어 다음 내용을 배워요.
+
+1. 통합 방향에 맞는 API를 선택해요.
+2. UIKit 화면에 SwiftUI 화면과 셀을 넣어요.
+3. SwiftUI 화면에서 UIKit 뷰와 뷰 컨트롤러를 재사용해요.
+4. 두 프레임워크 사이의 상태, 이벤트, 크기와 생명주기를 연결해요.
+5. 지원 OS를 확인하며 제스처, 환경 값, 애니메이션을 공유해요.
+
+## 먼저 알아둘 통합 용어
+
+| 용어                    | 쉬운 뜻                                                                                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UIKit                   | `UIView`와 `UIViewController` 같은 참조 타입을 만들고 속성을 직접 바꾸며 iOS 화면을 구성하는 Apple 프레임워크예요.                                                      |
+| SwiftUI                 | 현재 상태로 화면이 어떻게 보여야 하는지를 `View` 값으로 선언하면, 상태 변화에 맞춰 필요한 부분을 갱신하는 Apple 프레임워크예요.                                         |
+| 컨테이너(container)     | 다른 화면이나 객체를 안에 담고 크기와 생명주기를 관리하는 바깥 객체예요.                                                                                                |
+| 호스팅(hosting)         | SwiftUI 뷰 계층을 UIKit의 뷰 컨트롤러나 셀 구성처럼 사용할 수 있는 형태로 담는 일이에요.                                                                                |
+| Representable           | UIKit 뷰나 뷰 컨트롤러를 SwiftUI의 `View`처럼 사용할 수 있도록 생성·갱신·정리 방법을 알려 주는 어댑터예요.                                                              |
+| 어댑터(adapter)         | 서로 다른 사용 규칙을 가진 두 대상을 연결하는 얇은 변환 계층이에요. 여기서는 UIKit의 명령형 객체를 SwiftUI의 선언형 갱신 흐름에 연결해요.                               |
+| 단일 데이터 원천        | 같은 의미의 상태를 여러 곳에 따로 저장하지 않고 한 곳을 기준값으로 삼는 원칙이에요.                                                                                     |
+| Coordinator             | UIKit의 delegate나 target-action 이벤트를 받아 SwiftUI의 `Binding`이나 클로저로 전달하는 객체예요.                                                                      |
+| 뷰 컨트롤러 containment | 부모 `UIViewController`가 자식 뷰 컨트롤러의 추가와 제거를 생명주기 규칙에 맞게 관리하는 방식이에요. `UIHostingController`를 화면 일부에 넣을 때 이 규칙을 따라야 해요. |
+| 환경 값과 trait         | SwiftUI의 environment와 UIKit의 trait은 색상 모드나 크기 등 계층 전체에 내려보내는 구성 정보예요. iOS 17부터 사용자 정의 값도 두 체계 사이에서 연결할 수 있어요.        |
+
+## 통합은 소유권 경계를 만드는 일이에요
+
+두 프레임워크를 섞을 때 핵심 질문은 “어느 프레임워크가 바깥 화면을 소유하나요?”예요.
+
+```text
+UIKit이 바깥 화면을 소유
+
+UIViewController
+└─ UIHostingController
+   └─ SwiftUI View
+
+
+SwiftUI가 바깥 화면을 소유
+
+SwiftUI View
+└─ UIViewRepresentable 또는 UIViewControllerRepresentable
+   └─ UIView 또는 UIViewController
+```
+
+바깥 프레임워크가 크기와 생명주기를 주도하고, 안쪽 프레임워크는 브리지 API를 통해 그 규칙에 참여해요. 그래서 UIKit 객체의 `frame`을 SwiftUI 안에서 임의로 바꾸거나, 자식 `UIHostingController`를 containment 절차 없이 뷰만 추가하면 두 프레임워크가 같은 책임을 두고 충돌할 수 있어요.
+
+Apple의 [UIKit integration](https://developer.apple.com/documentation/swiftui/uikit-integration) 문서도 같은 두 방향을 구분해요. SwiftUI를 UIKit에 넣을 때는 hosting controller를, UIKit 객체를 SwiftUI에 넣을 때는 representable을 사용해요.
+
+## 바깥 화면과 재사용 대상을 기준으로 API를 골라요
+
+| 상황                                               | 먼저 고려할 API                    | 이유                                                                                      |
+| -------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| UIKit에서 SwiftUI 화면을 push, present하고 싶어요. | `UIHostingController`              | SwiftUI 계층을 일반 `UIViewController`처럼 다룰 수 있어요.                                |
+| UIKit 화면 일부에 SwiftUI를 넣고 싶어요.           | 자식 `UIHostingController`         | containment와 Auto Layout으로 기존 화면 일부만 교체할 수 있어요.                          |
+| UIKit 목록 셀의 내용만 SwiftUI로 만들고 싶어요.    | `UIHostingConfiguration`           | 별도 자식 컨트롤러 없이 셀의 `contentConfiguration`으로 SwiftUI 내용을 구성해요.          |
+| SwiftUI에서 UIKit 뷰 하나를 쓰고 싶어요.           | `UIViewRepresentable`              | `UIView`의 생성, 상태 갱신, 이벤트 전달을 SwiftUI 흐름에 연결해요.                        |
+| SwiftUI에서 UIKit 뷰 컨트롤러를 쓰고 싶어요.       | `UIViewControllerRepresentable`    | delegate와 화면 생명주기가 있는 컨트롤러 전체를 감싸요.                                   |
+| SwiftUI 뷰에 UIKit 제스처 인식기를 붙이고 싶어요.  | `UIGestureRecognizerRepresentable` | iOS 18부터 인식기 생성과 좌표 변환을 직접 연결해요.                                       |
+| 계층형 설정을 두 프레임워크에서 함께 읽고 싶어요.  | `UITraitBridgedEnvironmentKey`     | iOS 17부터 UIKit trait과 SwiftUI environment가 같은 값을 공유해요.                        |
+| 앱의 SwiftUI scene을 UIKit 생명주기와 연결해요.    | `UIHostingSceneDelegate`           | iOS 26부터 scene 수준의 브리지를 제공해요. 일반 화면 임베딩보다 큰 마이그레이션 단위예요. |
+
+`UIHostingController`와 `UIViewControllerRepresentable`은 이름이 비슷하지만 방향이 반대예요.
+
+- `UIHostingController`: UIKit이 SwiftUI를 소유해요.
+- `UIViewControllerRepresentable`: SwiftUI가 UIKit을 소유해요.
+
+이 한 문장을 먼저 기억하면 API를 고르기 쉬워요.
+
+## 지원 OS가 통합 전략을 바꿔요
+
+공식 문서에 표시된 iOS 도입 버전을 기준으로 정리하면 다음과 같아요.
+
+| iOS 버전 | 사용할 수 있는 대표 기능                                                          | 하위 버전에서의 선택                                                                   |
+| -------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| iOS 13   | `UIHostingController`, `UIViewRepresentable`, `UIViewControllerRepresentable`     | 양방향 통합의 기본 API이므로 iOS 13 이상 앱에서 바로 사용할 수 있어요.                 |
+| iOS 16   | `UIHostingConfiguration`, `UIHostingControllerSizingOptions`                      | 이전 버전 목록 셀은 UIKit content configuration이나 별도 hosting container를 사용해요. |
+| iOS 17   | `UITraitBridgedEnvironmentKey`와 사용자 정의 UIKit trait                          | 직접 프로퍼티, 공유 모델, 명시적인 변환 코드를 사용해요.                               |
+| iOS 18   | `UIGestureRecognizerRepresentable`, SwiftUI `Animation`을 이용한 UIKit 애니메이션 | SwiftUI 기본 gesture를 우선하고, 꼭 필요한 UIKit 인식기는 별도 어댑터로 감싸요.        |
+| iOS 26   | `UIHostingSceneDelegate`                                                          | 기존 scene delegate와 화면 단위 hosting을 유지해요.                                    |
+
+`UIHostingOrnament`와 `UIOrnament`도 공식 UIKit integration 목차에 있지만 visionOS 1.0 이상 전용이에요. 이 섹션의 iOS 예제에는 포함하지 않고, [제스처·환경·애니메이션 문서](./gestures-environment-animation)에서 플랫폼 범위를 따로 설명해요.
+
+## UIKit 앱에는 작은 SwiftUI 경계부터 넣어요
+
+독서 목표 앱의 대시보드가 UIKit으로 만들어져 있다고 가정할게요. 전체 화면을 다시 쓰기 전에 다음처럼 작은 경계를 선택할 수 있어요.
+
+1. 상태 변화가 적은 진행률 카드 하나를 SwiftUI로 만들어요.
+2. `UIHostingController`로 기존 `UIViewController`의 자식에 넣어요.
+3. UIKit과 SwiftUI가 같은 `ReadingGoalStore`를 전달받게 해요.
+4. 문제가 없다면 목록 셀을 `UIHostingConfiguration`으로 바꿔요.
+5. 화면 전환과 내비게이션의 소유권은 당분간 UIKit에 둬요.
+
+이 방식은 한 화면의 모든 책임을 동시에 옮기지 않아요. SwiftUI로 바꾼 경계가 작으므로 성능, 접근성, 상태 갱신을 확인하고 다음 범위를 결정할 수 있어요.
+
+구현은 [UIKit에 SwiftUI 넣기](./swiftui-in-uikit)에서 단계별로 살펴봐요.
+
+## SwiftUI 앱에서는 UIKit 기능만 좁게 감싸요
+
+SwiftUI로 만든 목표 편집 화면에서 `UISlider`나 기존 색상 선택 컨트롤러가 필요할 수 있어요. 이때 UIKit 화면 전체를 새로 만들기보다 필요한 객체만 representable로 감싸요.
+
+1. 뷰 하나면 `UIViewRepresentable`을 선택해요.
+2. delegate와 자체 화면 생명주기가 있는 컨트롤러면 `UIViewControllerRepresentable`을 선택해요.
+3. SwiftUI 상태는 `Binding`으로 어댑터에 전달해요.
+4. UIKit 이벤트는 `Coordinator`가 다시 `Binding`에 기록해요.
+5. `update` 메서드는 현재 상태를 여러 번 받아도 결과가 같도록 작성해요.
+
+구현은 [SwiftUI에 UIKit 넣기](./uikit-in-swiftui)에서 이어져요.
+
+## 화면보다 상태의 소유자를 먼저 정해요
+
+통합 코드가 어려워지는 가장 흔한 이유는 같은 값을 UIKit과 SwiftUI가 각각 저장하기 때문이에요.
+
+```text
+피해야 할 흐름
+
+UIKit의 completedMinutes ──┐
+                          ├─ 어느 값이 최신인지 알기 어려움
+SwiftUI의 completedMinutes ┘
+
+
+권장 흐름
+
+                 ┌─ UIKit이 읽고 변경
+ReadingGoalStore ┤
+                 └─ SwiftUI가 관찰하고 표시
+```
+
+화면 기술이 둘이어도 도메인 상태의 기준은 하나여야 해요. UIKit이 소유한 공유 모델을 SwiftUI에 전달할 수도 있고, SwiftUI의 `State`를 `Binding`으로 UIKit 어댑터에 전달할 수도 있어요. 중요한 것은 **양쪽이 모두 독립적인 원본이라고 생각하지 않게 하는 것**이에요.
+
+자세한 갱신 규칙과 피드백 루프 방지는 [상태·레이아웃·생명주기](./data-layout-lifecycle)에서 다뤄요.
+
+## 언제 함께 사용해야 하나요
+
+다음 조건에서는 통합 API가 특히 유용해요.
+
+- 큰 UIKit 앱에 SwiftUI를 화면이나 컴포넌트 단위로 점진적으로 도입할 때
+- SwiftUI에 아직 같은 기능이 없거나 기존 UIKit 컴포넌트를 검증된 상태로 재사용할 때
+- UIKit의 내비게이션 구조는 유지하면서 셀과 작은 화면부터 SwiftUI로 바꿀 때
+- 두 프레임워크가 공유해야 하는 상태와 소유권 경계를 명확히 정할 수 있을 때
+
+반대로 아래 상황에서는 브리지를 추가하지 않아도 돼요.
+
+- 순수 SwiftUI나 순수 UIKit으로 짧고 명확하게 구현할 수 있는 새 화면
+- 어댑터가 실제 기능보다 더 많은 상태 복제와 생명주기 코드를 만들 때
+- 최소 지원 OS 때문에 핵심 API를 쓸 수 없고 하위 버전용 구현 비용이 이득보다 클 때
+- 프레임워크 전환 목적 없이 단지 새로운 API를 사용해 보기 위해 경계를 늘릴 때
+
+브리지는 영구적인 구조가 될 수도 있고 마이그레이션 중간 단계가 될 수도 있어요. 어느 쪽인지 팀이 미리 정하면 나중에 어댑터를 유지할지 제거할지 판단하기 쉬워요.
+
+## 적용 순서를 정리해요
+
+1. 바깥 화면을 UIKit과 SwiftUI 중 누가 소유하는지 적어요.
+2. 전체 화면, 화면 일부, 셀, 뷰, 뷰 컨트롤러 중 가장 작은 통합 단위를 고르세요.
+3. 최소 지원 OS에서 쓸 수 있는 API인지 확인하세요.
+4. 상태의 단일 원천과 이벤트가 돌아갈 경로를 정하세요.
+5. 생성, 갱신, 제거와 크기 협상의 책임을 각각 한쪽에 배정하세요.
+6. 작은 경계 하나를 구현하고 갱신 횟수, 메모리 해제, 회전과 Dynamic Type을 확인하세요.
+7. 효과가 확인된 다음 경계를 넓히세요.
+
+## 어떤 문서부터 읽어야 하나요
+
+| 목표                                            | 다음 문서                                                  |
+| ----------------------------------------------- | ---------------------------------------------------------- |
+| UIKit 화면이나 셀에 SwiftUI를 도입하고 싶어요.  | [UIKit에 SwiftUI 넣기](./swiftui-in-uikit)                 |
+| SwiftUI에서 UIKit 뷰나 컨트롤러를 재사용해요.   | [SwiftUI에 UIKit 넣기](./uikit-in-swiftui)                 |
+| 갱신 루프, 크기, 해제 문제를 예방하고 싶어요.   | [상태·레이아웃·생명주기](./data-layout-lifecycle)          |
+| 최신 제스처, 환경 값, 애니메이션 브리지를 써요. | [제스처·환경·애니메이션](./gestures-environment-animation) |
+
+## 면접에서 이어질 수 있는 질문
+
+### `UIHostingController`와 `UIViewControllerRepresentable`은 어떻게 다른가요?
+
+통합 방향이 반대예요. `UIHostingController`는 SwiftUI 뷰 계층을 UIKit 뷰 컨트롤러로 감싸고, `UIViewControllerRepresentable`은 UIKit 뷰 컨트롤러를 SwiftUI의 `View`로 감싸요. 바깥 화면을 어느 프레임워크가 소유하는지 먼저 보면 선택할 수 있어요.
+
+### UIKit 앱을 SwiftUI로 한 번에 다시 작성하지 않는 이유는 무엇인가요?
+
+동작이 검증된 화면을 유지한 채 작은 경계부터 상태, 접근성, 성능을 확인할 수 있기 때문이에요. 통합 API를 사용하면 내비게이션이나 데이터 계층을 그대로 두고 화면이나 셀 단위로 전환할 수 있어 회귀 범위를 줄일 수 있어요.
+
+### 통합 화면에서 가장 먼저 정해야 할 것은 무엇인가요?
+
+화면의 소유자와 상태의 단일 원천이에요. 이 둘을 정하지 않으면 UIKit과 SwiftUI가 같은 값을 따로 보관하거나 같은 크기를 동시에 제어해 갱신 루프와 레이아웃 충돌이 생길 수 있어요.
+
+### Representable이 어댑터인 이유는 무엇인가요?
+
+UIKit은 오래 살아 있는 참조 객체의 속성을 바꾸고, SwiftUI는 새 상태를 반영한 `View` 값을 반복해서 만들어요. Representable은 `make`, `update`, `dismantle` 단계로 두 생명주기를 연결하고 Coordinator로 이벤트 방향을 변환해요.
+
+## 참고 자료
+
+- [UIKit integration](https://developer.apple.com/documentation/swiftui/uikit-integration)
+- [UIHostingController](https://developer.apple.com/documentation/swiftui/uihostingcontroller)
+- [UIHostingConfiguration](https://developer.apple.com/documentation/swiftui/uihostingconfiguration)
+- [UIViewRepresentable](https://developer.apple.com/documentation/swiftui/uiviewrepresentable)
+- [UIViewControllerRepresentable](https://developer.apple.com/documentation/swiftui/uiviewcontrollerrepresentable)
+- [Managing user interface state](https://developer.apple.com/documentation/swiftui/managing-user-interface-state)

--- a/docs/guide/swiftui/uikit-integration/swiftui-in-uikit.md
+++ b/docs/guide/swiftui/uikit-integration/swiftui-in-uikit.md
@@ -1,0 +1,400 @@
+---
+title: UIKit에 SwiftUI 넣기
+description: UIHostingController의 화면 표시와 자식 containment, 공유 모델의 데이터 전달, UIHostingConfiguration 셀 구성과 크기 협상을 단계별로 설명합니다.
+---
+
+# UIKit에 SwiftUI 넣기
+
+> **면접 답변 한 줄 요약:** UIKit에 SwiftUI를 넣을 때는 화면 단위면 `UIHostingController`, 목록 셀 내용이면 `UIHostingConfiguration`을 사용하고, UIKit이 컨테이너 생명주기를 소유하되 두 화면은 같은 상태 모델을 관찰하게 만들어요.
+
+UIKit으로 만든 독서 목표 앱에 SwiftUI 진행률 카드를 추가해 볼게요. 기존 `UINavigationController`, 화면 전환, 분석 로직은 유지하고 카드부터 SwiftUI로 바꾸는 상황이에요.
+
+이 문서에서는 다음 순서로 구현해요.
+
+1. SwiftUI 화면과 상태 모델을 만들어요.
+2. 전체 화면으로 present해 가장 작은 통합을 확인해요.
+3. 기존 UIKit 화면 일부에 자식 뷰 컨트롤러로 넣어요.
+4. UIKit과 SwiftUI가 같은 모델을 공유하게 해요.
+5. Collection View 셀은 `UIHostingConfiguration`으로 구성해요.
+6. 콘텐츠 크기와 메모리 소유 관계를 점검해요.
+
+## 먼저 알아둘 UIKit 용어
+
+| 용어                     | 쉬운 뜻                                                                                                                                   |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `UIHostingController`    | SwiftUI 뷰 계층을 관리하는 UIKit 뷰 컨트롤러예요. 일반 `UIViewController`처럼 present, push, 자식 추가를 할 수 있어요.                    |
+| root view                | hosting controller가 관리하는 SwiftUI 계층의 시작 `View`예요. 생성할 때 전달하고 `rootView` 프로퍼티로 교체할 수 있어요.                  |
+| containment              | 부모 뷰 컨트롤러가 자식 뷰 컨트롤러를 `addChild`, `didMove` 순서로 등록하고 함께 생명주기를 관리하는 규칙이에요.                          |
+| Auto Layout              | 제약 조건으로 UIKit 뷰의 위치와 크기 관계를 계산하는 시스템이에요. 자식 hosting controller의 뷰도 기존 UIKit 뷰처럼 제약 조건을 연결해요. |
+| `UIHostingConfiguration` | SwiftUI 뷰 계층을 `UITableViewCell`이나 `UICollectionViewCell`의 content configuration으로 사용하는 iOS 16 이상의 값 타입이에요.          |
+| `preferredContentSize`   | popover나 사용자 정의 컨테이너가 자식 뷰 컨트롤러의 이상적인 크기를 물을 때 사용하는 UIKit 크기예요.                                      |
+| intrinsic content size   | 제약 조건이 너비나 높이를 모두 지정하지 않았을 때 뷰가 본래 필요하다고 알리는 크기예요.                                                   |
+
+## UIKit 코드만으로 카드를 만들면 상태 표현이 흩어질 수 있어요
+
+독서 시간과 목표가 바뀔 때 UIKit 카드의 여러 뷰를 직접 갱신한다고 가정해 볼게요.
+
+```swift
+final class ReadingCardView: UIView {
+  private let minutesLabel = UILabel()
+  private let progressView = UIProgressView()
+
+  func update(completedMinutes: Int, targetMinutes: Int) {
+    minutesLabel.text = "\(completedMinutes) / \(targetMinutes)분"
+    progressView.progress =
+      Float(completedMinutes) / Float(max(targetMinutes, 1))
+  }
+}
+```
+
+이 코드가 잘못된 것은 아니에요. 하지만 카드의 조건부 문구, 색상, 접근성 값이 늘어날수록 “현재 상태라면 어떻게 보여야 하는가”가 여러 명령으로 흩어져요. 전체 화면을 다시 만들기보다 이 카드만 SwiftUI의 선언형 표현으로 바꿔 볼 수 있어요.
+
+## 공유할 상태와 SwiftUI 화면을 만들어요
+
+먼저 두 프레임워크가 함께 사용할 모델을 만들어요. `ObservableObject`는 변경된 `@Published` 프로퍼티를 SwiftUI가 관찰할 수 있게 해요.
+
+```swift
+import Combine
+import SwiftUI
+
+@MainActor
+final class ReadingGoalStore: ObservableObject {
+  @Published var completedMinutes: Int
+  @Published var targetMinutes: Int
+
+  init(completedMinutes: Int, targetMinutes: Int) {
+    self.completedMinutes = completedMinutes
+    self.targetMinutes = targetMinutes
+  }
+}
+```
+
+SwiftUI 카드는 모델을 만들지 않고 외부에서 받아 관찰해요.
+
+```swift
+struct ReadingProgressView: View {
+  @ObservedObject var store: ReadingGoalStore
+  var onEdit: () -> Void = {}
+
+  private var progress: Double {
+    Double(store.completedMinutes) /
+      Double(max(store.targetMinutes, 1))
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("오늘의 독서")
+        .font(.headline)
+
+      ProgressView(value: min(progress, 1))
+
+      Text("\(store.completedMinutes) / \(store.targetMinutes)분")
+        .foregroundStyle(.secondary)
+
+      Button("목표 수정", action: onEdit)
+    }
+    .padding()
+  }
+}
+```
+
+이 예제의 `ProgressView`는 iOS 14 이상, `foregroundStyle`은 iOS 15 이상에서 사용할 수 있어요. `UIHostingController` 자체는 iOS 13부터 지원하므로 iOS 13을 지원해야 한다면 진행 막대를 직접 그리고 `foregroundColor`를 사용하는 뷰로 바꿀 수 있어요.
+
+`ReadingProgressView`는 UIKit을 몰라요. 모델을 표시하고 버튼 이벤트를 클로저로 내보낼 뿐이에요. 이 분리는 같은 SwiftUI 뷰를 preview, hosting controller, 다른 SwiftUI 화면에서 재사용하기 쉽게 만들어요.
+
+## 전체 화면은 `UIHostingController`로 표시해요
+
+가장 작은 확인 방법은 일반 UIKit 뷰 컨트롤러처럼 present하는 거예요.
+
+```swift
+@MainActor
+func presentProgress(
+  from presenter: UIViewController,
+  store: ReadingGoalStore
+) {
+  let progressView = ReadingProgressView(store: store)
+  let hostingController = UIHostingController(rootView: progressView)
+
+  presenter.present(hostingController, animated: true)
+}
+```
+
+`UIHostingController`는 `UIViewController`의 하위 클래스예요. 따라서 `present`, `navigationController?.pushViewController`, sheet 설정처럼 기존 UIKit 화면 전환을 그대로 사용할 수 있어요. Apple의 [UIHostingController](https://developer.apple.com/documentation/swiftui/uihostingcontroller) 문서도 생성 시 root view를 전달하고 일반 뷰 컨트롤러처럼 표시하거나 자식으로 넣으라고 설명해요.
+
+이 단계에서 소유 관계는 단순해요.
+
+```text
+presenting UIViewController
+└─ UIHostingController
+   └─ ReadingProgressView
+      └─ ReadingGoalStore를 관찰
+```
+
+## 화면 일부에는 자식 뷰 컨트롤러로 넣어요
+
+기존 대시보드의 상단 카드만 바꾸려면 hosting controller를 자식으로 추가해야 해요.
+
+```swift
+import SwiftUI
+import UIKit
+
+@MainActor
+final class ReadingDashboardViewController: UIViewController {
+  private let store: ReadingGoalStore
+  private let hostingController: UIHostingController<ReadingProgressView>
+
+  init(store: ReadingGoalStore) {
+    self.store = store
+    self.hostingController = UIHostingController(
+      rootView: ReadingProgressView(store: store)
+    )
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 지원하지 않아요.")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    let hostedView = hostingController.view!
+    hostedView.translatesAutoresizingMaskIntoConstraints = false
+
+    addChild(hostingController)
+    view.addSubview(hostedView)
+
+    NSLayoutConstraint.activate([
+      hostedView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor
+      ),
+      hostedView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      hostedView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+    ])
+
+    hostingController.didMove(toParent: self)
+  }
+}
+```
+
+순서에는 의미가 있어요.
+
+1. `addChild(_:)`로 부모가 자식을 관리하기 시작한다고 알려요.
+2. 자식의 `view`를 실제 UIKit 뷰 계층에 추가해요.
+3. Auto Layout 제약으로 바깥 UIKit 화면이 크기를 제안해요.
+4. `didMove(toParent:)`로 이동이 끝났다고 알려요.
+
+뷰만 `addSubview`하면 화면은 보일 수 있지만 뷰 컨트롤러 containment가 빠져요. 회전, appearance callback, trait 전달처럼 컨트롤러 계층을 따르는 동작이 예상과 달라질 수 있어요.
+
+자식을 명시적으로 제거할 때는 반대 순서를 사용해요.
+
+```swift
+func removeProgressCard() {
+  hostingController.willMove(toParent: nil)
+  hostingController.view.removeFromSuperview()
+  hostingController.removeFromParent()
+}
+```
+
+부모가 사라질 때 자식도 함께 사라지는 일반적인 구조라면 UIKit이 containment를 따라 정리해요. 화면 중간에 카드만 제거하는 경우에는 위 절차를 직접 수행하세요.
+
+## UIKit과 SwiftUI는 같은 모델을 변경해요
+
+`ReadingDashboardViewController`와 `ReadingProgressView`가 같은 `ReadingGoalStore` 인스턴스를 들고 있으므로 상태를 복사할 필요가 없어요.
+
+```swift
+extension ReadingDashboardViewController {
+  @objc
+  func addFiveMinutes() {
+    store.completedMinutes += 5
+  }
+}
+```
+
+UIKit 버튼이 `addFiveMinutes()`를 호출하면 `@Published`가 변경을 알리고 SwiftUI 카드가 다시 계산돼요. 반대로 SwiftUI 버튼이 UIKit 화면 전환을 요청해야 하면 root view에 클로저를 전달해요.
+
+```swift
+hostingController.rootView = ReadingProgressView(
+  store: store,
+  onEdit: { [weak self] in
+    self?.presentGoalEditor()
+  }
+)
+```
+
+hosting controller가 root view를 소유하고, root view의 클로저가 다시 UIKit 뷰 컨트롤러를 강하게 잡으면 순환 참조가 생길 수 있어요. UIKit 객체를 캡처할 때는 실제 소유 관계를 확인하고, 화면에 대한 역참조라면 보통 `[weak self]`를 사용해요.
+
+### `rootView` 교체와 관찰 모델 중 하나를 상태 경로로 골라요
+
+작은 읽기 전용 값은 새 root view를 대입해 갱신할 수도 있어요.
+
+```swift
+struct CompactProgressView: View {
+  let completedMinutes: Int
+
+  var body: some View {
+    Text("\(completedMinutes)분 읽었어요")
+  }
+}
+
+func updateProgress(to minutes: Int) {
+  compactHostingController.rootView = CompactProgressView(
+    completedMinutes: minutes
+  )
+}
+```
+
+이 방식은 입력이 작고 UIKit이 상태를 완전히 소유할 때 명확해요. 하지만 여러 값이 자주 변하거나 SwiftUI에서도 편집한다면 공유 관찰 모델이 더 자연스러워요.
+
+| 갱신 방식               | 적합한 상황                                          | 주의할 점                                          |
+| ----------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| `rootView`에 새 값 대입 | 작은 읽기 전용 입력, UIKit 단방향 갱신               | 모든 변경 지점에서 root view를 다시 만들어야 해요. |
+| 같은 관찰 모델 공유     | 여러 값이 변하고 양쪽 화면이 같은 상태를 읽거나 변경 | 모델의 소유자와 생존 범위를 분명히 해야 해요.      |
+
+두 방식을 같은 상태에 동시에 사용하면 어떤 경로가 기준인지 흐려져요. 한 상태에는 한 갱신 경로를 정하세요.
+
+## 목록 셀은 `UIHostingConfiguration`으로 구성해요
+
+iOS 16 이상에서는 셀 하나마다 hosting controller를 직접 관리하지 않아도 돼요. `UIHostingConfiguration`은 `UIContentConfiguration`을 따르므로 Collection View와 Table View 셀의 `contentConfiguration`에 바로 대입할 수 있어요.
+
+```swift
+struct Book: Hashable {
+  let id: UUID
+  let title: String
+  let isFinished: Bool
+}
+
+struct BookRowView: View {
+  let book: Book
+
+  var body: some View {
+    HStack {
+      Image(systemName: book.isFinished ? "checkmark.circle.fill" : "book")
+        .foregroundStyle(book.isFinished ? .green : .secondary)
+
+      Text(book.title)
+
+      Spacer()
+    }
+  }
+}
+```
+
+cell registration에서 현재 모델을 SwiftUI 뷰에 전달해요.
+
+```swift
+@available(iOS 16.0, *)
+let bookRegistration = UICollectionView.CellRegistration<
+  UICollectionViewListCell,
+  Book
+> { cell, _, book in
+  cell.contentConfiguration = UIHostingConfiguration {
+    BookRowView(book: book)
+  }
+  .margins(.all, 12)
+}
+```
+
+Apple의 [UIHostingConfiguration](https://developer.apple.com/documentation/swiftui/uihostingconfiguration) 문서는 Collection View 또는 Table View 셀 안에 SwiftUI 계층을 넣는 용도로 이 타입을 제공해요. SwiftUI `background`와 `margins`도 configuration에 연결할 수 있어요.
+
+셀의 선택 상태처럼 UIKit이 소유한 값을 SwiftUI 내용에 반영하려면 `configurationUpdateHandler`에서 새 configuration을 만들 수 있어요.
+
+```swift
+@available(iOS 16.0, *)
+func configure(_ cell: UICollectionViewListCell, with book: Book) {
+  cell.configurationUpdateHandler = { cell, state in
+    cell.contentConfiguration = UIHostingConfiguration {
+      HStack {
+        BookRowView(book: book)
+
+        if state.isSelected {
+          Image(systemName: "checkmark")
+        }
+      }
+    }
+    .margins(.all, 12)
+  }
+}
+```
+
+`UIHostingConfiguration`은 화면 전체의 내비게이션이나 자식 컨트롤러 생명주기를 대신하는 API가 아니에요. 반복되는 셀의 **내용 구성**에 맞춘 선택이에요.
+
+## SwiftUI 콘텐츠의 크기를 UIKit에 전달해요
+
+전체 화면을 네 모서리에 고정하면 바깥 Auto Layout 제약이 크기를 결정하므로 추가 설정이 필요하지 않은 경우가 많아요. 하지만 popover나 자체 크기를 가진 자식 뷰처럼 콘텐츠의 이상적인 크기가 바깥 컨테이너에 필요할 때는 iOS 16 이상의 `sizingOptions`를 사용해요.
+
+```swift
+let hostingController = UIHostingController(
+  rootView: ReadingProgressView(store: store)
+)
+
+if #available(iOS 16.0, *) {
+  hostingController.sizingOptions = .preferredContentSize
+}
+
+hostingController.modalPresentationStyle = .popover
+present(hostingController, animated: true)
+```
+
+| 옵션                    | UIKit에 전달하는 변화                                                                    | 주로 쓰는 위치                               |
+| ----------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `.preferredContentSize` | SwiftUI 콘텐츠의 이상적인 크기를 hosting controller의 `preferredContentSize`에 반영해요. | popover, 사용자 정의 컨테이너                |
+| `.intrinsicContentSize` | 콘텐츠 크기가 변할 때 hosting view의 intrinsic content size를 무효화해요.                | Auto Layout 안의 자체 크기 뷰                |
+| 빈 집합                 | 자동 크기 추적을 하지 않아요. 기본값이에요.                                              | 바깥 제약이 크기를 완전히 결정하는 일반 화면 |
+
+Apple은 `.preferredContentSize`가 지정되지 않은 크기 제안으로 이상적인 크기를 측정하므로 성능 비용이 있다고 안내해요. 컨테이너가 실제로 콘텐츠 크기를 알아야 할 때만 켜세요.
+
+## 화면 단위와 셀 단위를 구분해요
+
+| 비교 기준             | `UIHostingController`                        | `UIHostingConfiguration`                        |
+| --------------------- | -------------------------------------------- | ----------------------------------------------- |
+| 도입 버전             | iOS 13                                       | iOS 16                                          |
+| UIKit에서 보이는 형태 | `UIViewController`                           | `UIContentConfiguration`                        |
+| 적합한 범위           | 전체 화면, sheet, 화면 일부의 자식 컨트롤러  | Collection View와 Table View 셀의 내용          |
+| 내비게이션·생명주기   | UIKit 뷰 컨트롤러 규칙을 직접 따름           | 셀과 content view가 관리                        |
+| 크기 처리             | Auto Layout, `sizingOptions`, `sizeThatFits` | 셀의 self-sizing과 configuration margins를 활용 |
+
+## 흔한 실수를 점검해요
+
+- 자식 hosting controller의 `view`만 추가하고 `addChild`와 `didMove`를 생략하지 않았나요?
+- UIKit 상태와 SwiftUI 상태에 같은 값을 중복 저장하지 않았나요?
+- `rootView` 교체와 관찰 모델 갱신을 같은 상태에 섞지 않았나요?
+- root view의 클로저가 UIKit 컨트롤러를 강하게 잡아 순환 참조를 만들지 않나요?
+- 고정된 전체 화면에도 불필요하게 크기 추적 옵션을 켜지 않았나요?
+- iOS 16 미만에서 `UIHostingConfiguration`을 호출하지 않도록 availability를 확인했나요?
+
+## 적용 순서를 정리해요
+
+1. 화면 전체, 화면 일부, 셀 중 SwiftUI로 옮길 가장 작은 경계를 고르세요.
+2. UIKit이 소유할 상태와 공유 모델이 소유할 상태를 구분하세요.
+3. SwiftUI 뷰가 UIKit 타입을 직접 알지 않도록 입력과 이벤트 클로저를 설계하세요.
+4. 화면은 `UIHostingController`, 셀은 지원 버전을 확인한 뒤 `UIHostingConfiguration`으로 감싸세요.
+5. 자식 컨트롤러에는 containment와 Auto Layout 순서를 적용하세요.
+6. 상태 변경, 회전, Dynamic Type, dismiss 뒤 메모리 해제를 확인하세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `UIHostingController`를 화면 일부에 넣을 때 왜 containment가 필요한가요?
+
+`UIHostingController`는 단순한 `UIView`가 아니라 뷰 컨트롤러예요. 부모-자식 관계를 등록해야 appearance callback, 회전, trait과 같은 UIKit 뷰 컨트롤러 생명주기가 계층에 맞게 전달돼요.
+
+### UIKit의 값이 바뀔 때 SwiftUI는 어떻게 갱신하나요?
+
+작은 불변 입력이면 새 SwiftUI 값을 만들어 `rootView`에 대입할 수 있어요. 여러 값이 자주 바뀌면 UIKit과 SwiftUI에 같은 `ObservableObject` 인스턴스를 전달하고, UIKit이 모델을 변경하면 SwiftUI가 관찰하도록 만드는 편이 명확해요.
+
+### `UIHostingConfiguration`은 언제 `UIHostingController`보다 적합한가요?
+
+Collection View나 Table View 셀의 내용만 SwiftUI로 구성할 때 적합해요. 셀 재사용과 상태 갱신은 기존 UIKit 목록이 맡고, SwiftUI는 셀 내부 표현을 선언해요.
+
+### `sizingOptions`를 항상 설정해야 하나요?
+
+아니요. 바깥 Auto Layout이 크기를 완전히 정하는 화면에는 필요하지 않을 수 있어요. popover나 self-sizing 컨테이너처럼 SwiftUI 콘텐츠의 이상적인 크기를 UIKit이 알아야 할 때만 선택하세요.
+
+## 참고 자료
+
+- [UIHostingController](https://developer.apple.com/documentation/swiftui/uihostingcontroller)
+- [UIHostingControllerSizingOptions](https://developer.apple.com/documentation/swiftui/uihostingcontrollersizingoptions)
+- [UIHostingConfiguration](https://developer.apple.com/documentation/swiftui/uihostingconfiguration)
+- [Use SwiftUI with UIKit](https://developer.apple.com/videos/play/wwdc2022/10072/)
+- [UIViewController containment](https://developer.apple.com/documentation/uikit/uiviewcontroller)

--- a/docs/guide/swiftui/uikit-integration/uikit-in-swiftui.md
+++ b/docs/guide/swiftui/uikit-integration/uikit-in-swiftui.md
@@ -1,0 +1,358 @@
+---
+title: SwiftUI에 UIKit 넣기
+description: UIViewRepresentable과 UIViewControllerRepresentable의 make·update·dismantle 생명주기, Coordinator와 Binding을 이용한 양방향 이벤트 전달을 설명합니다.
+---
+
+# SwiftUI에 UIKit 넣기
+
+> **면접 답변 한 줄 요약:** SwiftUI에 UIKit을 넣을 때는 뷰를 `UIViewRepresentable`, 뷰 컨트롤러를 `UIViewControllerRepresentable`로 감싸고, SwiftUI 상태는 `update`에서 UIKit에 반영하며 UIKit 이벤트는 `Coordinator`를 통해 `Binding`으로 돌려보내요.
+
+SwiftUI로 독서 목표 편집 화면을 만들었지만 검증된 `UISlider`와 UIKit 색상 선택 화면을 계속 사용한다고 가정할게요. UIKit 객체는 SwiftUI의 `View`를 따르지 않으므로 `body`에 직접 놓을 수 없어요. 대신 SwiftUI가 UIKit 객체를 언제 만들고, 어떤 상태로 갱신하고, 어떻게 정리할지 알 수 있는 어댑터를 제공해야 해요.
+
+이 문서에서는 다음 내용을 배워요.
+
+1. `UIViewRepresentable`로 `UISlider`를 감싸요.
+2. SwiftUI 상태를 `updateUIView`에서 UIKit에 반영해요.
+3. `Coordinator`로 UIKit 이벤트를 `Binding`에 전달해요.
+4. `UIViewControllerRepresentable`로 색상 선택 화면을 감싸요.
+5. 크기와 정리 메서드의 책임을 구분해요.
+
+## 먼저 알아둘 SwiftUI와 UIKit 용어
+
+| 용어                            | 쉬운 뜻                                                                                                                                                           |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `UIViewRepresentable`           | `UIView` 하나를 SwiftUI 뷰 계층에 넣기 위한 프로토콜이에요. 생성은 `makeUIView`, 상태 반영은 `updateUIView`가 맡아요.                                             |
+| `UIViewControllerRepresentable` | `UIViewController` 전체를 SwiftUI 뷰 계층에 넣기 위한 프로토콜이에요. 자체 delegate와 화면 생명주기가 있는 UIKit 기능에 적합해요.                                 |
+| `Binding`                       | 값을 읽고 쓸 수 있는 연결이에요. 자식이 값을 바꾸면 실제 저장소인 부모의 `State`도 바뀌어요.                                                                      |
+| target-action                   | `UIControl`에서 값 변경이나 탭이 발생하면 지정한 객체의 메서드를 호출하는 UIKit 이벤트 전달 방식이에요.                                                           |
+| delegate                        | UIKit 객체가 선택, 취소, 스크롤 같은 사건을 미리 정한 메서드로 다른 객체에 알리는 방식이에요.                                                                     |
+| `Coordinator`                   | target-action이나 delegate 이벤트를 받는 참조 객체예요. Representable 값이 다시 만들어져도 UIKit 객체와 함께 유지되며 이벤트를 최신 SwiftUI 상태 연결로 전달해요. |
+| `Context`                       | SwiftUI가 Representable의 생성·갱신 메서드에 주는 정보 묶음이에요. coordinator, environment, 현재 transaction에 접근할 수 있어요.                                 |
+| 멱등성                          | 같은 입력으로 여러 번 실행해도 결과가 달라지지 않는 성질이에요. `update` 메서드는 자주 호출될 수 있으므로 현재 값과 같으면 불필요한 변경을 피해야 해요.           |
+
+## `UIViewRepresentable`은 UIKit 뷰의 생명주기를 번역해요
+
+`UIViewRepresentable`의 핵심 흐름은 세 단계예요.
+
+```text
+처음 계층에 들어옴
+makeUIView(context:) ── UIKit 뷰 한 번 생성
+
+SwiftUI 입력이나 환경이 바뀜
+updateUIView(_:context:) ── 기존 UIKit 뷰를 최신 상태로 갱신
+
+계층에서 제거됨
+dismantleUIView(_:coordinator:) ── delegate, observer, 작업 정리
+```
+
+SwiftUI의 `View`는 값 타입이라 상태가 바뀔 때 새 값이 만들어질 수 있어요. 반면 `UISlider`는 오래 살아 있는 참조 객체예요. Representable은 새 SwiftUI 입력을 기존 UIKit 객체에 적용하는 경계가 돼요.
+
+Apple의 [UIViewRepresentable](https://developer.apple.com/documentation/swiftui/uiviewrepresentable) 문서도 생성, 갱신, 해제 메서드를 사용해 UIKit 뷰를 관리하고, UIKit에서 발생한 변경은 Coordinator로 전달하라고 설명해요.
+
+## 가장 작은 `UISlider` 어댑터를 만들어요
+
+독서 목표 시간을 10분부터 120분까지 고르는 slider를 감싸 볼게요.
+
+```swift
+import SwiftUI
+import UIKit
+
+struct MinutesSlider: UIViewRepresentable {
+  @Binding var minutes: Double
+
+  func makeUIView(context: Context) -> UISlider {
+    let slider = UISlider()
+    slider.minimumValue = 10
+    slider.maximumValue = 120
+    slider.addTarget(
+      context.coordinator,
+      action: #selector(Coordinator.valueChanged(_:)),
+      for: .valueChanged
+    )
+    return slider
+  }
+
+  func updateUIView(_ slider: UISlider, context: Context) {
+    context.coordinator.minutes = $minutes
+
+    let newValue = Float(minutes)
+    guard abs(slider.value - newValue) > 0.001 else {
+      return
+    }
+
+    slider.setValue(newValue, animated: false)
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(minutes: $minutes)
+  }
+
+  final class Coordinator: NSObject {
+    var minutes: Binding<Double>
+
+    init(minutes: Binding<Double>) {
+      self.minutes = minutes
+    }
+
+    @objc
+    func valueChanged(_ sender: UISlider) {
+      minutes.wrappedValue = Double(sender.value)
+    }
+  }
+}
+```
+
+각 메서드의 책임을 나눠 볼게요.
+
+- `makeUIView`: slider 생성, 범위처럼 한 번 정할 설정, target 등록을 해요.
+- `updateUIView`: 현재 `minutes`를 이미 존재하는 slider에 반영해요.
+- `makeCoordinator`: UIKit 이벤트를 받을 참조 객체를 만들어요.
+- `valueChanged`: UIKit의 새 값을 `Binding`에 기록해 SwiftUI 상태를 바꿔요.
+
+`updateUIView`에서 coordinator의 `minutes`를 `$minutes`로 다시 대입하는 점도 중요해요. Coordinator는 오래 유지되지만 Representable 값과 binding은 부모 계층 변화로 새로 전달될 수 있어요. 이벤트가 과거의 binding에 기록되지 않도록 최신 연결을 넘겨줘요.
+
+## 부모의 `State`가 단일 데이터 원천이에요
+
+SwiftUI 화면에서는 일반 뷰처럼 사용해요.
+
+```swift
+struct GoalEditorView: View {
+  @State private var targetMinutes = 30.0
+
+  var body: some View {
+    Form {
+      Text("하루 목표: \(Int(targetMinutes))분")
+
+      MinutesSlider(minutes: $targetMinutes)
+    }
+  }
+}
+```
+
+데이터 흐름은 한 바퀴를 돌아요.
+
+```text
+@State targetMinutes
+      │
+      ▼
+updateUIView가 UISlider.value에 반영
+      │
+      ▼
+사용자가 slider를 움직임
+      │
+      ▼
+Coordinator가 Binding에 기록
+      │
+      └──────────────> @State targetMinutes
+```
+
+`UISlider`에 별도의 원본 값을 저장한 것이 아니에요. slider의 `value`는 화면 표현이고, 기준 상태는 부모의 `@State`예요.
+
+## 같은 값을 다시 쓰는 피드백 루프를 막아요
+
+다음과 같이 `updateUIView`에서 매번 값을 설정하면 UIKit이 추가 이벤트나 레이아웃을 일으키는 컨트롤에서 불필요한 갱신이 반복될 수 있어요.
+
+```swift
+func updateUIView(_ slider: UISlider, context: Context) {
+  slider.value = Float(minutes)
+}
+```
+
+앞의 완성 코드에서는 현재 값과 새 값의 차이를 확인했어요.
+
+```swift
+let newValue = Float(minutes)
+guard abs(slider.value - newValue) > 0.001 else {
+  return
+}
+
+slider.setValue(newValue, animated: false)
+```
+
+`updateUIView`는 한 번만 호출된다고 가정하면 안 돼요. 부모 상태, 환경 값, transaction이 바뀔 때 다시 호출될 수 있어요. 같은 입력을 여러 번 받아도 추가 부작용이 없도록 작성하세요.
+
+## `UIViewControllerRepresentable`은 컨트롤러 전체를 감싸요
+
+UIKit의 색상 선택 화면은 `UIColorPickerViewController`예요. 이 객체는 자체 화면과 delegate를 가지므로 `UIViewControllerRepresentable`이 맞아요.
+
+```swift
+@available(iOS 15.0, *)
+struct ColorPickerController: UIViewControllerRepresentable {
+  @Binding var selectedColor: UIColor
+
+  func makeUIViewController(
+    context: Context
+  ) -> UIColorPickerViewController {
+    let picker = UIColorPickerViewController()
+    picker.supportsAlpha = false
+    picker.selectedColor = selectedColor
+    picker.delegate = context.coordinator
+    return picker
+  }
+
+  func updateUIViewController(
+    _ picker: UIColorPickerViewController,
+    context: Context
+  ) {
+    context.coordinator.selectedColor = $selectedColor
+
+    guard !picker.selectedColor.isEqual(selectedColor) else {
+      return
+    }
+
+    picker.selectedColor = selectedColor
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(selectedColor: $selectedColor)
+  }
+
+  static func dismantleUIViewController(
+    _ picker: UIColorPickerViewController,
+    coordinator: Coordinator
+  ) {
+    picker.delegate = nil
+  }
+
+  final class Coordinator: NSObject,
+    UIColorPickerViewControllerDelegate
+  {
+    var selectedColor: Binding<UIColor>
+
+    init(selectedColor: Binding<UIColor>) {
+      self.selectedColor = selectedColor
+    }
+
+    func colorPickerViewController(
+      _ viewController: UIColorPickerViewController,
+      didSelect color: UIColor,
+      continuously: Bool
+    ) {
+      selectedColor.wrappedValue = color
+    }
+  }
+}
+```
+
+`makeUIViewController`는 컨트롤러를 만들고 delegate를 연결해요. 사용자가 색을 고르면 Coordinator가 UIKit delegate callback을 받아 binding을 갱신해요. `updateUIViewController`는 바깥 SwiftUI 상태가 다른 경로로 바뀐 경우 새 색을 picker에 반영해요.
+
+`dismantleUIViewController`에서는 delegate 연결을 끊어요. 이 예제의 delegate는 UIKit에서 `weak`으로 보관하지만, 명시적인 정리는 어댑터가 어떤 연결을 책임지는지 드러내요. NotificationCenter observer, KVO, 타이머, 비동기 작업을 시작했다면 이 단계에서 반드시 해제하거나 취소해야 해요.
+
+SwiftUI에서는 다음처럼 색을 공유해요.
+
+```swift
+@available(iOS 15.0, *)
+struct ThemeEditorView: View {
+  @State private var accentColor = UIColor.systemBlue
+
+  var body: some View {
+    VStack {
+      Color(uiColor: accentColor)
+        .frame(height: 80)
+
+      ColorPickerController(selectedColor: $accentColor)
+    }
+  }
+}
+```
+
+`UIColorPickerViewController`는 iOS 14 이상이고, 예제에서 사용한 연속 선택 delegate 메서드는 iOS 15 이상이에요. 최소 지원 버전이 iOS 14라면 deprecated된 이전 callback을 별도로 처리하거나 기능 범위를 조정해야 해요.
+
+## 뷰와 뷰 컨트롤러 중 어느 쪽을 감쌀지 골라요
+
+| 비교 기준   | `UIViewRepresentable`                        | `UIViewControllerRepresentable`                              |
+| ----------- | -------------------------------------------- | ------------------------------------------------------------ |
+| 감싸는 대상 | `UIView` 하위 클래스                         | `UIViewController` 하위 클래스                               |
+| 대표 사례   | `UISlider`, `MKMapView`, 기존 사용자 정의 뷰 | 문서 선택기, 색상 선택기, 기존 화면 컨트롤러                 |
+| 생성 메서드 | `makeUIView(context:)`                       | `makeUIViewController(context:)`                             |
+| 갱신 메서드 | `updateUIView(_:context:)`                   | `updateUIViewController(_:context:)`                         |
+| 정리 메서드 | `dismantleUIView(_:coordinator:)`            | `dismantleUIViewController(_:coordinator:)`                  |
+| 선택 기준   | 기능이 뷰 하나에서 끝나요.                   | delegate, presentation, 자식 관리 등 컨트롤러 책임이 있어요. |
+
+UIKit 타입 이름에 `ViewController`가 들어가고 자체 화면 흐름을 관리한다면 컨트롤러 representable부터 검토하세요. 단순히 컨트롤러의 `view`만 꺼내 `UIViewRepresentable`로 감싸면 원래 컨트롤러 생명주기를 잃을 수 있어요.
+
+## 크기는 SwiftUI의 제안을 존중해요
+
+Representable 안의 UIKit 객체는 SwiftUI 레이아웃에 참여해요. Apple은 SwiftUI가 representable 대상의 `center`, `bounds`, `frame`, `transform`을 제어하므로 직접 바꾸면 정의되지 않은 동작이 생길 수 있다고 경고해요.
+
+기본 intrinsic content size로 충분하지 않다면 iOS 16 이상에서 `sizeThatFits`를 구현할 수 있어요.
+
+```swift
+@available(iOS 16.0, *)
+func sizeThatFits(
+  _ proposal: ProposedViewSize,
+  uiView slider: UISlider,
+  context: Context
+) -> CGSize? {
+  CGSize(
+    width: proposal.width ?? 240,
+    height: slider.intrinsicContentSize.height
+  )
+}
+```
+
+이 메서드는 SwiftUI가 제안한 크기를 보고 UIKit 뷰가 선호하는 크기를 반환해요. 고정 `frame`을 직접 대입하는 것과 달리 레이아웃 협상에 참여하는 방식이에요. 특별한 측정 규칙이 없다면 기본 구현에 맡기세요.
+
+## `Context`에는 현재 환경과 transaction이 들어 있어요
+
+`Context`는 직접 만드는 값이 아니에요. SwiftUI가 현재 갱신에 필요한 정보를 넣어 전달해요.
+
+| 값                    | 사용할 때                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `context.coordinator` | UIKit delegate와 target-action을 SwiftUI 상태에 연결할 때                             |
+| `context.environment` | color scheme, size category처럼 UIKit 뷰 구성에 반영할 현재 SwiftUI 환경 값을 읽을 때 |
+| `context.transaction` | 이번 갱신에 애니메이션이 포함됐는지 확인하거나 iOS 18의 통합 애니메이션을 적용할 때   |
+
+예를 들어 UIKit 라벨이 SwiftUI의 Dynamic Type 크기를 따라야 한다면 `updateUIView`에서 `context.environment.dynamicTypeSize`를 읽고 적절한 폰트를 선택할 수 있어요. 다만 UIKit이 이미 trait으로 같은 시스템 값을 전달받는다면 중복 변환을 만들 필요는 없어요.
+
+## 언제 Representable을 사용해야 하나요
+
+다음 조건에서는 좋은 경계가 될 수 있어요.
+
+- SwiftUI에 없는 시스템 컨트롤이나 기존 UIKit 컴포넌트를 재사용해요.
+- UIKit SDK가 제공하는 delegate 기반 기능을 그대로 활용해야 해요.
+- UIKit 대상과 SwiftUI 상태 사이의 입력·출력을 좁은 API로 정의할 수 있어요.
+- 장기적으로 UIKit 구현을 교체하더라도 바깥 SwiftUI 화면은 유지하고 싶어요.
+
+다음 경우에는 먼저 순수 SwiftUI 구현을 검토하세요.
+
+- SwiftUI 기본 컨트롤이 같은 사용자 경험과 접근성을 이미 제공해요.
+- Representable이 많은 상태 복제와 수동 레이아웃을 요구해요.
+- UIKit 객체의 내부 동작에 지나치게 의존해 어댑터가 화면 전체를 대신하게 돼요.
+
+## 적용 순서를 정리해요
+
+1. 재사용 대상이 `UIView`인지 `UIViewController`인지 확인하세요.
+2. SwiftUI가 소유할 단일 상태를 `State`, 관찰 모델, 상위 binding 중 하나로 정하세요.
+3. `make`에는 생성과 한 번만 필요한 연결을 넣으세요.
+4. `update`에는 최신 입력 반영만 넣고 같은 값이면 건너뛰세요.
+5. UIKit 이벤트는 Coordinator를 거쳐 binding이나 명시적인 클로저로 돌려보내세요.
+6. delegate, observer, 타이머, 비동기 작업은 `dismantle`에서 정리하세요.
+7. 상태 변경, 화면 제거, 재표시, 회전과 Dynamic Type을 확인하세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `makeUIView`와 `updateUIView`의 역할은 어떻게 다른가요?
+
+`makeUIView`는 UIKit 뷰를 만들고 한 번만 필요한 target이나 delegate 연결을 설정해요. `updateUIView`는 SwiftUI의 현재 상태와 환경을 이미 존재하는 UIKit 뷰에 반복해서 반영하므로 멱등하게 작성해야 해요.
+
+### Coordinator가 필요한 이유는 무엇인가요?
+
+Representable은 다시 만들어질 수 있는 값 타입이지만 UIKit delegate와 target-action은 오래 살아 있는 참조 객체를 필요로 해요. Coordinator가 UIKit 이벤트를 받고 최신 `Binding`이나 클로저로 전달해 두 생명주기를 연결해요.
+
+### `updateUIView`에서 왜 현재 값과 새 값을 비교하나요?
+
+SwiftUI는 여러 원인으로 update를 호출할 수 있고, UIKit 속성 변경이 다시 이벤트를 발생시킬 수도 있기 때문이에요. 값이 실제로 다를 때만 UIKit 객체를 바꾸면 불필요한 작업과 피드백 루프를 줄일 수 있어요.
+
+### `dismantle` 메서드는 언제 필요한가요?
+
+대상이 SwiftUI 계층에서 제거되기 전에 delegate, observer, 타이머, 비동기 작업처럼 어댑터가 만든 외부 연결을 정리할 때 필요해요. 기본 구현이 있으므로 정리할 것이 없다면 생략할 수 있어요.
+
+## 참고 자료
+
+- [UIViewRepresentable](https://developer.apple.com/documentation/swiftui/uiviewrepresentable)
+- [UIViewRepresentableContext](https://developer.apple.com/documentation/swiftui/uiviewrepresentablecontext)
+- [UIViewControllerRepresentable](https://developer.apple.com/documentation/swiftui/uiviewcontrollerrepresentable)
+- [UIViewControllerRepresentableContext](https://developer.apple.com/documentation/swiftui/uiviewcontrollerrepresentablecontext)
+- [UIColorPickerViewController](https://developer.apple.com/documentation/uikit/uicolorpickerviewcontroller)
+- [Managing user interface state](https://developer.apple.com/documentation/swiftui/managing-user-interface-state)


### PR DESCRIPTION
## Summary

Apple의 UIKit integration 공식 문서를 바탕으로 SwiftUI와 UIKit을 양방향으로 연결하는 입문자용 학습 섹션을 추가합니다. API 나열보다 기존 UIKit 앱의 점진적 SwiftUI 도입, 상태·이벤트·크기·생명주기 경계와 지원 OS에 따른 선택 기준을 중심으로 구성했습니다.

## Changes

- `SwiftUI > UIKit 통합` 최상위 내비게이션과 사이드바 섹션을 추가했습니다.
- 통합 방향, API 선택표, 지원 OS, 점진적 마이그레이션 순서를 한눈에 보는 개요 문서를 추가했습니다.
- `UIHostingController`의 present·containment·공유 모델·크기 협상과 `UIHostingConfiguration` 셀 예제를 작성했습니다.
- `UIViewRepresentable`과 `UIViewControllerRepresentable`의 make·update·dismantle, Coordinator와 Binding 양방향 예제를 작성했습니다.
- 단일 데이터 원천, 반복 update, identity, 피드백 루프, 레이아웃 소유권, 메모리 해제와 테스트 기준을 정리했습니다.
- iOS 17의 trait–environment 브리지, iOS 18의 UIKit 제스처·통합 애니메이션, iOS 26 scene 브리지와 visionOS 전용 API 범위를 설명했습니다.
- 모든 새 페이지에 한국어 title과 50~160자의 description, 면접 한 줄 요약, 용어 설명, 적용 체크리스트, 후속 질문과 Apple 공식 참고 자료를 추가했습니다.

## Testing

- `xcrun --sdk iphonesimulator swiftc -typecheck ...` — 주요 SwiftUI·UIKit 예제를 iOS 18 시뮬레이터 SDK에서 타입 검사
- `npm run format`
- `npm run lint`
- `npm run docs:check-collection-views`
- `npm run docs:check-combine-operators`
- `npm run docs:check-rxswift-operators`
- `npm run build`
- `npm run dev -- --host 127.0.0.1` — 새 문서 5개 경로의 HTTP 200 응답 확인
- 새 문서의 상대 링크 대상과 Apple 공식 외부 링크 19개의 응답 확인
- `git diff --check`
- 최신 `origin/main`과 `git merge-tree --write-tree HEAD origin/main`으로 충돌 없음 확인

## Related Issues

Closes #23

## Notes

- 기본 통합 API의 도입 버전과 예제에서 사용하는 개별 SwiftUI API의 지원 버전을 구분했습니다.
- Rspress 빌드는 성공했으며 로컬 persistent cache 저장 경고가 발생한 경우 캐시를 비활성화한 뒤 빌드를 정상 완료했습니다.
