### PR TITLE
[#27] SwiftUI ObservableObject와 Observation 상태 관리 문서를 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -7,7 +7,7 @@
   },
   {
     "text": "SwiftUI",
-    "link": "/guide/swiftui/uikit-integration/index",
+    "link": "/guide/swiftui/state-management/observable-object",
     "activeMatch": "/guide/swiftui/",
     "position": "left"
   },

--- a/docs/guide/swiftui/_meta.json
+++ b/docs/guide/swiftui/_meta.json
@@ -1,6 +1,13 @@
 [
   {
     "type": "dir",
+    "name": "state-management",
+    "label": "상태 관리",
+    "collapsible": true,
+    "collapsed": false
+  },
+  {
+    "type": "dir",
     "name": "uikit-integration",
     "label": "UIKit 통합",
     "collapsible": true,

--- a/docs/guide/swiftui/state-management/_meta.json
+++ b/docs/guide/swiftui/state-management/_meta.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "file",
+    "name": "observable-object",
+    "label": "ObservableObject와 상태 객체"
+  },
+  {
+    "type": "file",
+    "name": "observation",
+    "label": "@Observable과 Observation"
+  }
+]

--- a/docs/guide/swiftui/state-management/observable-object.md
+++ b/docs/guide/swiftui/state-management/observable-object.md
@@ -1,0 +1,419 @@
+---
+title: SwiftUI ObservableObject와 상태 객체 래퍼
+description: ObservableObject와 @StateObject, @ObservedObject, @EnvironmentObject의 소유권·생명주기·전달 방식과 선택 기준을 SwiftUI 예제로 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# SwiftUI ObservableObject와 상태 객체 래퍼
+
+> **면접 답변 한 줄 요약:** `ObservableObject`는 변경 알림을 보내는 참조형 모델의 약속이고, `@StateObject`는 View가 모델을 생성해 소유할 때, `@ObservedObject`는 외부 모델을 직접 전달받을 때, `@EnvironmentObject`는 조상 View가 환경으로 주입한 모델을 읽을 때 사용해요.
+
+SwiftUI 화면에서 여러 값이 함께 바뀌거나 여러 하위 View가 같은 데이터를 사용하면 상태를 클래스 하나에 모으고 싶을 수 있어요. 이때 `ObservableObject`, `@StateObject`, `@ObservedObject`, `@EnvironmentObject`가 한꺼번에 등장해요.
+
+네 이름은 비슷하지만 같은 종류가 아니에요. `ObservableObject`는 모델이 변경 알림을 제공한다는 **프로토콜**이고, 나머지 세 개는 SwiftUI View가 그 모델을 어떤 경로로 얻고 관찰하는지 나타내는 **프로퍼티 래퍼**예요.
+
+이 문서는 독서 목표를 기록하는 앱을 예로 들어 다음 질문에 답해요.
+
+- 어떤 프로퍼티가 바뀌었다고 SwiftUI에 알리나요?
+- View가 모델을 직접 만들었다면 어떤 래퍼로 수명을 유지하나요?
+- 부모가 만든 모델을 자식이 받을 때는 무엇을 사용하나요?
+- 여러 단계 아래의 View에 같은 모델을 전달하려면 어떻게 하나요?
+- View identity가 바뀌거나 환경 주입을 빠뜨리면 무슨 일이 생기나요?
+- iOS 17 이상의 `@Observable`과는 어떻게 다른가요?
+
+## 먼저 알아둘 상태 관리 용어
+
+| 용어              | 쉬운 뜻                                                                                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 상태(state)       | 화면의 현재 모습을 결정하는 값이에요. 완료한 독서 시간이나 일일 목표가 달라지면 화면도 달라져요.                                                         |
+| 단일 데이터 원천  | 같은 의미의 값을 여러 곳에 복사하지 않고 한 인스턴스를 기준값으로 삼는 원칙이에요.                                                                       |
+| 참조 타입         | 클래스처럼 여러 변수가 같은 인스턴스를 가리킬 수 있는 타입이에요. 한 곳에서 프로퍼티를 바꾸면 같은 인스턴스를 가진 다른 곳에서도 바뀐 값을 읽어요.       |
+| 관찰(observation) | 모델의 변경을 알아차리고 그 모델에 의존하는 화면을 다시 계산하게 연결하는 일이에요.                                                                      |
+| publisher         | Combine에서 값이나 이벤트를 구독자에게 시간 순서대로 전달하는 타입이에요. `ObservableObject`는 변경 직전 이벤트를 publisher로 보내요.                    |
+| 프로퍼티 래퍼     | 프로퍼티의 저장과 접근 규칙을 `@이름` 문법으로 적용하는 Swift 기능이에요. 기본 원리는 [Property Wrapper](../../swift/property-wrappers) 문서에서 다뤄요. |
+| View identity     | SwiftUI가 이전 View와 새 View를 같은 화면 요소로 연결할 때 사용하는 정체성이에요. identity가 유지되면 SwiftUI가 관리하는 상태 저장소도 이어져요.         |
+| 환경(environment) | 조상 View가 넣은 값을 여러 하위 View가 타입이나 key path로 찾을 수 있는 계층형 저장 공간이에요.                                                          |
+| Binding           | 값을 읽을 뿐 아니라 원래 저장 위치에 변경을 다시 기록하는 양방향 연결이에요. `$`로 얻는 경우가 많아요.                                                   |
+| 소유권            | 여기서는 모델 인스턴스를 누가 만들고 수명을 결정하는지 뜻해요. ARC의 강한 참조 소유권과 연결되지만, SwiftUI 상태 저장소의 책임에 초점을 맞춰 사용해요.   |
+
+## body에서 모델을 만들면 화면 상태를 유지하기 어려워요
+
+가장 먼저 피해야 할 코드는 `body`를 계산할 때마다 모델을 새로 만드는 방식이에요.
+
+```swift
+import SwiftUI
+
+final class ReadingStore {
+  var completedMinutes = 0
+
+  func record(minutes: Int) {
+    completedMinutes += minutes
+  }
+}
+
+struct ReadingDashboard: View {
+  var body: some View {
+    let store = ReadingStore()
+
+    VStack {
+      Text("완료: \(store.completedMinutes)분")
+
+      Button("10분 기록") {
+        store.record(minutes: 10)
+      }
+    }
+  }
+}
+```
+
+이 코드에는 두 문제가 있어요.
+
+1. `ReadingStore`는 값을 바꿔도 SwiftUI에 변경 이벤트를 보내지 않아요.
+2. SwiftUI가 `body`를 다시 계산하면 새 `ReadingStore`를 만들 수 있어 기존 인스턴스의 상태를 화면 수명과 연결하지 못해요.
+
+클래스의 프로퍼티가 바뀌었다는 사실만으로 SwiftUI가 자동으로 화면을 다시 계산하지는 않아요. 먼저 모델이 변경 알림을 제공하게 만들고, 그다음 View가 모델을 얻는 경로에 맞는 래퍼를 선택해야 해요.
+
+## ObservableObject는 변경 알림을 제공하는 프로토콜이에요
+
+`ObservableObject`는 Combine이 제공하는 클래스 전용 프로토콜이에요. 모델이 이 프로토콜을 따르면 `objectWillChange` publisher로 변경 직전 이벤트를 보낼 수 있어요.
+
+독서 상태 모델을 `ObservableObject`로 바꿔 볼게요.
+
+```swift
+import Combine
+
+@MainActor
+final class ReadingStore: ObservableObject {
+  @Published private(set) var completedMinutes = 0
+  @Published var dailyGoal = 30
+
+  var progress: Double {
+    guard dailyGoal > 0 else { return 0 }
+
+    return min(
+      Double(completedMinutes) / Double(dailyGoal),
+      1
+    )
+  }
+
+  func record(minutes: Int) {
+    completedMinutes += max(minutes, 0)
+  }
+}
+```
+
+각 요소의 역할은 다음과 같아요.
+
+- `ObservableObject`는 모델이 변경 알림을 제공한다는 약속이에요.
+- `@Published`는 프로퍼티가 바뀌기 전에 `objectWillChange`가 이벤트를 보내도록 연결해요.
+- `private(set)`은 화면이 `completedMinutes`를 읽을 수 있지만 기록은 `record(minutes:)`을 통해서만 하게 만들어요.
+- `@MainActor`는 UI 모델의 프로퍼티 접근과 변경을 main actor에 격리해요. `ObservableObject` 자체가 main thread 실행을 자동으로 보장하는 것은 아니에요.
+
+`@Published`는 클래스 프로퍼티에 사용하는 Combine 프로퍼티 래퍼예요. `$dailyGoal`은 값이 아니라 `Published.Publisher`를 제공해서 Combine 코드가 변화를 구독할 수 있게 해요.
+
+```swift
+let cancellable = store.$dailyGoal.sink { goal in
+  print("새 목표:", goal)
+}
+```
+
+`@Published` publisher는 `willSet` 시점에 새 값을 보내요. sink 안에서 전달받은 `goal`은 새 값이지만 같은 순간에 `store.dailyGoal`을 직접 읽으면 아직 이전 값일 수 있어요.
+
+## StateObject는 View가 만든 모델의 수명을 관리해요
+
+`ReadingDashboard`가 `ReadingStore`의 생성자라면 `@StateObject`를 사용해요.
+
+```swift
+import SwiftUI
+
+struct ReadingDashboard: View {
+  @StateObject private var store = ReadingStore()
+
+  var body: some View {
+    VStack(spacing: 16) {
+      Text("완료: \(store.completedMinutes)분")
+
+      ProgressView(value: store.progress)
+
+      Button("10분 기록") {
+        store.record(minutes: 10)
+      }
+
+      GoalEditor(store: store)
+    }
+    .padding()
+  }
+}
+```
+
+`@StateObject`는 View 구조체 안에 클래스 인스턴스를 단순히 저장하는 문법이 아니에요. SwiftUI가 View identity와 연결된 별도 저장소에서 인스턴스를 관리해요.
+
+```text
+ReadingDashboard 값이 다시 만들어짐
+              │
+              ▼
+같은 View identity인가요?
+       │              │
+      예             아니요
+       │              │
+       ▼              ▼
+기존 ReadingStore   새 ReadingStore
+인스턴스 재사용      인스턴스 생성
+```
+
+부모 상태가 바뀌어 `ReadingDashboard` 값과 `body`가 여러 번 다시 계산돼도 identity가 같으면 `ReadingStore()` 초기값의 인스턴스를 계속 사용해요. 반대로 `.id(...)`, 조건 분기, 목록 identity 변화 등으로 View identity가 바뀌면 새 상태 객체를 만들 수 있어요.
+
+Apple은 `@StateObject` 프로퍼티를 `private`으로 선언하라고 권장해요. 외부 memberwise initializer로 상태 객체를 교체하는 경로를 막아 SwiftUI가 관리하는 저장소와 충돌하지 않게 하기 위해서예요.
+
+`ObservableObject`와 `@ObservedObject`는 iOS 13부터 사용할 수 있지만 `@StateObject`는 iOS 14부터 제공돼요. iOS 13까지 지원하는 코드에서는 상위 소유자가 모델을 만들고 하위 View가 `@ObservedObject`로 받는 구조 등을 별도로 설계해야 해요.
+
+## StateObject의 초기값은 입력이 바뀔 때 자동으로 다시 만들어지지 않아요
+
+상태 객체의 초기값이 View 입력에 의존한다면 backing storage인 `_store`를 명시적으로 초기화할 수 있어요.
+
+```swift
+struct GoalDashboard: View {
+  @StateObject private var store: ReadingStore
+
+  init(initialGoal: Int) {
+    _store = StateObject(
+      wrappedValue: ReadingStore(
+        dailyGoal: initialGoal
+      )
+    )
+  }
+
+  var body: some View {
+    Text("목표: \(store.dailyGoal)분")
+  }
+}
+```
+
+이 예제를 사용하려면 `ReadingStore`에 `init(dailyGoal:)`을 추가해야 해요. 중요한 점은 SwiftUI가 같은 View identity에서 상태 객체의 초기화 클로저를 **처음 한 번만** 사용한다는 것이에요.
+
+부모가 `initialGoal`을 30에서 60으로 바꾸면 `GoalDashboard.init(initialGoal:)`은 다시 호출될 수 있지만 기존 `ReadingStore`의 `dailyGoal`이 자동으로 60이 되지는 않아요. 초기 입력이 해당 View identity 동안 변하지 않는 설정일 때만 이 방식을 사용하세요.
+
+입력 변화에 따라 같은 모델을 갱신해야 한다면 부모가 모델을 소유하고 전달하거나 `onChange`에서 명시적으로 동기화하는 편이 의도가 분명해요. `.id(initialGoal)`로 identity를 바꾸면 상태 객체도 다시 만들 수 있지만, 그 View가 가진 `@State`, `@FocusState` 같은 다른 상태도 함께 초기화되고 불필요한 생성 비용이 생길 수 있어요.
+
+## ObservedObject는 외부에서 받은 모델을 관찰해요
+
+부모가 만든 `ReadingStore`를 자식 View가 직접 전달받는다면 `@ObservedObject`를 사용해요.
+
+```swift
+struct GoalEditor: View {
+  @ObservedObject var store: ReadingStore
+
+  var body: some View {
+    Stepper(
+      "하루 목표: \(store.dailyGoal)분",
+      value: $store.dailyGoal,
+      in: 10...180,
+      step: 10
+    )
+  }
+}
+```
+
+`GoalEditor`는 `ReadingStore`를 만들지 않아요. 부모의 `@StateObject`가 소유한 인스턴스를 입력으로 받고, 변경 알림을 구독해 화면을 갱신해요.
+
+```text
+ReadingDashboard
+@StateObject store ── 생성·수명 관리
+         │
+         └── GoalEditor(store: store)
+                 @ObservedObject ── 전달받아 관찰
+```
+
+`@ObservedObject`는 외부 입력을 위한 래퍼이므로 다음처럼 기본값으로 새 모델을 만들지 않는 편이 좋아요.
+
+```swift
+// 피해야 할 방식
+struct UnstableEditor: View {
+  @ObservedObject var store = ReadingStore()
+
+  var body: some View {
+    Text("\(store.dailyGoal)")
+  }
+}
+```
+
+이 View가 새 값으로 만들어질 때 `ReadingStore()`도 다시 평가돼요. `@ObservedObject`는 전달받은 객체를 구독하지만 그 객체의 안정적인 저장소를 View identity에 연결하는 역할은 하지 않아요. 직접 생성한 모델을 유지해야 한다면 `@StateObject`가 맞아요.
+
+### $store.dailyGoal은 Binding이에요
+
+앞의 `GoalEditor`에서 사용한 `$store.dailyGoal`은 `Binding<Int>`예요. `$store`는 `ObservedObject`의 projected value이고, dynamic member lookup으로 모델의 쓰기 가능한 프로퍼티에 Binding을 만들어요.
+
+비슷해 보이는 두 표현을 구분하세요.
+
+| 표현               | 만들어지는 값              | 사용하는 곳                             |
+| ------------------ | -------------------------- | --------------------------------------- |
+| `store.$dailyGoal` | `Published<Int>.Publisher` | Combine 구독과 연산자 체인              |
+| `$store.dailyGoal` | `Binding<Int>`             | `Stepper`, `TextField`, `Toggle` 입력값 |
+
+## EnvironmentObject는 조상 View가 주입한 모델을 찾아요
+
+여러 단계 아래의 View가 같은 모델을 사용하고 중간 View가 그 모델을 전달할 이유가 없다면 환경에 넣을 수 있어요.
+
+먼저 소유자가 모델을 만들고 하위 계층에 주입해요.
+
+```swift
+@main
+struct ReadingApp: App {
+  @StateObject private var store = ReadingStore()
+
+  var body: some Scene {
+    WindowGroup {
+      ReadingDashboard()
+        .environmentObject(store)
+    }
+  }
+}
+```
+
+하위 View는 생성자 매개변수 없이 같은 타입의 객체를 읽어요.
+
+```swift
+struct ReadingSummary: View {
+  @EnvironmentObject private var store: ReadingStore
+
+  var body: some View {
+    VStack {
+      Text("오늘 \(store.completedMinutes)분")
+      ProgressView(value: store.progress)
+    }
+  }
+}
+```
+
+`@EnvironmentObject`가 객체를 소유하는 것은 아니에요. 조상 계층의 `.environmentObject(store)`가 제공한 인스턴스를 타입으로 찾고 관찰해요.
+
+환경 주입은 매개변수 전달을 줄이지만 의존성이 View의 initializer에 보이지 않아요. 앱 전역 세션, 사용자 설정, 깊은 화면 계층이 공유하는 모델처럼 넓은 범위에서 실제로 공유하는 상태에 사용하고, 가까운 부모와 자식 사이에서는 명시적인 `@ObservedObject` 입력을 우선 검토하세요.
+
+### 환경 객체를 주입하지 않으면 런타임 오류가 나요
+
+`@EnvironmentObject private var store: ReadingStore`는 해당 타입의 객체가 조상에 반드시 있다고 가정해요. `.environmentObject(store)`를 빠뜨리면 컴파일은 되지만 View를 평가할 때 필요한 객체를 찾지 못해 런타임 오류가 발생해요.
+
+Preview와 테스트도 별도의 View 계층이므로 직접 주입해야 해요.
+
+```swift
+#Preview {
+  ReadingSummary()
+    .environmentObject(ReadingStore())
+}
+```
+
+같은 구체 타입의 환경 객체로 서로 다른 역할을 구분하려 하면 어떤 인스턴스를 읽는지 코드만 보고 이해하기 어려워요. 역할이 다르면 `UserSessionStore`, `ReadingSettingsStore`처럼 타입 자체를 나누는 편이 안전해요.
+
+## 네 이름을 소유권과 전달 경로로 비교해요
+
+| 이름                 | 종류                  | 객체를 누가 만드나요?           | View가 하는 일                       | 대표적인 사용 위치             |
+| -------------------- | --------------------- | ------------------------------- | ------------------------------------ | ------------------------------ |
+| `ObservableObject`   | Combine 프로토콜      | 이 프로토콜이 결정하지 않아요.  | 변경 publisher를 제공할 약속을 해요. | 모델 클래스 선언               |
+| `@StateObject`       | SwiftUI 프로퍼티 래퍼 | 이 래퍼를 선언한 View·App·Scene | 객체 저장소를 만들고 관찰해요.       | 상태 모델의 소유자             |
+| `@ObservedObject`    | SwiftUI 프로퍼티 래퍼 | 부모나 외부 조립 코드           | 전달받은 객체를 관찰해요.            | 직접 입력을 받는 자식 View     |
+| `@EnvironmentObject` | SwiftUI 프로퍼티 래퍼 | 조상 View·App·Scene             | 환경에서 객체를 찾아 관찰해요.       | 깊은 계층이 공유하는 필수 모델 |
+
+선택 순서는 객체의 타입보다 생성 책임에서 시작해요.
+
+```text
+이 View가 모델을 처음 만들고 수명을 관리하나요?
+  ├─ 예  → @StateObject
+  └─ 아니요
+       ├─ 부모가 직접 인자로 전달하나요? → @ObservedObject
+       └─ 조상 환경에서 찾나요?           → @EnvironmentObject
+```
+
+한 인스턴스를 두 군데에서 각각 `@StateObject`로 만들면 단일 데이터 원천이 두 개가 돼요. 한 곳만 소유자가 되고, 나머지는 `@ObservedObject` 또는 `@EnvironmentObject`로 같은 인스턴스를 관찰해야 해요.
+
+## State에 ObservableObject를 넣는 것과는 달라요
+
+다음 코드는 문법상 가능할 수 있지만 `ObservableObject` 모델의 내부 변경을 관찰하는 올바른 대체가 아니에요.
+
+```swift
+struct IncorrectDashboard: View {
+  @State private var store = ReadingStore()
+
+  var body: some View {
+    Text("\(store.completedMinutes)")
+  }
+}
+```
+
+`@State`는 `store` 참조 자체가 다른 인스턴스로 바뀌는 것은 관리하지만, Combine 기반 객체의 `@Published` 변경을 구독하지 않아요. `ObservableObject`의 내부 프로퍼티 변경까지 화면에 반영하려면 소유자에서 `@StateObject`를 사용해야 해요.
+
+iOS 17부터 Observation의 `@Observable`을 적용한 참조 타입은 `@State`에 저장할 수 있어요. 같은 `@State` 문법이라도 모델이 `ObservableObject`인지 Observation의 `Observable`인지에 따라 추적 방식이 다르므로 섞어서 외우지 마세요. 자세한 흐름은 [@Observable과 Observation](./observation) 문서에서 이어서 설명해요.
+
+## 테스트에서는 모델과 View 연결을 나눠 확인해요
+
+`ReadingStore`의 계산과 변경은 SwiftUI 없이 테스트할 수 있어요.
+
+```swift
+import Testing
+
+@Test
+@MainActor
+func recordsReadingProgress() {
+  let store = ReadingStore()
+
+  store.record(minutes: 15)
+
+  #expect(store.completedMinutes == 15)
+  #expect(store.progress == 0.5)
+}
+```
+
+View 테스트나 Preview에서는 다음 경계를 따로 확인하세요.
+
+- 소유 View가 같은 identity에서 `@StateObject` 인스턴스를 유지하는지 확인해요.
+- 자식이 부모와 같은 인스턴스를 `@ObservedObject`로 받는지 확인해요.
+- `@EnvironmentObject`를 사용하는 모든 Preview와 테스트 root에 객체를 주입해요.
+- 모델을 교체해야 하는 화면은 View identity 변경이 다른 로컬 상태까지 초기화하지 않는지 확인해요.
+
+## 언제 어떤 방식을 사용해야 하나요
+
+다음 기준으로 선택해 보세요.
+
+1. 모델이 Combine의 `ObservableObject`를 따르는지 확인해요.
+2. 모델 인스턴스를 처음 만드는 한 곳을 정해요.
+3. SwiftUI View가 생성자라면 `private @StateObject`로 소유해요.
+4. 가까운 자식에게는 같은 인스턴스를 `@ObservedObject`로 명시적으로 전달해요.
+5. 많은 계층이 공유하고 중간 View가 알 필요 없는 모델만 환경에 주입해요.
+6. Preview와 테스트의 환경 주입을 프로덕션 root와 함께 점검해요.
+7. 최소 지원 OS가 iOS 17 이상이면 새로운 모델에 Observation을 사용할지도 비교해요.
+
+짧은 View 하나에서 값 타입 몇 개만 관리한다면 `@State`와 `@Binding`으로 충분해요. 참조형 모델이 필요하지 않은데 모든 상태를 `ObservableObject` 클래스에 모으면 소유권과 변경 범위가 오히려 커질 수 있어요.
+
+## 면접에서 이어질 수 있는 질문
+
+### StateObject와 ObservedObject의 가장 큰 차이는 무엇인가요?
+
+객체의 저장소와 수명을 누가 관리하는지가 달라요. `@StateObject`는 선언한 View의 identity에 연결해 인스턴스를 유지하고, `@ObservedObject`는 외부에서 전달된 인스턴스의 변경만 구독해요.
+
+### ObservedObject에서 모델을 직접 생성하면 왜 문제가 되나요?
+
+`@ObservedObject`는 인스턴스를 안정적으로 보관하는 소유 래퍼가 아니기 때문이에요. View 값이 다시 만들어질 때 기본값 표현식에서 새 객체가 생길 수 있으므로 직접 생성한 모델은 `@StateObject`에 두는 편이 맞아요.
+
+### EnvironmentObject의 장점과 비용은 무엇인가요?
+
+깊은 View 계층에서 중간 매개변수 전달을 줄일 수 있어요. 반면 initializer만 보고 의존성을 알기 어렵고, 주입을 빠뜨려도 컴파일 단계에서 잡히지 않아 런타임 오류가 날 수 있어요.
+
+### Published와 ObservableObject는 어떤 관계인가요?
+
+`ObservableObject`는 객체 수준의 변경 publisher를 제공하는 프로토콜이고, `@Published`는 프로퍼티 변경을 그 알림과 연결하는 Combine 프로퍼티 래퍼예요. 직접 `objectWillChange.send()`를 호출할 수도 있지만 일반적인 저장 프로퍼티에는 `@Published`가 반복 코드를 줄여 줘요.
+
+### View identity가 StateObject에 왜 중요한가요?
+
+SwiftUI는 `@StateObject` 저장소를 View 값 자체가 아니라 identity와 연결해요. identity가 유지되면 새 View 값에도 같은 객체를 제공하고, identity가 달라지면 새 객체를 만들며 같은 View의 다른 로컬 상태도 함께 초기화할 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer — ObservableObject](https://developer.apple.com/documentation/combine/observableobject)
+- [Apple Developer — Published](https://developer.apple.com/documentation/combine/published)
+- [Apple Developer — StateObject](https://developer.apple.com/documentation/swiftui/stateobject)
+- [Apple Developer — ObservedObject](https://developer.apple.com/documentation/swiftui/observedobject)
+- [Apple Developer — EnvironmentObject](https://developer.apple.com/documentation/swiftui/environmentobject)
+- [Apple Developer — environmentObject(_:)](<https://developer.apple.com/documentation/swiftui/view/environmentobject(_:)>)
+- [Apple Developer — Managing user interface state](https://developer.apple.com/documentation/swiftui/managing-user-interface-state)
+- [Swift-KR — Property Wrapper](../../swift/property-wrappers)
+- [Swift-KR — @Observable과 Observation](./observation)

--- a/docs/guide/swiftui/state-management/observation.md
+++ b/docs/guide/swiftui/state-management/observation.md
@@ -1,0 +1,545 @@
+---
+title: SwiftUI에서 이해하는 @Observable과 Observation
+description: '@Observable 매크로의 프로퍼티 접근 기반 추적과 @State, @Bindable, @Environment 사용법, ObservableObject에서의 마이그레이션 기준을 설명합니다.'
+pageType: doc-wide
+outline: false
+---
+
+# SwiftUI에서 이해하는 @Observable과 Observation
+
+> **면접 답변 한 줄 요약:** `@Observable`은 클래스에 Observation 추적 코드를 생성하는 매크로이며, SwiftUI는 `body`가 실제로 읽은 프로퍼티의 변경만 추적하고 소유 모델은 `@State`, 전달 모델은 일반 프로퍼티, Binding이 필요할 때는 `@Bindable`, 환경 공유에는 `@Environment(Type.self)`를 사용해요.
+
+`ObservableObject`와 `@Published`로 만든 모델은 SwiftUI 상태 관리의 오랜 기본 방식이에요. 하지만 프로퍼티마다 `@Published`를 붙이고, 객체를 어디에서 얻는지에 따라 `@StateObject`, `@ObservedObject`, `@EnvironmentObject`를 선택해야 해요.
+
+iOS 17부터 SwiftUI는 Swift Observation 프레임워크와 통합돼요. 모델 클래스에 `@Observable`을 붙이면 저장 프로퍼티에 별도의 `@Published`를 붙이지 않아도 되고, View는 `body`가 실제로 읽은 프로퍼티와 의존 관계를 만들어요.
+
+이 문서는 다음 내용을 설명해요.
+
+- `@Observable` 매크로가 모델에 추가하는 역할
+- 프로퍼티 접근 기반 추적이 화면 갱신 범위를 줄이는 방법
+- 소유 모델을 `@State`에 저장하는 이유
+- 일반 프로퍼티와 `@Bindable`을 구분하는 기준
+- `@Environment(Type.self)`로 모델을 공유하는 방법
+- `@ObservationIgnored`로 추적에서 제외하는 방법
+- `ObservableObject` 코드를 단계적으로 마이그레이션하는 방법
+
+Observation의 SwiftUI 통합은 iOS 17, iPadOS 17, macOS 14, tvOS 17, watchOS 10부터 사용할 수 있어요. 더 낮은 OS를 지원한다면 [ObservableObject와 상태 객체 래퍼](./observable-object) 방식도 유지해야 해요.
+
+## 먼저 알아둘 Observation 용어
+
+| 용어                  | 쉬운 뜻                                                                                                                                                   |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Observation           | 특정 프로퍼티를 읽은 곳과 그 프로퍼티의 변경을 연결하는 Swift 관찰 시스템이에요. SwiftUI 밖에서도 사용할 수 있어요.                                       |
+| `@Observable`         | 클래스의 저장 프로퍼티 접근과 변경을 추적하도록 코드를 생성하고 `Observable` 프로토콜 준수도 추가하는 attached 매크로예요.                                |
+| `Observable`          | 타입이 Observation을 지원한다는 표시 프로토콜이에요. 프로토콜만 직접 채택해서는 추적 코드가 생기지 않으므로 모델에는 `@Observable`을 적용해야 해요.       |
+| 접근 추적             | 관찰 범위를 미리 모든 프로퍼티로 정하지 않고 실행 중 실제로 읽은 프로퍼티를 기록하는 방식이에요.                                                          |
+| source of truth       | 화면이 기준으로 삼는 상태의 원본이에요. SwiftUI가 모델 참조의 저장소를 관리해야 한다면 `@State`로 만들어요.                                               |
+| `@Bindable`           | `Observable` 모델의 쓰기 가능한 프로퍼티에서 `Binding`을 만들게 해 주는 SwiftUI 프로퍼티 래퍼예요. 객체의 소유권을 만들지는 않아요.                       |
+| `@Environment`        | View 계층의 환경에서 key path 또는 타입을 기준으로 값을 읽는 SwiftUI 프로퍼티 래퍼예요. Observation 모델은 타입 자체를 key처럼 사용할 수 있어요.          |
+| `@ObservationIgnored` | 접근 가능한 프로퍼티를 Observation 추적 대상에서 제외하는 매크로예요. 캐시나 진단용 값처럼 화면 갱신과 무관한 저장 공간에 사용할 수 있어요.               |
+| 매크로 확장           | `@Observable` 사용을 컴파일러가 일반 Swift 선언과 접근 코드로 펼치는 과정이에요. 매크로 기본 원리는 [Swift 매크로](../../swift/macros) 문서에서 설명해요. |
+
+## ObservableObject 방식은 객체 단위로 변경을 알려요
+
+먼저 기존 방식을 다시 볼게요. 독서 상태를 `ObservableObject`로 만들면 화면에 반영할 각 저장 프로퍼티에 `@Published`를 붙여요.
+
+```swift
+import Combine
+
+@MainActor
+final class ReadingStore: ObservableObject {
+  @Published private(set) var completedMinutes = 0
+  @Published var dailyGoal = 30
+  @Published var note = ""
+
+  func record(minutes: Int) {
+    completedMinutes += max(minutes, 0)
+  }
+}
+```
+
+이 모델의 published 프로퍼티가 바뀌면 `objectWillChange`가 이벤트를 보내요. `@StateObject`, `@ObservedObject`, `@EnvironmentObject`로 모델을 관찰하는 View는 객체 수준의 이벤트를 받고 `body`를 다시 계산할 수 있어요.
+
+예를 들어 한 View가 `completedMinutes`만 화면에 표시하더라도 같은 객체의 `note`가 `@Published` 변경을 보내면 그 객체를 관찰하는 View가 무효화될 수 있어요. 작은 모델에서는 문제가 되지 않지만 프로퍼티가 많고 여러 View가 나눠 읽는다면 변경 범위가 넓어질 수 있어요.
+
+## Observable 매크로는 프로퍼티 추적 코드를 생성해요
+
+같은 모델을 Observation으로 바꾸면 `ObservableObject` 준수와 `@Published`를 제거하고 클래스에 `@Observable`을 붙여요.
+
+```swift
+import Observation
+
+@MainActor
+@Observable
+final class ReadingStore {
+  private(set) var completedMinutes = 0
+  var dailyGoal = 30
+  var note = ""
+
+  @ObservationIgnored
+  var diagnosticMessage = ""
+
+  var progress: Double {
+    guard dailyGoal > 0 else { return 0 }
+
+    return min(
+      Double(completedMinutes) / Double(dailyGoal),
+      1
+    )
+  }
+
+  func record(minutes: Int) {
+    completedMinutes += max(minutes, 0)
+  }
+}
+```
+
+`@Observable`은 런타임에 주기적으로 프로퍼티를 비교하는 객체가 아니에요. 컴파일할 때 모델의 프로퍼티 접근과 변경을 Observation registrar에 연결하는 코드를 생성하고 `Observable` 프로토콜 준수도 추가해요.
+
+따라서 다음처럼 프로토콜만 직접 적는 것은 충분하지 않아요.
+
+```swift
+// 추적 코드를 생성하지 않으므로 이렇게 사용하지 않아요.
+final class IncorrectStore: Observable {
+  var completedMinutes = 0
+}
+```
+
+Apple도 Observation 지원을 추가할 때 `Observable` 프로토콜만 직접 채택하지 말고 `@Observable` 매크로를 사용하라고 안내해요.
+
+`@ObservationIgnored`를 붙인 `diagnosticMessage`는 읽고 바꿀 수 있지만 그 접근은 View의 Observation 의존성에 포함되지 않아요. 화면과 무관한 캐시, logger, 진단 카운터를 추적에서 제외할 수 있지만 실제 UI를 결정하는 값을 제외하면 화면이 갱신되지 않으므로 목적을 명확히 해야 해요.
+
+## SwiftUI는 body가 실제로 읽은 프로퍼티를 추적해요
+
+Observation의 핵심은 **객체 전체를 구독하는 대신 View 계산에서 접근한 프로퍼티를 기록한다**는 점이에요.
+
+```swift
+struct CompletedMinutesView: View {
+  let store: ReadingStore
+
+  var body: some View {
+    Text("완료: \(store.completedMinutes)분")
+  }
+}
+
+struct GoalView: View {
+  let store: ReadingStore
+
+  var body: some View {
+    Text("목표: \(store.dailyGoal)분")
+  }
+}
+```
+
+각 View의 의존 관계를 나누면 다음과 같아요.
+
+```text
+CompletedMinutesView.body
+└─ store.completedMinutes를 읽음
+   └─ completedMinutes가 바뀔 때 갱신
+
+GoalView.body
+└─ store.dailyGoal을 읽음
+   └─ dailyGoal이 바뀔 때 갱신
+```
+
+`store.note`가 바뀌어도 두 View의 `body`는 그 프로퍼티를 읽지 않았으므로 해당 변경만으로 갱신되지 않아요. 반대로 `Text(store.note)`를 추가하면 그 View는 `note`에도 의존하게 돼요.
+
+이 추적은 프로퍼티 이름을 소스에서 단순 검색한 결과가 아니에요. `body`가 실행되는 동안 실제 접근을 기록해요. 조건에 따라 읽는 프로퍼티가 달라지거나 계산 프로퍼티가 다른 observable 프로퍼티를 읽는 경우에도 실행된 접근을 기준으로 관계를 만들어요.
+
+```swift
+struct ProgressViewCard: View {
+  let store: ReadingStore
+
+  var body: some View {
+    VStack {
+      Text("진행률")
+      ProgressView(value: store.progress)
+    }
+  }
+}
+```
+
+`progress` 계산 프로퍼티가 `completedMinutes`와 `dailyGoal`을 읽으므로 둘 중 하나가 바뀌면 `ProgressViewCard`가 갱신돼요.
+
+SwiftUI 밖에서는 `withObservationTracking(_:onChange:)`이 같은 원리를 드러내요. `apply` 클로저에서 접근한 프로퍼티를 기록하고 참여한 값이 바뀌면 `onChange`를 호출해요. SwiftUI는 View 계산에 필요한 등록과 다시 계산하는 과정을 프레임워크 내부에서 처리하므로 일반적인 View 코드가 이 함수를 직접 호출할 필요는 없어요.
+
+## 소유자가 만든 Observable 모델은 State에 저장해요
+
+`ReadingDashboard`가 모델을 만들고 View identity 동안 유지해야 한다면 `@State`를 사용해요.
+
+```swift
+import SwiftUI
+
+struct ReadingDashboard: View {
+  @State private var store = ReadingStore()
+
+  var body: some View {
+    VStack(spacing: 16) {
+      CompletedMinutesView(store: store)
+      ProgressViewCard(store: store)
+
+      Button("10분 기록") {
+        store.record(minutes: 10)
+      }
+
+      GoalEditor(store: store)
+    }
+    .padding()
+  }
+}
+```
+
+`@State`는 `ReadingStore`의 참조를 SwiftUI가 관리하는 저장소에 연결해 source of truth를 만들어요. View 값이 다시 생성돼도 identity가 같으면 관리 중인 참조를 다시 제공해요. 모델이 `@Observable`이므로 SwiftUI는 참조 교체뿐 아니라 `body`가 읽은 내부 프로퍼티 변경도 추적해요.
+
+여기서 `@StateObject`를 기계적으로 `@State`의 옛 이름이라고 이해하면 안 돼요.
+
+- `@StateObject`는 Combine의 `ObservableObject`를 저장하고 객체 변경 publisher를 구독해요.
+- `@State`는 일반 값의 저장소이며, `@Observable` 참조를 저장하면 Observation 접근 추적과 함께 동작해요.
+
+`@State private var store = ReadingStore()`의 기본값 표현식은 View 값이 초기화될 때 평가될 수 있어요. 네트워크 요청, 파일 읽기, 무거운 객체 그래프 구성 같은 부수 효과를 모델 initializer에 넣지 마세요. 비동기 준비가 필요하면 optional 상태와 `.task` 등을 이용해 View가 나타난 뒤 명시적으로 실행하는 편이 좋아요.
+
+## 전달받은 모델은 일반 프로퍼티로도 관찰돼요
+
+Observation 모델은 자식 View에서 `@ObservedObject`로 감쌀 필요가 없어요. 참조를 일반 저장 프로퍼티로 받고 `body`에서 필요한 값을 읽으면 SwiftUI가 의존성을 추적해요.
+
+```swift
+struct ReadingSummary: View {
+  let store: ReadingStore
+
+  var body: some View {
+    VStack {
+      Text("오늘 \(store.completedMinutes)분")
+      ProgressView(value: store.progress)
+    }
+  }
+}
+```
+
+`ReadingSummary`는 모델을 소유하지 않고 부모가 전달한 참조를 사용해요. `let`이어도 클래스의 쓰기 가능한 프로퍼티는 모델이 허용하는 범위에서 변경할 수 있지만, 읽기 전용 화면이라면 `let`이 입력 의도를 더 잘 보여 줘요.
+
+`@ObservedObject`는 generic constraint가 `ObservableObject`인 기존 시스템의 래퍼예요. `@Observable`만 적용한 모델을 `@ObservedObject`로 감싸면 필요한 프로토콜이 달라 컴파일 오류가 날 수 있어요.
+
+## Binding이 필요할 때만 Bindable을 사용해요
+
+버튼 action에서는 모델 참조만으로 프로퍼티를 바꿀 수 있어요.
+
+```swift
+struct QuickRecordButton: View {
+  let store: ReadingStore
+
+  var body: some View {
+    Button("10분 기록") {
+      store.record(minutes: 10)
+    }
+  }
+}
+```
+
+하지만 `Stepper`, `TextField`, `Toggle`처럼 `Binding`을 요구하는 컨트롤에는 `$` 투영값이 필요해요. 이때 `@Bindable`로 observable 모델의 쓰기 가능한 프로퍼티에 Binding을 만들어요.
+
+```swift
+struct GoalEditor: View {
+  @Bindable var store: ReadingStore
+
+  var body: some View {
+    Form {
+      Stepper(
+        "하루 목표: \(store.dailyGoal)분",
+        value: $store.dailyGoal,
+        in: 10...180,
+        step: 10
+      )
+
+      TextField("메모", text: $store.note)
+    }
+  }
+}
+```
+
+`@Bindable`의 책임은 소유권이나 수명 관리가 아니라 Binding 생성이에요. 이미 부모나 환경에서 받은 객체에 적용하며, `@State`를 대신해 모델을 소유한다고 생각하면 안 돼요.
+
+View 입력은 일반 프로퍼티로 유지하고 `body`의 일부에서만 Binding이 필요하다면 지역 변수로 만들 수도 있어요.
+
+```swift
+struct InlineGoalEditor: View {
+  let store: ReadingStore
+
+  var body: some View {
+    @Bindable var store = store
+
+    Stepper(
+      "하루 목표: \(store.dailyGoal)분",
+      value: $store.dailyGoal,
+      in: 10...180,
+      step: 10
+    )
+  }
+}
+```
+
+## 환경 공유에는 Environment와 environment를 사용해요
+
+앱이나 상위 View가 만든 Observation 모델을 깊은 계층에 공유하려면 타입 기반 환경 값을 사용할 수 있어요.
+
+```swift
+@main
+struct ReadingApp: App {
+  @State private var store = ReadingStore()
+
+  var body: some Scene {
+    WindowGroup {
+      ReadingRootView()
+        .environment(store)
+    }
+  }
+}
+```
+
+하위 View는 `@Environment`에 타입을 전달해 같은 인스턴스를 읽어요.
+
+```swift
+struct EnvironmentSummary: View {
+  @Environment(ReadingStore.self)
+  private var store
+
+  var body: some View {
+    Text("오늘 \(store.completedMinutes)분")
+  }
+}
+```
+
+대응 관계를 기존 시스템과 비교하면 다음과 같아요.
+
+| ObservableObject 방식                 | Observation 방식                     |
+| ------------------------------------- | ------------------------------------ |
+| `.environmentObject(store)`           | `.environment(store)`                |
+| `@EnvironmentObject var store: Store` | `@Environment(Store.self) var store` |
+
+`@Environment(ReadingStore.self)`은 기본적으로 해당 타입의 non-optional 인스턴스가 조상 계층에 있다고 가정해요. 주입하지 않으면 View 평가 중 예외가 발생해요. 존재가 선택적이라면 타입을 optional로 선언할 수 있어요.
+
+```swift
+struct OptionalEnvironmentSummary: View {
+  @Environment(ReadingStore.self)
+  private var store: ReadingStore?
+
+  var body: some View {
+    if let store {
+      Text("오늘 \(store.completedMinutes)분")
+    } else {
+      Text("독서 기록을 연결하지 않았어요.")
+    }
+  }
+}
+```
+
+환경에서 받은 모델의 프로퍼티에 Binding이 필요하면 `body` 안에서 지역 `@Bindable`을 만들어요.
+
+```swift
+struct EnvironmentGoalEditor: View {
+  @Environment(ReadingStore.self)
+  private var store
+
+  var body: some View {
+    @Bindable var store = store
+
+    Stepper(
+      "하루 목표: \(store.dailyGoal)분",
+      value: $store.dailyGoal,
+      in: 10...180,
+      step: 10
+    )
+  }
+}
+```
+
+환경은 편리하지만 의존성이 initializer에 보이지 않는 비용은 그대로예요. 가까운 부모와 자식 사이에서는 일반 프로퍼티 전달을 우선하고, 여러 단계가 실제로 공유하는 모델에 환경을 사용하세요.
+
+## ObservableObject에서 단계적으로 옮겨요
+
+기존 앱 전체를 한 번에 바꿀 필요는 없어요. Apple은 두 관찰 시스템을 앱 안에서 함께 사용하며 모델 단위로 점진적으로 마이그레이션할 수 있다고 설명해요. 다만 하나의 모델을 바꿀 때는 선언과 그 모델을 보관·전달하는 View 코드를 함께 점검해야 해요.
+
+| 기존 ObservableObject 코드               | 완전한 Observation 전환                    | 이유                                               |
+| ---------------------------------------- | ------------------------------------------ | -------------------------------------------------- |
+| `class Store: ObservableObject`          | `@Observable final class Store`            | 매크로가 추적 코드와 `Observable` 준수를 생성해요. |
+| `@Published var goal = 30`               | `var goal = 30`                            | 접근 가능한 저장 프로퍼티를 기본으로 추적해요.     |
+| 추적하지 않을 일반 프로퍼티              | `@ObservationIgnored var cache`            | 명시적으로 Observation 추적에서 제외해요.          |
+| `@StateObject private var store`         | `@State private var store`                 | SwiftUI가 observable 참조의 저장소를 관리해요.     |
+| `@ObservedObject var store`              | `let store: Store` 또는 `var store: Store` | `body`의 프로퍼티 접근을 자동으로 추적해요.        |
+| `$store.goal`이 필요한 `@ObservedObject` | `@Bindable var store`                      | observable 프로퍼티의 Binding을 만들어요.          |
+| `@EnvironmentObject var store: Store`    | `@Environment(Store.self) var store`       | 타입 기반 환경에서 Observation 모델을 읽어요.      |
+| `.environmentObject(store)`              | `.environment(store)`                      | Observation 모델을 조상 환경에 넣어요.             |
+
+### 1단계: 모델 선언을 바꿔요
+
+```swift
+// 변경 전
+@MainActor
+final class ReadingStore: ObservableObject {
+  @Published var dailyGoal = 30
+}
+
+// 변경 후
+@MainActor
+@Observable
+final class ReadingStore {
+  var dailyGoal = 30
+}
+```
+
+### 2단계: 소유자의 래퍼를 바꿔요
+
+```swift
+// 변경 전
+@StateObject private var store = ReadingStore()
+
+// 변경 후
+@State private var store = ReadingStore()
+```
+
+### 3단계: 자식의 입력과 Binding을 구분해요
+
+```swift
+// 읽기만 하는 변경 전 코드
+@ObservedObject var store: ReadingStore
+
+// 읽기만 하는 변경 후 코드
+let store: ReadingStore
+```
+
+```swift
+// $store.dailyGoal이 필요한 변경 후 코드
+@Bindable var store: ReadingStore
+```
+
+### 4단계: 환경 주입과 조회를 함께 바꿔요
+
+```swift
+// 변경 전
+ReadingRootView()
+  .environmentObject(store)
+
+// 변경 후
+ReadingRootView()
+  .environment(store)
+```
+
+```swift
+// 변경 전
+@EnvironmentObject private var store: ReadingStore
+
+// 변경 후
+@Environment(ReadingStore.self)
+private var store
+```
+
+모델 선언만 바꾸고 View의 모든 래퍼를 그대로 두거나, 환경을 넣는 쪽만 `.environment`로 바꾸고 읽는 쪽은 `@EnvironmentObject`로 남기면 두 시스템의 타입 요구사항이 맞지 않을 수 있어요. 컴파일 오류가 나는 지점뿐 아니라 View가 실제로 읽는 프로퍼티와 갱신 범위가 달라지는지도 테스트하세요.
+
+## 두 관찰 시스템의 차이를 정리해요
+
+| 비교 기준          | `ObservableObject`와 `@Published`                  | `@Observable`과 Observation                           |
+| ------------------ | -------------------------------------------------- | ----------------------------------------------------- |
+| 도입 버전          | iOS 13, `@StateObject`는 iOS 14                    | SwiftUI 통합은 iOS 17                                 |
+| 모델 선언          | `ObservableObject` 프로토콜 준수                   | `@Observable` 매크로 적용                             |
+| 프로퍼티 표시      | 변경을 알릴 값에 `@Published`                      | 접근 가능한 저장 프로퍼티를 기본 추적                 |
+| 변경 전달 단위     | 객체의 `objectWillChange` publisher                | 관찰 중 접근한 프로퍼티                               |
+| 소유 View          | `@StateObject`                                     | `@State`                                              |
+| 직접 전달받는 View | `@ObservedObject`                                  | 일반 프로퍼티                                         |
+| Binding 생성       | `$observedObject.property`                         | `@Bindable`의 `$property`                             |
+| 환경 공유          | `.environmentObject`와 `@EnvironmentObject`        | `.environment`와 `@Environment(Type.self)`            |
+| Combine publisher  | `objectWillChange`, `$publishedProperty` 사용 가능 | 기본 Observation 자체는 Combine publisher가 아니에요. |
+| 최소 OS가 낮은 앱  | 기존 배포 대상에서 계속 사용 가능                  | availability 분기나 기존 방식 유지가 필요해요.        |
+
+`@Observable`이 항상 더 좋은 정답은 아니에요. 최소 지원 OS가 iOS 16 이하이거나 Combine publisher 체인과 직접 연결된 모델이라면 `ObservableObject`를 유지하는 편이 단순할 수 있어요. 반대로 iOS 17 이상에서 새 모델을 만들고 View별 프로퍼티 접근 범위를 좁히고 싶다면 Observation이 자연스러운 기본 선택이에요.
+
+## Observation은 실행 스레드를 자동으로 정하지 않아요
+
+`@Observable`은 변경을 추적하는 코드를 만들지만 모든 mutation을 main actor로 보내지는 않아요. UI와 밀접한 모델을 여러 task에서 변경한다면 격리 규칙을 별도로 정해야 해요.
+
+```swift
+@MainActor
+@Observable
+final class ReadingStore {
+  private(set) var completedMinutes = 0
+
+  func record(minutes: Int) {
+    completedMinutes += max(minutes, 0)
+  }
+}
+```
+
+`@MainActor`를 붙이면 모델 생성과 접근도 main actor 규칙을 따라요. 네트워크와 파일 처리를 모델 안에서 모두 main actor로 실행하라는 뜻은 아니에요. 무거운 작업은 별도 비동기 서비스에서 수행하고, 결과를 UI 모델에 반영하는 경계만 main actor로 가져오는 구조를 검토하세요.
+
+## 테스트는 모델 결과와 View 의존 범위를 나눠요
+
+모델의 비즈니스 규칙은 Observation 런타임을 직접 다루지 않고도 테스트할 수 있어요.
+
+```swift
+import Testing
+
+@Test
+@MainActor
+func recordsProgressWithObservableStore() {
+  let store = ReadingStore()
+
+  store.record(minutes: 15)
+
+  #expect(store.completedMinutes == 15)
+  #expect(store.progress == 0.5)
+}
+```
+
+View 수준에서는 다음을 추가로 확인하세요.
+
+- 한 View가 읽지 않은 프로퍼티 변경 때문에 불필요하게 다시 계산되지 않는지 확인해요.
+- `@Bindable`로 만든 `TextField`와 `Stepper` 변경이 원본 모델에 기록되는지 확인해요.
+- 환경 기반 View의 Preview와 테스트 root에 `.environment(store)`를 넣어요.
+- optional 환경을 사용한다면 모델이 없을 때의 대체 UI도 확인해요.
+- 마이그레이션 전후에 화면 갱신 범위가 달라져 숨겨진 부수 효과가 사라지거나 동작이 누락되지 않는지 확인해요.
+
+## 적용 순서를 정리해요
+
+1. 앱의 최소 지원 OS가 Observation의 SwiftUI 통합 버전을 만족하는지 확인해요.
+2. 클래스에 `@Observable`을 적용하고 `@Published`를 제거해요.
+3. 화면 갱신과 무관한 접근 가능 프로퍼티에는 필요한 경우 `@ObservationIgnored`를 붙여요.
+4. 모델을 만드는 View·App·Scene에는 `private @State`로 참조 저장소를 만들어요.
+5. 읽기만 하는 자식은 모델을 일반 프로퍼티로 받아요.
+6. 컨트롤에 Binding을 전달할 때만 `@Bindable`을 추가해요.
+7. 깊은 계층이 공유하는 모델은 `.environment`와 `@Environment(Type.self)`로 함께 바꿔요.
+8. 프로퍼티별 갱신, 환경 누락, actor 격리와 기존 Combine 연동을 테스트해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Observable 매크로와 Observable 프로토콜은 어떻게 다른가요?
+
+`Observable`은 Observation을 지원한다는 표시 프로토콜이고, `@Observable`은 프로퍼티 접근·변경 추적 코드와 그 프로토콜 준수를 생성하는 매크로예요. 프로토콜만 직접 채택해서는 필요한 추적 코드가 생기지 않아요.
+
+### Observable 모델을 자식 View에서 ObservedObject로 감싸지 않는 이유는 무엇인가요?
+
+Observation 모델은 `body`가 프로퍼티를 읽으면 SwiftUI가 자동으로 의존성을 만들어요. `@ObservedObject`는 `ObservableObject` 제약을 가진 기존 Combine 기반 래퍼이므로 읽기만 하는 Observation 모델은 일반 프로퍼티로 전달하면 돼요.
+
+### State와 Bindable은 어떤 역할 차이가 있나요?
+
+`@State`는 소유 View의 identity에 연결된 모델 참조 저장소를 만들고, `@Bindable`은 이미 존재하는 observable 모델에서 프로퍼티 Binding을 만들어요. `@Bindable`은 source of truth나 객체 수명을 만들지 않아요.
+
+### 접근 기반 추적의 장점은 무엇인가요?
+
+View의 `body`가 읽지 않은 프로퍼티가 바뀌었을 때 그 View를 갱신 대상에서 제외할 수 있어요. 큰 모델을 여러 View가 나눠 읽을 때 객체 전체 알림보다 의존 범위를 구체적으로 만들 수 있어요.
+
+### ObservableObject를 한 번에 모두 바꿔야 하나요?
+
+아니요. 앱 안에서 기존 모델과 Observation 모델을 함께 사용할 수 있어 모델 단위로 옮길 수 있어요. 다만 바꾸는 모델의 소유 래퍼, 자식 입력, Binding과 환경 주입은 같은 관찰 시스템에 맞게 함께 점검해야 해요.
+
+## 참고 자료
+
+- [Apple Developer — Observation](https://developer.apple.com/documentation/observation)
+- [Apple Developer — Observable()](<https://developer.apple.com/documentation/observation/observable()>)
+- [Apple Developer — ObservationIgnored()](<https://developer.apple.com/documentation/observation/observationignored()>)
+- [Apple Developer — withObservationTracking(_:onChange:)](<https://developer.apple.com/documentation/observation/withobservationtracking(_:onchange:)>)
+- [Apple Developer — Managing model data in your app](https://developer.apple.com/documentation/swiftui/managing-model-data-in-your-app)
+- [Apple Developer — Migrating from the Observable Object protocol to the Observable macro](https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro)
+- [Apple Developer — State](https://developer.apple.com/documentation/swiftui/state)
+- [Apple Developer — Bindable](https://developer.apple.com/documentation/swiftui/bindable)
+- [Apple Developer — Environment](https://developer.apple.com/documentation/swiftui/environment)
+- [Swift-KR — ObservableObject와 상태 객체 래퍼](./observable-object)
+- [Swift-KR — Swift 매크로](../../swift/macros)


### PR DESCRIPTION
## 요약

- SwiftUI의 `ObservableObject`, `@StateObject`, `@ObservedObject`, `@EnvironmentObject`를 소유권과 전달 경로 중심으로 한 문서에서 비교합니다.
- Observation의 `@Observable`을 별도 문서로 설명하고 `@State`, 일반 프로퍼티, `@Bindable`, `@Environment(Type.self)`의 역할과 마이그레이션 기준을 정리합니다.
- SwiftUI 내비게이션에 `상태 관리` 섹션을 추가합니다.

## 변경 사항

- 객체 생성 위치와 View identity에 따른 `@StateObject` 생명주기 설명
- `@ObservedObject`와 `@EnvironmentObject`의 주입 방식, Binding, 런타임 주의점 설명
- `@Observable`의 접근 기반 추적, `@ObservationIgnored`, 환경 주입, 동시성 설명
- `ObservableObject` 기반 코드에서 Observation으로 옮기는 단계별 예제와 비교표 추가
- 공식 Apple 문서 및 관련 Swift-KR 문서 링크 연결

## 테스트

- `npm run format`
- `npm run lint`
- `npx prettier --check .`
- `npm run build`
- Xcode 26.4 / iOS 17 Simulator SDK에서 Swift 예제 타입 검사
- 두 문서의 내부 링크, 내비게이션 JSON, Apple 공식 링크 응답 검증
- 개발 서버에서 두 신규 문서 경로 HTTP 200 확인
- 최신 `origin/main` 기준 `git merge-tree` 충돌 검사

## 관련 이슈

Closes #27
