### PR TITLE
[#29] SwiftUI 사이드바 하위 섹션을 기본으로 접는다

### DIFF
--- a/docs/guide/swiftui/_meta.json
+++ b/docs/guide/swiftui/_meta.json
@@ -4,13 +4,13 @@
     "name": "state-management",
     "label": "상태 관리",
     "collapsible": true,
-    "collapsed": false
+    "collapsed": true
   },
   {
     "type": "dir",
     "name": "uikit-integration",
     "label": "UIKit 통합",
     "collapsible": true,
-    "collapsed": false
+    "collapsed": true
   }
 ]


### PR DESCRIPTION
## Summary

- SwiftUI 사이드바의 접이식 하위 섹션을 첫 진입 시 모두 닫힌 상태로 표시합니다.

## Changes

- `상태 관리` 섹션의 `collapsed` 기본값을 `true`로 변경했습니다.
- `UIKit 통합` 섹션의 `collapsed` 기본값을 `true`로 변경했습니다.
- 섹션 순서와 사용자가 직접 펼치고 접는 동작은 유지합니다.

## Testing

- `npm run format`
- `npm run lint`
- `npm run build`
- SwiftUI `_meta.json`의 모든 접이식 디렉터리가 `collapsed: true`인지 검증
- `git diff --check`
- 최신 `origin/main` 기준 `git merge-tree` 충돌 검사

## Related Issues

Closes #29

## Notes

- 문서 본문은 변경하지 않았습니다.
