### PR TITLE
[#31] UserDefaults, AppStorage와 App Groups 데이터 공유 문서를 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -12,6 +12,12 @@
     "position": "left"
   },
   {
+    "text": "데이터 저장",
+    "link": "/guide/data-storage/userdefaults",
+    "activeMatch": "/guide/data-storage/",
+    "position": "left"
+  },
+  {
     "text": "UIKit",
     "link": "/guide/uikit/collection-views/index",
     "activeMatch": "/guide/uikit/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -11,6 +11,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "data-storage",
+    "label": "데이터 저장"
+  },
+  {
+    "type": "dir-section-header",
     "name": "uikit",
     "label": "UIKit"
   },

--- a/docs/guide/data-storage/_meta.json
+++ b/docs/guide/data-storage/_meta.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "file",
+    "name": "userdefaults",
+    "label": "UserDefaults"
+  },
+  {
+    "type": "file",
+    "name": "appstorage",
+    "label": "@AppStorage"
+  },
+  {
+    "type": "file",
+    "name": "app-groups",
+    "label": "App Groups와 Widget 공유"
+  }
+]

--- a/docs/guide/data-storage/app-groups.md
+++ b/docs/guide/data-storage/app-groups.md
@@ -1,0 +1,681 @@
+---
+title: Swift로 이해하는 App Groups와 Widget 데이터 공유
+description: App Groups의 entitlement와 sandbox 구조, shared UserDefaults·파일 container, App과 Widget timeline 데이터 공유 흐름을 상세한 Swift 예제로 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 App Groups와 Widget 데이터 공유
+
+> **면접 답변 한 줄 요약:** App Groups는 같은 개발 팀이 서명한 앱과 extension에 공통 group container 접근 권한을 부여하며, App과 Widget은 별도 프로세스에서 shared UserDefaults나 파일을 읽고 WidgetKit timeline snapshot을 교환해 데이터를 공유해요.
+
+Widget extension bundle은 앱 안에 포함되지만 Widget 코드가 앱 프로세스 안에서 계속 실행되는 것은 아니에요. 앱과 Widget은 각자의 sandbox container를 사용하므로 `UserDefaults.standard`와 일반 파일 경로도 서로 달라요.
+
+[App Groups](https://developer.apple.com/documentation/xcode/configuring-app-groups)는 이 경계에 예외를 만들어요. 두 target이 같은 App Group entitlement를 갖도록 서명하면 운영체제가 둘 다 접근할 수 있는 group container와 shared preferences domain을 제공해요.
+
+이 문서에서는 독서 목표 앱과 Widget을 예로 들어 다음 내용을 설명해요.
+
+- App target, Widget extension, 프로세스와 sandbox의 관계
+- capability, entitlement, provisioning과 group identifier의 역할
+- App Group shared container가 private container와 분리되는 구조
+- `UserDefaults(suiteName:)`으로 작은 설정을 공유하는 방법
+- `FileManager.containerURL`로 파일과 데이터베이스 위치를 얻는 방법
+- 앱이 값을 쓴 뒤 WidgetKit timeline을 갱신하는 전체 예제
+- Widget이 앱의 Binding을 실시간으로 관찰하지 못하는 이유
+- 여러 프로세스의 동시 쓰기, 보안, privacy manifest와 문제 해결 기준
+
+## 먼저 알아둘 App Groups 용어
+
+| 용어                 | 쉬운 뜻                                                                                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| target               | Xcode가 별도의 실행 파일이나 bundle로 빌드하는 단위예요. iOS 앱과 Widget extension은 같은 프로젝트에 있어도 서로 다른 target이에요.                                  |
+| containing app       | extension bundle을 포함해 설치되는 본체 앱이에요. Widget의 설정과 데이터를 준비하는 앱을 가리켜요.                                                                   |
+| app extension        | 앱의 일부 기능을 시스템 영역에 제공하는 별도 bundle과 실행 코드예요. Widget extension이 한 종류예요.                                                                 |
+| process              | 운영체제가 실행 중인 코드와 메모리를 격리하는 단위예요. 앱과 Widget은 서로 다른 프로세스에서 실행될 수 있어 전역 변수와 메모리 객체를 공유하지 않아요.               |
+| sandbox              | 실행 파일이 접근할 수 있는 파일과 시스템 자원을 제한하는 보안 경계예요. 각 앱과 extension은 기본적으로 자기 container만 접근해요.                                    |
+| container            | 앱이나 extension의 데이터 파일을 보관하도록 운영체제가 관리하는 디렉터리예요. private container와 App Group의 shared container가 따로 있어요.                        |
+| capability           | Xcode의 Signing & Capabilities에서 target이 특정 시스템 기능을 사용하도록 설정하는 항목이에요. App Groups capability를 추가하면 entitlement 설정을 관리할 수 있어요. |
+| entitlement          | 서명된 실행 파일이 특정 권한을 가진다고 운영체제에 증명하는 key-value 정보예요. App Groups는 `com.apple.security.application-groups` 배열을 사용해요.                |
+| App Group identifier | 공유 경계를 식별하는 문자열이에요. iOS에서는 `group.`으로 시작하고 예제에서는 `group.com.example.Reading`을 사용해요.                                                |
+| suite                | `UserDefaults`의 별도 설정 domain이에요. App Group identifier로 suite를 만들면 group 구성원들이 같은 preferences를 읽고 쓸 수 있어요.                                |
+| timeline             | WidgetKit이 특정 시점에 표시할 데이터 snapshot인 `TimelineEntry`의 배열이에요. Widget은 앱 화면의 live state 대신 timeline entry를 렌더링해요.                       |
+| snapshot             | 특정 순간의 데이터를 복사해 고정한 값이에요. Widget provider는 shared store를 읽어 entry snapshot을 만들고 WidgetKit에 넘겨요.                                       |
+
+## 앱과 Widget은 같은 bundle 안에 있어도 저장소가 달라요
+
+App Group을 사용하지 않은 기본 구조부터 볼게요.
+
+```text
+Reading.app
+├─ Reading 실행 파일 ── App 프로세스 ── App private container
+└─ PlugIns/
+   └─ ReadingWidget.appex
+      └─ Widget 실행 코드 ── Widget 프로세스 ── Extension private container
+```
+
+extension bundle은 배포를 위해 앱 bundle 안에 들어 있지만 실행 중인 프로세스와 데이터 container는 분리돼요. Apple의 App Extension 문서도 실행 중인 extension과 containing app이 서로의 container에 직접 접근하지 못한다고 설명해요.
+
+따라서 다음 두 코드는 이름이 같아도 서로 다른 앱 domain을 가리켜요.
+
+```swift
+// App target에서 실행
+UserDefaults.standard.set(45, forKey: "reading.dailyGoal")
+
+// Widget extension target에서 실행
+let goal = UserDefaults.standard.integer(
+  forKey: "reading.dailyGoal"
+)
+```
+
+Widget의 `UserDefaults.standard`는 App의 standard defaults가 아니에요. 앱 process의 메모리 객체, singleton, `@State`, `@Observable` 인스턴스도 Widget process가 직접 읽을 수 없어요.
+
+## App Group은 두 sandbox가 공유하는 세 번째 경계를 만들어요
+
+두 target에 같은 App Group을 허용하면 구조가 다음처럼 바뀌어요.
+
+```text
+┌──────────────────────── App target ────────────────────────┐
+│ App 프로세스                                               │
+│ App private container                                      │
+│ entitlement: group.com.example.Reading ───────┐            │
+└───────────────────────────────────────────────┼────────────┘
+                                                │ 권한 확인
+                                                ▼
+                              ┌──────────────────────────────┐
+                              │ App Group shared container   │
+                              │                              │
+                              │ shared preferences domain    │
+                              │ shared files / database      │
+                              └──────────────────────────────┘
+                                                ▲
+                                                │ 권한 확인
+┌──────────────────── Widget extension target ──┼────────────┐
+│ Widget 프로세스                               │            │
+│ Extension private container                   │            │
+│ entitlement: group.com.example.Reading ───────┘            │
+└────────────────────────────────────────────────────────────┘
+```
+
+App Group은 private container를 합치지 않아요. 각 target의 private 영역은 그대로 유지하면서, 운영체제가 관리하는 **추가 shared container에 접근할 권한**을 함께 부여해요.
+
+두 target이 같은 문자열을 코드에 적는 것만으로는 충분하지 않아요. 서명된 각 실행 파일의 entitlement와 provisioning 정보가 그 group을 허용해야 운영체제가 접근을 승인해요.
+
+## entitlement는 실행 파일의 권한 증명이에요
+
+App Groups capability를 추가하면 Xcode가 target의 `.entitlements` 설정에 다음과 같은 값을 관리해요.
+
+```xml
+<key>com.apple.security.application-groups</key>
+<array>
+  <string>group.com.example.Reading</string>
+</array>
+```
+
+이 값은 단순한 런타임 설정 파일이 아니에요. Xcode는 developer account와 provisioning 정보를 함께 사용해 최종 entitlement를 실행 파일의 code signature에 적용해요. 운영체제는 실행 중인 프로세스가 group container를 열려고 할 때 이 권한을 검사해요.
+
+### App과 Widget target을 모두 설정해요
+
+Xcode에서 다음 순서로 구성해요.
+
+1. App target을 선택하고 **Signing & Capabilities**에서 **App Groups** capability를 추가해요.
+2. `group.com.example.Reading`처럼 `group.`으로 시작하는 identifier를 만들거나 기존 group을 선택해요.
+3. Widget extension target에도 **App Groups** capability를 추가해요.
+4. App target과 Widget target에서 정확히 같은 group checkbox를 선택해요.
+5. 두 target의 Team, bundle signing과 provisioning 상태가 정상인지 확인해요.
+
+App Group identifier에 오타가 있거나 한 target에만 capability를 추가하면 shared `UserDefaults` 생성이나 container URL 접근이 실패할 수 있어요.
+
+## 공유 상수와 저장 코드는 두 target에 포함해요
+
+식별자와 key를 App과 Widget이 각각 복사해 쓰면 쉽게 달라져요. 공통 Swift 파일이나 app-extension-safe framework에 모으고 두 target의 Target Membership에 포함해요.
+
+```swift
+import Foundation
+
+enum ReadingAppGroup {
+  static let identifier = "group.com.example.Reading"
+  static let widgetKind = "ReadingProgressWidget"
+}
+
+enum SharedPreferenceKey {
+  static let dailyGoal = "reading.dailyGoal"
+  static let completedMinutes = "reading.completedMinutes"
+}
+
+enum SharedDefaults {
+  static let store: UserDefaults = {
+    guard let store = UserDefaults(
+      suiteName: ReadingAppGroup.identifier
+    ) else {
+      preconditionFailure("App Group entitlement를 확인하세요.")
+    }
+
+    store.register(defaults: [
+      SharedPreferenceKey.dailyGoal: 30,
+      SharedPreferenceKey.completedMinutes: 0,
+    ])
+
+    return store
+  }()
+}
+```
+
+`UserDefaults(suiteName:)`은 지정한 custom domain을 읽고 쓰는 인스턴스를 만들어요. suite 이름이 App Group identifier이고 entitlement가 맞으면 App과 Widget이 같은 shared preferences database를 사용해요.
+
+`register(defaults:)`의 registration domain은 volatile fallback이므로 각 프로세스가 시작될 때 실행돼야 해요. 위 공통 `store`를 App과 Widget이 각각 처음 접근하면 각 process에서 같은 fallback을 등록해요.
+
+## 전용 타입이 shared key와 검증을 관리해요
+
+UI와 Widget provider가 문자열 key를 직접 반복하지 않도록 작은 저장 타입을 만들 수 있어요.
+
+```swift
+import Foundation
+
+struct SharedReadingPreferences {
+  private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = SharedDefaults.store) {
+    self.defaults = defaults
+  }
+
+  var dailyGoal: Int {
+    get {
+      defaults.integer(forKey: SharedPreferenceKey.dailyGoal)
+    }
+    nonmutating set {
+      defaults.set(
+        max(newValue, 1),
+        forKey: SharedPreferenceKey.dailyGoal
+      )
+    }
+  }
+
+  var completedMinutes: Int {
+    get {
+      defaults.integer(
+        forKey: SharedPreferenceKey.completedMinutes
+      )
+    }
+    nonmutating set {
+      defaults.set(
+        max(newValue, 0),
+        forKey: SharedPreferenceKey.completedMinutes
+      )
+    }
+  }
+}
+```
+
+이 타입은 App Group 권한을 만들어 주지 않아요. 이미 권한이 있는 target에서 suite의 key, 기본값과 검증을 일관되게 사용하는 역할만 해요.
+
+## App은 값을 저장한 뒤 WidgetKit에 reload를 요청해요
+
+App의 설정 화면은 shared suite에 값을 쓰고 현재 Widget timeline이 더 이상 최신이 아니라고 WidgetKit에 알려요.
+
+```swift
+import SwiftUI
+import WidgetKit
+
+struct ReadingDashboard: View {
+  @AppStorage(
+    SharedPreferenceKey.dailyGoal,
+    store: SharedDefaults.store
+  )
+  private var dailyGoal = 30
+
+  @AppStorage(
+    SharedPreferenceKey.completedMinutes,
+    store: SharedDefaults.store
+  )
+  private var completedMinutes = 0
+
+  var body: some View {
+    Form {
+      Stepper(
+        "하루 목표: \(dailyGoal)분",
+        value: $dailyGoal,
+        in: 10...180,
+        step: 10
+      )
+
+      Text("오늘 완료: \(completedMinutes)분")
+
+      Button("10분 기록") {
+        completedMinutes += 10
+        reloadReadingWidget()
+      }
+    }
+    .onChange(of: dailyGoal) {
+      reloadReadingWidget()
+    }
+  }
+
+  private func reloadReadingWidget() {
+    WidgetCenter.shared.reloadTimelines(
+      ofKind: ReadingAppGroup.widgetKind
+    )
+  }
+}
+```
+
+`@AppStorage`의 store를 App Group suite로 지정했기 때문에 값은 앱의 standard domain이 아니라 shared domain에 기록돼요.
+
+`reloadTimelines(ofKind:)`의 `kind`는 Widget의 `StaticConfiguration`에 사용하는 문자열과 정확히 같아야 해요. 이 호출은 Widget View를 앱 프로세스에서 직접 다시 그리는 함수가 아니에요. WidgetKit에 기존 timeline이 오래되었으니 새 timeline을 요청해 달라고 알리는 **reload 요청**이에요.
+
+WidgetKit은 전력과 시스템 상태를 고려해 갱신을 scheduling해요. 함수를 호출한 줄에서 Widget 화면이 동기적으로 바뀐다고 가정하면 안 돼요. 현재 표시 정보가 실제로 달라졌을 때만 요청해 불필요한 reload를 줄여요.
+
+## Widget provider는 shared store를 읽어 entry snapshot을 만들어요
+
+Widget extension에서 `TimelineProvider`를 구현해요.
+
+```swift
+import SwiftUI
+import WidgetKit
+
+struct ReadingEntry: TimelineEntry {
+  let date: Date
+  let dailyGoal: Int
+  let completedMinutes: Int
+
+  var progress: Double {
+    guard dailyGoal > 0 else { return 0 }
+
+    return min(
+      Double(completedMinutes) / Double(dailyGoal),
+      1
+    )
+  }
+}
+
+struct ReadingProvider: TimelineProvider {
+  func placeholder(in context: Context) -> ReadingEntry {
+    ReadingEntry(
+      date: .now,
+      dailyGoal: 30,
+      completedMinutes: 10
+    )
+  }
+
+  func getSnapshot(
+    in context: Context,
+    completion: @escaping (ReadingEntry) -> Void
+  ) {
+    if context.isPreview {
+      completion(placeholder(in: context))
+      return
+    }
+
+    completion(makeCurrentEntry())
+  }
+
+  func getTimeline(
+    in context: Context,
+    completion: @escaping (Timeline<ReadingEntry>) -> Void
+  ) {
+    let entry = makeCurrentEntry()
+    let timeline = Timeline(
+      entries: [entry],
+      policy: .never
+    )
+
+    completion(timeline)
+  }
+
+  private func makeCurrentEntry() -> ReadingEntry {
+    let preferences = SharedReadingPreferences()
+
+    return ReadingEntry(
+      date: .now,
+      dailyGoal: preferences.dailyGoal,
+      completedMinutes: preferences.completedMinutes
+    )
+  }
+}
+```
+
+provider가 실행되는 곳은 Widget extension process예요. App process의 `@AppStorage` 인스턴스를 참조하는 것이 아니라 같은 App Group suite를 새 process에서 열어 현재 값을 읽어요.
+
+`.never` policy는 예측 가능한 다음 변경 시각이 없으므로 WidgetKit이 스스로 다음 timeline을 요청할 날짜를 지정하지 않는다는 뜻이에요. 앱이 값을 바꿀 때 `reloadTimelines(ofKind:)`를 호출하는 흐름과 맞아요. 시간에 따라 자연스럽게 바뀌는 정보라면 미래 entry를 만들거나 `.after(date)` 같은 policy를 선택해요.
+
+## Widget View는 TimelineEntry만 렌더링해요
+
+provider가 만든 snapshot을 View에 전달해요.
+
+```swift
+import SwiftUI
+import WidgetKit
+
+struct ReadingWidgetView: View {
+  let entry: ReadingEntry
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("오늘의 독서")
+        .font(.headline)
+
+      ProgressView(value: entry.progress)
+
+      Text(
+        "\(entry.completedMinutes) / \(entry.dailyGoal)분"
+      )
+      .font(.caption)
+    }
+    .containerBackground(.fill.tertiary, for: .widget)
+  }
+}
+
+struct ReadingProgressWidget: Widget {
+  let kind = ReadingAppGroup.widgetKind
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(
+      kind: kind,
+      provider: ReadingProvider()
+    ) { entry in
+      ReadingWidgetView(entry: entry)
+    }
+    .configurationDisplayName("독서 진행률")
+    .description("오늘의 독서 목표와 완료 시간을 보여 줍니다.")
+    .supportedFamilies([.systemSmall])
+  }
+}
+```
+
+Widget View가 `SharedDefaults.store`를 직접 읽게 만들 수도 있지만 timeline entry에 필요한 값을 먼저 넣는 구조가 데이터 시점을 명확하게 해요. `placeholder`, `snapshot`, 실제 timeline이 각각 어떤 값을 렌더링하는지 테스트하기도 쉬워져요.
+
+[Apple의 Widget interactivity 문서](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities)는 Widget 코드가 앱과 분리된 독립 process에서 실행되고, 시스템이 timeline entry 기반 View 표현을 archive해 렌더링한다고 설명해요. Widget이 보이는 동안 앱의 `Binding`이나 `@Observable` 모델에 계속 연결되어 실행되는 구조가 아니에요.
+
+## 전체 데이터 흐름은 저장과 표시 요청으로 나뉘어요
+
+App에서 목표를 바꿨을 때 내부 흐름을 순서대로 정리하면 다음과 같아요.
+
+```text
+1. App process
+   @AppStorage 또는 SharedReadingPreferences가 shared suite에 값을 써요.
+                     │
+                     ▼
+2. Foundation defaults system
+   App process의 메모리 표현을 즉시 갱신하고 영속 저장소에는 비동기로 반영해요.
+                     │
+                     ▼
+3. App process
+   WidgetCenter.reloadTimelines(ofKind:)로 새 snapshot이 필요하다고 요청해요.
+                     │
+                     ▼
+4. WidgetKit
+   시스템 정책에 따라 Widget extension에 timeline을 요청해요.
+                     │
+                     ▼
+5. Widget extension process
+   같은 suiteName으로 shared domain을 읽고 TimelineEntry를 만들어요.
+                     │
+                     ▼
+6. WidgetKit rendering
+   entry를 포함한 View 표현을 보관하고 적절한 시점에 화면에 표시해요.
+```
+
+여기에는 App View와 Widget View 사이의 직접 함수 호출이나 live Binding이 없어요. **shared storage가 데이터 전달 경로**이고 **WidgetCenter와 timeline이 표시 갱신 경로**예요.
+
+## shared UserDefaults와 실제 group container 파일은 다른 API로 열어요
+
+App Group으로 공유할 수 있는 저장 방식은 UserDefaults suite만이 아니에요.
+
+Apple은 다음과 같은 접근 방법을 제공해요.
+
+- 작은 설정은 `UserDefaults(suiteName:)`으로 shared preferences database를 사용해요.
+- 파일은 `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)`로 group container URL을 얻어 저장해요.
+- background URL session은 configuration의 `sharedContainerIdentifier`를 지정할 수 있어요.
+- 데이터베이스 파일도 group container에 둘 수 있지만 여러 process 접근을 안전하게 조정해야 해요.
+
+App Group의 실제 파일 경로를 문자열로 만들면 안 돼요. 특히 iOS는 group directory의 이름과 물리적 위치를 보장하지 않으므로 [`containerURL(forSecurityApplicationGroupIdentifier:)`](<https://developer.apple.com/documentation/foundation/filemanager/containerurl(forsecurityapplicationgroupidentifier:)>)의 반환값을 사용해야 해요.
+
+```swift
+import Foundation
+
+enum SharedContainerError: Error {
+  case unavailable
+}
+
+struct SharedReadingFileStore {
+  private let fileManager: FileManager
+
+  init(fileManager: FileManager = .default) {
+    self.fileManager = fileManager
+  }
+
+  func save(_ snapshot: ReadingSnapshot) throws {
+    let url = try snapshotURL()
+    let data = try JSONEncoder().encode(snapshot)
+    try data.write(to: url, options: .atomic)
+  }
+
+  func load() throws -> ReadingSnapshot? {
+    let url = try snapshotURL()
+
+    guard fileManager.fileExists(atPath: url.path) else {
+      return nil
+    }
+
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(
+      ReadingSnapshot.self,
+      from: data
+    )
+  }
+
+  private func snapshotURL() throws -> URL {
+    guard let containerURL = fileManager.containerURL(
+      forSecurityApplicationGroupIdentifier:
+        ReadingAppGroup.identifier
+    ) else {
+      throw SharedContainerError.unavailable
+    }
+
+    return containerURL.appendingPathComponent(
+      "reading-widget-snapshot.json"
+    )
+  }
+}
+
+struct ReadingSnapshot: Codable {
+  let dailyGoal: Int
+  let completedMinutes: Int
+  let updatedAt: Date
+}
+```
+
+`.atomic` 쓰기는 임시 파일을 완성한 뒤 교체하는 방식으로 부분 파일 노출 가능성을 줄여요. 하지만 App과 Widget이 동시에 읽고 쓰는 전체 업무 규칙까지 자동으로 해결하지는 않아요.
+
+## 저장 방식은 데이터 크기와 동시 접근 방식으로 선택해요
+
+| 데이터와 접근 특성                         | App Group 안의 선택지                         |
+| ------------------------------------------ | --------------------------------------------- |
+| 작은 Boolean, 숫자, 문자열 설정            | shared `UserDefaults` suite                   |
+| 한 번에 통째로 교체하고 읽는 작은 snapshot | 원자적으로 쓰는 파일                          |
+| 이미지, 미리 렌더링한 asset, 큰 JSON       | shared file container                         |
+| 검색, 관계, 부분 수정, 여러 record         | SQLite·Core Data 등 transaction 가능한 저장소 |
+| 인증 token이나 암호 같은 민감 정보         | 요구사항에 맞게 구성한 Keychain sharing       |
+
+UserDefaults의 내부 preferences 파일을 group container에서 직접 찾아 수정하면 안 돼요. Foundation API가 domain 검색, 메모리 표현과 영속 반영을 관리하도록 둬요.
+
+큰 데이터베이스를 App과 extension이 함께 연다면 두 process가 동시에 접근하거나 한 process가 중단되는 상황을 고려해야 해요. Apple의 extension 가이드는 shared container의 데이터 손상을 피하도록 접근을 동기화하고 SQLite, Core Data, POSIX lock, `NSFileCoordinator` 같은 수단을 데이터 특성에 맞게 검토하라고 안내해요.
+
+## 여러 프로세스에서 read-modify-write 경쟁을 피해야 해요
+
+shared UserDefaults 자체는 key-value 저장을 안전하게 관리하지만 다음과 같은 업무 연산은 두 호출로 나뉘어요.
+
+```swift
+let oldValue = SharedDefaults.store.integer(
+  forKey: SharedPreferenceKey.completedMinutes
+)
+
+SharedDefaults.store.set(
+  oldValue + 10,
+  forKey: SharedPreferenceKey.completedMinutes
+)
+```
+
+App process와 interactive Widget의 App Intent가 동시에 같은 연산을 실행하면 둘 다 같은 `oldValue`를 읽고 하나의 증가가 사라질 수 있어요. 한 process 안의 actor는 다른 process까지 직렬화하지 못해요.
+
+다음 중 데이터에 맞는 전략을 선택해요.
+
+- 쓰기 주체를 App 하나로 제한하고 Widget은 읽기만 해요.
+- 서로 다른 process가 쓰는 key를 분리해 충돌 범위를 줄여요.
+- 충돌이 중요한 record는 SQLite transaction 같은 다중 process 저장 전략을 사용해요.
+- 파일은 원자적 교체와 coordination 정책을 함께 설계해요.
+- Widget App Intent가 값을 바꾼다면 성공 후 새 timeline을 만들고 App도 foreground 복귀 시 저장소를 다시 읽어요.
+
+## reload 요청은 실시간 IPC가 아니에요
+
+App Groups가 일부 IPC 메커니즘도 허용하지만 Widget의 일반적인 데이터 갱신은 shared container와 WidgetKit timeline을 사용해요.
+
+[`WidgetCenter.shared.reloadTimelines(ofKind:)`를 사용한 갱신](https://developer.apple.com/documentation/widgetkit/keeping-a-widget-up-to-date)을 요청할 때 기억할 점은 다음과 같아요.
+
+- 호출은 현재 timeline을 무효화하는 요청이며 동기식 화면 redraw가 아니에요.
+- WidgetKit은 전력과 시스템 정책에 따라 extension 실행과 rendering을 scheduling해요.
+- Widget에는 일일 refresh budget이 있으므로 표시 데이터가 실제로 달라졌을 때 요청해요.
+- 미래 변경 시간이 예상되면 여러 timeline entry를 미리 제공하는 편이 효율적이에요.
+- Xcode debugger에서는 실제 기기의 refresh 제한이 그대로 나타나지 않을 수 있어요.
+
+앱이 서버에서 새 데이터를 받았다면 Widget이 다시 네트워크 요청을 반복하게 하기보다 앱이 필요한 snapshot을 group container에 준비하고 reload를 요청하는 구조가 효율적일 수 있어요.
+
+## 보안 경계는 group 구성원 전체로 넓어져요
+
+App Group container는 아무 앱이나 접근하는 공개 폴더가 아니에요. 같은 group entitlement를 가진, 같은 개발 팀의 관련 executable이 접근하는 공유 경계예요.
+
+하지만 private container보다 접근 주체가 늘어나므로 다음을 지켜요.
+
+- 필요하지 않은 extension을 group에 추가하지 않아요.
+- 모든 group 구성원이 읽어도 되는 데이터만 넣어요.
+- 잠금 화면 Widget에 민감한 정보가 노출되지 않도록 redaction과 표시 정책을 검토해요.
+- 비밀번호, 인증 token, 암호화 key를 평문 UserDefaults에 저장하지 않아요.
+- App Group identifier와 entitlement를 source code의 보안 비밀로 오해하지 않아요. 실제 권한은 code signature와 provisioning으로 검증돼요.
+
+App Group은 같은 기기의 관련 process 사이에서 데이터를 공유하는 기능이에요. 같은 사용자의 여러 기기에 자동 동기화하는 기능이 아니므로 그 목적에는 CloudKit이나 `NSUbiquitousKeyValueStore` 같은 별도 기술을 검토해요.
+
+## App Group UserDefaults는 privacy manifest에 공유 목적을 선언해요
+
+`UserDefaults`는 required reason API예요. 같은 App Group의 앱·extension·App Clip이 읽고 쓰는 용도에는 [Apple이 정의한 `1C8F.1` reason](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype)이 해당 범위를 설명해요.
+
+privacy manifest의 관련 부분은 다음 구조를 사용해요.
+
+```xml
+<key>NSPrivacyAccessedAPITypes</key>
+<array>
+  <dict>
+    <key>NSPrivacyAccessedAPIType</key>
+    <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+    <key>NSPrivacyAccessedAPITypeReasons</key>
+    <array>
+      <string>1C8F.1</string>
+    </array>
+  </dict>
+</array>
+```
+
+실제 제출 시점의 Apple 문서에서 reason code와 허용 범위를 다시 확인해요. App만 접근하는 standard defaults와 App Group 공유를 모두 사용한다면 각 사용이 선언한 reason 범위에 맞는지 privacy report로 점검해요.
+
+## 문제가 생기면 권한과 프로세스 경계부터 확인해요
+
+| 증상                                                  | 확인할 항목                                                                                                             |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `UserDefaults(suiteName:)`이 기대대로 공유되지 않아요 | App과 Widget target에 같은 App Groups capability가 있는지, group identifier 철자가 같은지 확인해요.                     |
+| `containerURL`이 iOS에서 `nil`이에요.                 | 전달한 identifier가 entitlement 배열에 정확히 포함됐는지와 signing·provisioning 상태를 확인해요.                        |
+| App에서는 보이지만 Widget 값이 오래됐어요.            | App이 shared suite에 썼는지, Widget `kind`가 같은지, reload를 요청했는지, provider가 새 entry에서 값을 읽는지 확인해요. |
+| `reloadTimelines` 직후 화면이 안 바뀌어요.            | reload는 비동기 요청이고 시스템 scheduling과 budget의 영향을 받는다는 점을 확인해요. 실제 기기에서도 테스트해요.        |
+| Preview에서 group store가 실패해요.                   | Preview process의 entitlement 환경에 의존하지 않도록 sample entry나 주입 가능한 test store를 사용해요.                  |
+| 값이 가끔 덮어써져요.                                 | App과 extension이 같은 key를 read-modify-write하는지 확인하고 쓰기 주체 단일화나 transaction 저장소를 검토해요.         |
+| 파일 일부가 깨져 보여요.                              | 실제 group URL API를 사용하는지, 원자적 쓰기와 여러 process coordination을 적용했는지 확인해요.                         |
+
+## 테스트는 저장과 timeline 생성을 분리해요
+
+`TimelineProvider`가 global shared store를 직접 열기만 하면 테스트에서 실제 entitlement와 container에 의존해요. entry 생성 로직이 `UserDefaults`나 protocol을 받도록 분리할 수 있어요.
+
+```swift
+import Foundation
+
+struct ReadingEntryFactory {
+  let defaults: UserDefaults
+
+  func makeEntry(now: Date) -> ReadingEntry {
+    let preferences = SharedReadingPreferences(
+      defaults: defaults
+    )
+
+    return ReadingEntry(
+      date: now,
+      dailyGoal: preferences.dailyGoal,
+      completedMinutes: preferences.completedMinutes
+    )
+  }
+}
+```
+
+unit test에서는 고유한 suite를 전달해 저장값과 entry 결과를 확인하고, 실제 App Group 통합 테스트에서는 다음을 별도로 검증해요.
+
+1. App과 Widget target이 같은 entitlement로 서명됐는지 확인해요.
+2. App이 shared suite에 쓴 값을 Widget provider가 읽는지 확인해요.
+3. 앱에서 표시값을 바꾼 뒤 Widget timeline이 갱신되는지 실제 기기에서 확인해요.
+4. 앱이 background 또는 종료된 상태에서 Widget이 fallback과 마지막 snapshot을 안전하게 표시하는지 확인해요.
+5. 여러 process가 동시에 접근할 수 있는 저장소의 손상과 충돌 시나리오를 확인해요.
+
+## 언제 App Groups를 사용해야 하나요
+
+다음 조건에서 사용해요.
+
+- 같은 개발 팀의 여러 앱이나 app extension이 같은 기기에서 데이터를 공유해야 해요.
+- containing app과 Widget이 작은 설정, snapshot, 파일 또는 데이터베이스를 함께 읽어야 해요.
+- 각 process의 private container를 유지하면서 명시적인 공유 경계만 추가하고 싶어요.
+- 공유 대상 target과 데이터 범위를 entitlement로 제한할 수 있어요.
+
+한 앱 process 안의 여러 View가 값을 공유하는 문제에는 App Group이 필요하지 않아요. SwiftUI environment, `@Observable` 모델, dependency injection 같은 메모리 내 전달 방법을 먼저 사용해요.
+
+## 적용 순서를 정리해요
+
+1. App과 extension이 실제로 같은 기기에서 공유해야 하는 데이터인지 확인해요.
+2. App target과 Widget target에 같은 App Groups capability와 identifier를 추가해요.
+3. group identifier, Widget kind와 key를 두 target이 함께 빌드하는 코드에 모아요.
+4. 작은 설정은 `UserDefaults(suiteName:)`, 큰 snapshot은 group container 파일, 복잡한 record는 transaction 저장소를 선택해요.
+5. App이 값을 쓴 뒤 표시 데이터가 달라졌을 때 `reloadTimelines(ofKind:)`를 요청해요.
+6. Widget provider가 shared store를 읽어 완결된 `TimelineEntry` snapshot을 만들게 해요.
+7. 여러 process의 동시 쓰기와 앱 중단 상황을 고려해 coordination 정책을 정해요.
+8. 민감 정보, 잠금 화면 노출과 privacy manifest의 `1C8F.1` reason을 점검해요.
+9. Simulator뿐 아니라 실제 기기에서 timeline scheduling과 refresh budget을 테스트해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### App과 Widget이 UserDefaults.standard로 값을 공유할 수 있나요?
+
+아니요. App과 Widget extension은 별도 process와 sandbox를 사용하므로 각각의 `standard`가 서로 다른 앱 domain을 가리켜요. 같은 App Group entitlement를 설정하고 `UserDefaults(suiteName: groupIdentifier)`로 shared domain을 열어야 해요.
+
+### App Group identifier 문자열만 같으면 공유할 수 있나요?
+
+아니요. 각 target의 서명된 executable에 같은 App Groups entitlement가 포함되고 provisioning이 이를 허용해야 해요. 운영체제는 문자열뿐 아니라 code signature의 권한을 확인해 group container 접근을 결정해요.
+
+### App에서 값을 바꾸면 Widget이 즉시 다시 그려지나요?
+
+아니요. 앱은 shared storage에 값을 쓴 뒤 WidgetKit에 timeline reload를 요청해요. WidgetKit이 시스템 정책에 따라 extension에서 새 entry를 받고 렌더링하므로 동기식 또는 즉시 갱신을 보장하지 않아요.
+
+### shared UserDefaults와 shared container 파일은 어떻게 선택하나요?
+
+작은 비민감 설정은 UserDefaults suite가 간단하고, 큰 snapshot이나 asset은 `containerURL`로 얻은 파일 영역이 적합해요. 검색·관계·동시 transaction이 필요하면 SQLite나 Core Data 같은 저장소를 선택하고 다중 process 접근을 조정해야 해요.
+
+### actor로 App과 Widget의 동시 쓰기를 보호할 수 있나요?
+
+하나의 actor 인스턴스는 한 process 안의 task만 직렬화해요. App과 Widget은 별도 process이므로 actor만으로 둘 사이의 경쟁을 막을 수 없고, 쓰기 주체 단일화나 process 간 lock·transaction 저장 전략이 필요해요.
+
+## 참고 자료
+
+- [Apple Developer — Configuring app groups](https://developer.apple.com/documentation/xcode/configuring-app-groups)
+- [Apple Developer — App Groups Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.application-groups)
+- [Apple Developer — UserDefaults init(suiteName:)](<https://developer.apple.com/documentation/foundation/userdefaults/init(suitename:)>)
+- [Apple Developer — containerURL(forSecurityApplicationGroupIdentifier:)](<https://developer.apple.com/documentation/foundation/filemanager/containerurl(forsecurityapplicationgroupidentifier:)>)
+- [Apple Developer — Developing a WidgetKit strategy](https://developer.apple.com/documentation/widgetkit/developing-a-widgetkit-strategy)
+- [Apple Developer — TimelineProvider](https://developer.apple.com/documentation/widgetkit/timelineprovider)
+- [Apple Developer — Keeping a widget up to date](https://developer.apple.com/documentation/widgetkit/keeping-a-widget-up-to-date)
+- [Apple Developer — Adding interactivity to widgets and Live Activities](https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities)
+- [Apple Developer Archive — Sharing data with your containing app](https://developer.apple.com/library/archive/documentation/general/conceptual/extensibilitypg/extensionscenarios.html)
+- [Apple Developer — UserDefaults required reason API](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype)
+- [Swift-KR — UserDefaults](./userdefaults)
+- [Swift-KR — @AppStorage](./appstorage)
+- [Swift-KR — @Observable과 Observation](../swiftui/state-management/observation)

--- a/docs/guide/data-storage/appstorage.md
+++ b/docs/guide/data-storage/appstorage.md
@@ -1,0 +1,450 @@
+---
+title: SwiftUI로 이해하는 @AppStorage
+description: '@AppStorage가 UserDefaults 값을 SwiftUI View 갱신과 Binding에 연결하는 방식, 지원 타입, custom store, SceneStorage와의 선택 기준을 설명합니다.'
+pageType: doc-wide
+outline: false
+---
+
+# SwiftUI로 이해하는 @AppStorage
+
+> **면접 답변 한 줄 요약:** `@AppStorage`는 `UserDefaults`의 특정 key를 SwiftUI 프로퍼티로 연결해 값을 읽고 쓰며, 해당 설정이 바뀌면 View를 다시 계산하고 `$` projected value로 `Binding`까지 제공하는 프로퍼티 래퍼예요.
+
+`UserDefaults`만으로 설정을 저장할 수 있지만 SwiftUI View에서 직접 사용하면 읽기, 쓰기, 변경 관찰, 화면 갱신 코드를 각각 연결해야 해요. [Apple의 AppStorage 문서](https://developer.apple.com/documentation/swiftui/appstorage)가 정의하듯 `@AppStorage`는 UserDefaults 값을 반영하고 그 값이 바뀌면 View를 무효화해, 작은 설정 하나를 View와 연결하는 반복을 줄여요.
+
+이 문서에서는 독서 목표 앱의 설정 화면을 예로 들어 다음 내용을 설명해요.
+
+- `@AppStorage`가 `UserDefaults`와 SwiftUI 사이에서 맡는 역할
+- 기본값과 저장된 값이 선택되는 방식
+- `$프로퍼티`로 `Binding`을 전달하는 방법
+- 지원 타입과 `RawRepresentable` enum 저장
+- 특정 `UserDefaults`와 `defaultAppStorage(_:)` 사용
+- `@State`, `@SceneStorage`, `@Observable` 모델과의 선택 기준
+- 테스트, App Group 공유, 개인정보 보호 주의점
+
+## 먼저 알아둘 SwiftUI 저장 용어
+
+| 용어                      | 쉬운 뜻                                                                                                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 프로퍼티 래퍼             | 프로퍼티 저장과 접근 규칙을 `@이름` 문법으로 적용하는 Swift 기능이에요. 자세한 원리는 [Property Wrapper](../swift/property-wrappers)에서 설명해요.        |
+| `UserDefaults`            | 작고 민감하지 않은 설정을 문자열 key와 property list 값으로 저장하는 Foundation API예요. 자세한 원리는 [UserDefaults](./userdefaults)에서 설명해요.       |
+| View 무효화(invalidation) | View가 의존한 값이 바뀌었으니 SwiftUI가 `body`를 다시 계산해야 한다고 표시하는 과정이에요.                                                                |
+| `Binding`                 | 값을 읽고 원래 저장 위치에 변경을 다시 기록하는 양방향 연결이에요. `@AppStorage`의 `$프로퍼티`가 `Binding`을 제공해요.                                    |
+| dynamic property          | SwiftUI가 View의 외부 상태를 읽고 변경 시점을 추적할 수 있도록 갱신 주기에 참여하는 프로퍼티예요. `@State`와 `@AppStorage`가 대표적인 예예요.             |
+| custom store              | `UserDefaults.standard` 대신 직접 지정한 `UserDefaults` 인스턴스예요. 테스트 suite나 App Group suite를 연결할 때 사용해요.                                |
+| View identity             | SwiftUI가 이전 View와 새 View를 같은 화면 요소로 대응시키는 기준이에요. `@State` 수명에는 중요하지만 `@AppStorage` 값 자체는 UserDefaults key에 저장돼요. |
+
+`@AppStorage`는 iOS 14, macOS 11, tvOS 14, watchOS 7부터 사용할 수 있어요.
+
+## UserDefaults를 직접 쓰면 화면 갱신 연결이 필요해요
+
+먼저 View의 계산 프로퍼티가 `UserDefaults`를 직접 읽게 만들어 볼게요.
+
+```swift
+import SwiftUI
+
+struct ReadingGoalView: View {
+  private let key = "reading.dailyGoal"
+
+  private var dailyGoal: Int {
+    UserDefaults.standard.integer(forKey: key)
+  }
+
+  var body: some View {
+    VStack {
+      Text("하루 목표: \(dailyGoal)분")
+
+      Button("45분으로 변경") {
+        UserDefaults.standard.set(45, forKey: key)
+      }
+    }
+  }
+}
+```
+
+Button이 값을 저장해도 SwiftUI는 `dailyGoal`이 외부 저장소에서 바뀌었다는 사실을 자동으로 의존성으로 관리하지 못해요. 우연히 다른 상태 때문에 `body`가 다시 계산되면 새 값을 읽을 수 있지만, 이 코드는 설정 변경과 View 갱신을 명시적으로 연결하지 않았어요.
+
+notification을 구독하고 별도 `@State`에 복사할 수도 있지만 작은 설정 하나에 코드가 너무 많아져요.
+
+## AppStorage는 key 하나를 View 상태처럼 연결해요
+
+같은 설정을 `@AppStorage`로 바꿔 볼게요.
+
+```swift
+import SwiftUI
+
+struct ReadingGoalView: View {
+  @AppStorage("reading.dailyGoal")
+  private var dailyGoal = 30
+
+  var body: some View {
+    VStack(spacing: 16) {
+      Text("하루 목표: \(dailyGoal)분")
+
+      Button("45분으로 변경") {
+        dailyGoal = 45
+      }
+    }
+  }
+}
+```
+
+코드 한 줄에 세 역할이 연결돼요.
+
+1. getter는 `reading.dailyGoal` key에 해당하는 값을 `UserDefaults`에서 읽어요.
+2. `dailyGoal = 45`는 같은 key에 새 값을 기록해요.
+3. key의 값이 바뀌면 SwiftUI가 이 프로퍼티를 읽는 View를 무효화하고 `body`를 다시 계산해요.
+
+별도 store를 지정하지 않으면 View 계층의 기본 app storage를 사용하고, 기본값은 `UserDefaults.standard`예요.
+
+### 선언의 초기값은 key가 없을 때 보여 줄 값이에요
+
+```swift
+@AppStorage("reading.dailyGoal")
+private var dailyGoal = 30
+```
+
+여기서 `30`은 UserDefaults key에 값이 없을 때 래퍼가 사용할 초기 wrapped value예요. 이 선언만으로 앱 전체의 registration domain에 `30`이 등록되는 것은 아니에요. SwiftUI 밖의 코드도 같은 기본값을 읽어야 한다면 앱 시작 시 `register(defaults:)`를 별도로 호출해 저장 정책을 일치시켜요.
+
+```swift
+@main
+struct ReadingApp: App {
+  init() {
+    UserDefaults.standard.register(defaults: [
+      "reading.dailyGoal": 30,
+    ])
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      ReadingGoalView()
+    }
+  }
+}
+```
+
+`@AppStorage` 초기값과 `register(defaults:)`의 값을 다르게 두면 화면 위치에 따라 기본값이 달라질 수 있어요. key와 기본값을 한 타입에 모아 중복을 줄이는 편이 안전해요.
+
+## projected value는 원래 저장소로 쓰는 Binding이에요
+
+`@AppStorage` 프로퍼티 앞에 `$`를 붙이면 `Binding<Value>`를 얻어요. SwiftUI control이 변경값을 원래 UserDefaults key에 다시 쓰게 연결할 수 있어요.
+
+```swift
+import SwiftUI
+
+struct ReadingSettingsView: View {
+  @AppStorage("reading.dailyGoal")
+  private var dailyGoal = 30
+
+  @AppStorage("reading.reminderEnabled")
+  private var reminderEnabled = false
+
+  var body: some View {
+    Form {
+      Stepper(
+        "하루 목표: \(dailyGoal)분",
+        value: $dailyGoal,
+        in: 10...180,
+        step: 10
+      )
+
+      Toggle(
+        "리마인더 사용",
+        isOn: $reminderEnabled
+      )
+    }
+  }
+}
+```
+
+`dailyGoal`은 현재 `Int` 값을 읽고, `$dailyGoal`은 `Binding<Int>`를 제공해요. `Stepper`가 Binding에 새 값을 쓰면 `@AppStorage`가 UserDefaults를 갱신하고 View도 다시 계산돼요.
+
+`Binding`은 값의 복사본이 아니에요. 원래 저장 위치를 읽고 쓰는 연결이므로 별도 `@State`에 값을 복사해 둘 필요가 없어요.
+
+## 지원 타입은 UserDefaults보다 의도적으로 좁아요
+
+`UserDefaults`는 property list 배열과 딕셔너리도 저장할 수 있지만 `@AppStorage`는 SwiftUI가 명확하게 읽고 쓰며 변경을 비교할 수 있는 타입에 initializer를 제공해요.
+
+현재 SDK의 주요 지원 타입은 다음과 같아요.
+
+| 타입                                                   | 지원 기준                                                  |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| `Bool`, `Int`, `Double`, `String`, `URL`, `Data`       | iOS 14 이상의 기본 `@AppStorage` 값으로 사용할 수 있어요.  |
+| `Date`                                                 | iOS 18 이상에서 전용 initializer를 사용할 수 있어요.       |
+| `RawRepresentable`이며 raw value가 `String` 또는 `Int` | enum 같은 사용자 정의 선택지를 저장할 때 사용할 수 있어요. |
+| 위 기본 타입의 Optional                                | 저장값이 없음을 `nil`로 표현해야 할 때 사용할 수 있어요.   |
+
+`Float`, 배열, 딕셔너리, 임의의 `Codable` 구조체는 `@AppStorage` 프로퍼티 타입으로 직접 사용할 수 없어요. 작은 enum은 `RawRepresentable`로 표현하고, 복잡한 모델은 전용 저장 계층을 선택해요.
+
+## RawRepresentable enum은 raw value로 저장돼요
+
+사용자가 독서 화면의 테마를 선택한다고 가정해 볼게요.
+
+```swift
+import SwiftUI
+
+enum ReadingTheme: String, CaseIterable, Identifiable {
+  case system
+  case light
+  case dark
+
+  var id: Self { self }
+
+  var title: String {
+    switch self {
+    case .system:
+      "시스템 설정"
+    case .light:
+      "라이트"
+    case .dark:
+      "다크"
+    }
+  }
+}
+
+struct ThemeSettingsView: View {
+  @AppStorage("reading.theme")
+  private var theme = ReadingTheme.system
+
+  var body: some View {
+    Picker("테마", selection: $theme) {
+      ForEach(ReadingTheme.allCases) { theme in
+        Text(theme.title)
+          .tag(theme)
+      }
+    }
+  }
+}
+```
+
+실제 UserDefaults에는 `"system"`, `"light"`, `"dark"` 같은 `String` raw value가 저장돼요. case 이름이나 raw value를 바꾸면 예전 앱이 저장한 값을 복원하지 못할 수 있으므로 저장 schema처럼 안정적으로 관리해야 해요.
+
+## store를 지정하면 다른 UserDefaults를 사용할 수 있어요
+
+`store` 인자에 `UserDefaults` 인스턴스를 전달하면 `standard` 대신 해당 저장소를 사용해요.
+
+```swift
+import SwiftUI
+
+struct ReadingSettingsView: View {
+  @AppStorage private var dailyGoal: Int
+
+  init(store: UserDefaults = .standard) {
+    _dailyGoal = AppStorage(
+      wrappedValue: 30,
+      "reading.dailyGoal",
+      store: store
+    )
+  }
+
+  var body: some View {
+    Stepper(
+      "하루 목표: \(dailyGoal)분",
+      value: $dailyGoal,
+      in: 10...180,
+      step: 10
+    )
+  }
+}
+```
+
+initializer에서 backing storage인 `_dailyGoal`을 직접 초기화해요. 기본 실행에서는 `.standard`를 사용하고 preview나 테스트에서는 별도 suite를 전달할 수 있어요.
+
+```swift
+#Preview {
+  let suiteName = "ReadingSettingsPreview"
+  let store = UserDefaults(suiteName: suiteName)!
+  store.set(90, forKey: "reading.dailyGoal")
+
+  return ReadingSettingsView(store: store)
+}
+```
+
+preview를 여러 번 실행할 때 값이 남는 것이 싫다면 preview 전용 key를 사용하거나 실행 전에 persistent domain을 정리해요.
+
+## defaultAppStorage는 하위 View의 기본 store를 바꿔요
+
+여러 View가 같은 custom store를 사용한다면 모든 선언에 `store:`를 반복하는 대신 View나 Scene의 `defaultAppStorage(_:)`를 사용할 수 있어요.
+
+```swift
+import SwiftUI
+
+enum SharedDefaults {
+  static let appGroupID = "group.com.example.Reading"
+
+  static let store: UserDefaults = {
+    guard let store = UserDefaults(suiteName: appGroupID) else {
+      preconditionFailure("App Group 설정을 확인하세요.")
+    }
+
+    return store
+  }()
+}
+
+@main
+struct ReadingApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ReadingSettingsView()
+    }
+    .defaultAppStorage(SharedDefaults.store)
+  }
+}
+```
+
+이 Scene 아래의 `@AppStorage`는 `store:`를 생략해도 `SharedDefaults.store`를 사용해요.
+
+```swift
+struct ReadingSettingsView: View {
+  @AppStorage("reading.dailyGoal")
+  private var dailyGoal = 30
+
+  var body: some View {
+    Text("하루 목표: \(dailyGoal)분")
+  }
+}
+```
+
+[`defaultAppStorage(_:)`](<https://developer.apple.com/documentation/swiftui/view/defaultappstorage(_:)>)는 environment처럼 View 계층에 기본 store를 전달해요. 코드만 보면 어떤 store를 사용하는지 숨겨질 수 있으므로 앱 전체가 같은 store를 쓰는 경계에서 적용하고, 서로 다른 suite가 섞이는 화면에서는 `store:`를 명시하는 편이 읽기 쉬울 수 있어요.
+
+App Group store를 사용하려면 앱 target과 extension target 모두 같은 App Groups capability와 entitlement를 가져야 해요. 문자열만 같은 이름으로 만들었다고 접근 권한이 생기지는 않아요.
+
+## AppStorage는 저장 위치와 View 연결을 모두 포함해요
+
+`@State`와 비교하면 차이가 더 분명해요.
+
+```swift
+struct GoalEditor: View {
+  @State private var draftGoal = 30
+  @AppStorage("reading.dailyGoal")
+  private var savedGoal = 30
+
+  var body: some View {
+    Form {
+      Stepper(
+        "편집 중: \(draftGoal)분",
+        value: $draftGoal,
+        in: 10...180,
+        step: 10
+      )
+
+      Button("저장") {
+        savedGoal = draftGoal
+      }
+    }
+  }
+}
+```
+
+- `draftGoal`은 View identity와 연결된 임시 편집 상태예요.
+- `savedGoal`은 UserDefaults key와 연결된 영속 설정이에요.
+
+사용자가 Cancel을 누를 수 있는 form이라면 모든 입력을 곧바로 `@AppStorage`에 쓰지 않고 `@State` 초안에 모았다가 Save 시점에 기록하는 편이 의도에 맞아요.
+
+## State, SceneStorage, AppStorage의 수명이 달라요
+
+| 도구            | 값이 연결되는 위치                  | 앱 재실행 후 기대                         | 적합한 예                                     |
+| --------------- | ----------------------------------- | ----------------------------------------- | --------------------------------------------- |
+| `@State`        | 현재 View identity의 SwiftUI 저장소 | 일반적으로 유지하지 않아요.               | sheet 표시 여부, 입력 중인 초안               |
+| `@SceneStorage` | 특정 Scene의 상태 복원 저장소       | 시스템이 scene 복원을 시도해요.           | 창마다 다른 선택 탭, navigation 복원 단서     |
+| `@AppStorage`   | UserDefaults의 key                  | persistent domain에 저장된 값을 유지해요. | 앱 전체 테마, 작은 사용자 설정                |
+| 모델 저장소     | 파일이나 데이터베이스               | 저장 정책에 따라 유지해요.                | 책 목록, 기록 내역, 검색 가능한 관계형 데이터 |
+
+`@SceneStorage`는 scene마다 값이 다르고 저장 시점이나 횟수를 시스템이 관리해요. `@AppStorage`는 같은 store와 key를 사용하는 곳이 하나의 설정을 공유해요.
+
+## AppStorage는 앱의 전체 모델을 대신하지 않아요
+
+화면에 저장 설정이 많다고 모든 프로퍼티를 `@AppStorage`로 선언하면 key 문자열과 저장 정책이 View 곳곳에 퍼져요.
+
+```swift
+struct ProfileView: View {
+  @AppStorage("profile.name") private var name = ""
+  @AppStorage("profile.age") private var age = 0
+  @AppStorage("profile.avatar") private var avatar = Data()
+  @AppStorage("profile.introduction") private var introduction = ""
+
+  // 프로필 모델이 커질수록 View가 저장 schema까지 책임져요.
+  var body: some View {
+    Text(name)
+  }
+}
+```
+
+다음 상황에는 `@Observable` 모델과 전용 repository나 데이터베이스를 조합하는 편이 좋아요.
+
+- 여러 값이 하나의 transaction처럼 함께 검증되고 저장돼야 해요.
+- 비동기 I/O, 오류 처리, migration이 필요해요.
+- 목록 검색, 정렬, 관계 표현이 필요해요.
+- 저장 정책을 View와 분리해 unit test하고 싶어요.
+
+`@AppStorage`는 **View가 직접 소비하는 작은 설정**에 가장 잘 맞아요.
+
+## App Group과 Widget에서는 Binding보다 snapshot 흐름을 사용해요
+
+App과 Widget extension이 같은 App Group suite를 사용하면 둘 다 같은 설정을 읽을 수 있어요. 하지만 Widget은 앱의 SwiftUI View와 같은 프로세스에서 계속 실행되지 않으므로 `$dailyGoal` Binding이 앱과 Widget 화면을 실시간으로 연결하지는 않아요.
+
+앱은 공유 store에 값을 쓰고 `WidgetCenter`에 timeline reload를 요청해요. Widget provider는 새 timeline을 만들 때 shared defaults를 읽고 `TimelineEntry`에 값의 snapshot을 넣어요. 전체 코드는 [App Groups와 Widget 데이터 공유](./app-groups) 문서에서 설명해요.
+
+## 개인정보 보호와 저장 기준은 UserDefaults와 같아요
+
+`@AppStorage`의 저장소는 `UserDefaults`이므로 같은 주의점이 적용돼요.
+
+- 민감하거나 개인을 식별하는 값을 저장하지 않아요.
+- 큰 `Data`나 복잡한 모델을 편의상 넣지 않아요.
+- 기기 간 동기화 기능으로 오해하지 않아요.
+- `PrivacyInfo.xcprivacy`에 실제 UserDefaults 사용 범위와 맞는 required reason을 선언해요.
+- App Group suite를 사용하면 같은 group 구성원 모두가 그 값을 읽을 수 있다는 점을 고려해요.
+
+## 언제 AppStorage를 사용해야 하나요
+
+다음 조건을 대부분 만족하면 적합해요.
+
+- SwiftUI View가 직접 읽고 편집하는 작은 설정이에요.
+- `Bool`, `Int`, `Double`, `String`, `URL`, `Data`, 지원 OS의 `Date`, 또는 `String`·`Int` raw value enum으로 표현돼요.
+- 같은 key의 변경이 곧바로 화면 갱신으로 이어져야 해요.
+- 별도 저장 오류 처리나 transaction이 필요하지 않아요.
+- 값이 민감하지 않고 UserDefaults에 저장하기 적합해요.
+
+## 적용 순서를 정리해요
+
+1. 값이 UserDefaults에 적합한 작은 설정인지 확인해요.
+2. key와 기본값을 한 위치에서 정의해 오타와 불일치를 줄여요.
+3. 단일 View의 설정은 `@AppStorage(key)`로 시작해요.
+4. control에는 `$프로퍼티` Binding을 전달해요.
+5. 임시 편집값과 실제 저장값을 구분해야 하면 `@State` 초안을 둬요.
+6. custom suite가 필요하면 `store:` 또는 상위 `defaultAppStorage(_:)`를 선택해요.
+7. App Group 공유라면 모든 target의 entitlement와 Widget timeline reload를 함께 구성해요.
+8. privacy manifest와 지원 OS별 initializer를 검토해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### AppStorage와 UserDefaults는 어떤 관계인가요?
+
+`@AppStorage`는 별도 데이터베이스가 아니라 UserDefaults key를 SwiftUI dynamic property로 감싼 API예요. 읽기와 쓰기에 UserDefaults를 사용하면서 변경 시 View 무효화와 `Binding` 제공까지 연결해요.
+
+### AppStorage와 State는 어떻게 다른가요?
+
+`@State`는 View identity에 연결된 UI 상태이고 `@AppStorage`는 UserDefaults key에 연결된 영속 설정이에요. 임시 입력과 취소 가능한 초안은 `@State`, 앱 재실행 뒤에도 유지할 작은 설정은 `@AppStorage`가 적합해요.
+
+### AppStorage의 초기값은 register(defaults:)와 같은가요?
+
+아니에요. 래퍼의 초기값은 해당 `@AppStorage`가 key를 찾지 못했을 때 사용할 wrapped value예요. 앱 전체의 registration domain에 fallback을 제공하려면 `UserDefaults.register(defaults:)`를 별도로 호출해야 해요.
+
+### defaultAppStorage는 언제 사용하나요?
+
+View 또는 Scene 계층 전체가 같은 custom `UserDefaults`를 사용해야 할 때 중복 `store:` 인자를 줄여요. 다만 저장소 선택이 계층 위에 숨겨지므로 서로 다른 suite가 섞이는 화면에서는 직접 지정하는 방식이 더 명확할 수 있어요.
+
+### AppStorage를 Widget View에 선언하면 앱 변경이 즉시 보이나요?
+
+같은 suite의 값을 읽을 수는 있지만 Widget은 별도 프로세스에서 timeline snapshot으로 렌더링돼요. 앱이 값을 쓴 뒤 `WidgetCenter`에 reload를 요청하고 provider가 새 entry를 만들게 해야 하며, 요청 시점에 즉시 렌더링된다는 보장도 없어요.
+
+## 참고 자료
+
+- [Apple Developer — AppStorage](https://developer.apple.com/documentation/swiftui/appstorage)
+- [Apple Developer — defaultAppStorage(_:)](<https://developer.apple.com/documentation/swiftui/view/defaultappstorage(_:)>)
+- [Apple Developer — SceneStorage](https://developer.apple.com/documentation/swiftui/scenestorage)
+- [Apple Developer — UserDefaults](https://developer.apple.com/documentation/foundation/userdefaults)
+- [Apple Developer — Configuring app groups](https://developer.apple.com/documentation/xcode/configuring-app-groups)
+- [Swift-KR — UserDefaults](./userdefaults)
+- [Swift-KR — App Groups와 Widget 데이터 공유](./app-groups)
+- [Swift-KR — Property Wrapper](../swift/property-wrappers)
+- [Swift-KR — @Observable과 Observation](../swiftui/state-management/observation)

--- a/docs/guide/data-storage/userdefaults.md
+++ b/docs/guide/data-storage/userdefaults.md
@@ -1,0 +1,472 @@
+---
+title: Swift로 이해하는 UserDefaults
+description: UserDefaults의 key-value 저장, 지원 타입, 도메인 검색 순서, 메모리·디스크 반영, 개인정보 보호와 테스트 기준을 Swift 예제로 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 UserDefaults
+
+> **면접 답변 한 줄 요약:** `UserDefaults`는 앱의 작고 민감하지 않은 설정을 문자열 key와 property list 값으로 저장하는 Foundation API이며, 값을 메모리에 즉시 반영하고 영속 저장소에는 비동기로 기록해 다음 실행에서도 읽을 수 있게 해요.
+
+앱을 다시 실행해도 다크 모드 선택, 알림 허용 여부, 마지막으로 선택한 탭 같은 작은 설정은 유지되어야 해요. 이런 값을 매번 파일로 직렬화하고 경로를 관리할 수도 있지만, 단순한 설정에는 코드가 지나치게 커져요.
+
+`UserDefaults`는 이런 **사용자 기본 설정과 앱 구성 값**을 key-value 형태로 관리해요. 이름에 `Defaults`가 들어가지만 기본값만 제공하는 API는 아니에요. [Apple의 UserDefaults 문서](https://developer.apple.com/documentation/foundation/userdefaults)가 정의하듯 실제로 변경한 값을 기기에 영속적으로 저장하고, 다음 실행에서 다시 읽을 수 있는 설정 데이터베이스의 인터페이스예요.
+
+이 문서에서는 독서 목표 앱을 예로 들어 다음 내용을 설명해요.
+
+- `UserDefaults.standard`로 값을 읽고 쓰는 방법
+- 저장 가능한 값과 큰 모델을 넣지 않아야 하는 이유
+- 등록 기본값과 저장된 값의 차이
+- 여러 domain을 검색해 최종 값을 결정하는 구조
+- 메모리 반영과 비동기 디스크 저장의 관계
+- key 관리, 관찰, 동시성, 테스트 기준
+- privacy manifest에 UserDefaults 사용 이유를 선언하는 방법
+- `@AppStorage`와 App Group 공유로 이어지는 관계
+
+## 먼저 알아둘 저장 용어
+
+| 용어                  | 쉬운 뜻                                                                                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key-value 저장        | 문자열 key로 값을 찾는 저장 방식이에요. `reading.dailyGoal`이라는 key에 `30`을 연결하는 식이에요.                                                               |
+| 영속성(persistence)   | 앱 프로세스가 종료된 뒤에도 값을 남겨 다음 실행에서 다시 읽을 수 있는 성질이에요.                                                                               |
+| property list 값      | Apple 플랫폼의 설정 파일이 기본으로 표현할 수 있는 문자열, 숫자, Boolean, 날짜, 데이터, 배열, 딕셔너리 같은 값이에요.                                           |
+| domain                | 설정의 출처와 우선순위를 구분하는 논리적인 저장 영역이에요. 앱이 저장한 값, 실행 인자, 등록 기본값이 서로 다른 domain에 들어가요.                               |
+| volatile domain       | 현재 프로세스가 실행되는 동안만 존재하고 종료되면 사라지는 설정 영역이에요.                                                                                     |
+| persistent domain     | 기기의 영속 저장소에 기록되어 앱을 다시 실행해도 남는 설정 영역이에요.                                                                                          |
+| suite                 | 기본 앱 domain과 구분되는 사용자 정의 설정 domain이에요. App Group 식별자로 만든 suite는 앱과 extension이 같은 설정을 읽게 해요.                                |
+| 직렬화(serialization) | 메모리의 값을 저장하거나 전달할 수 있는 `Data` 형태로 바꾸는 과정이에요. `Codable` 모델을 `JSONEncoder`로 변환하는 작업이 한 예예요.                            |
+| privacy manifest      | 앱이나 SDK가 수집하는 데이터와 required reason API 사용 이유를 기록하는 `PrivacyInfo.xcprivacy` 파일이에요. `UserDefaults`는 사용 이유를 선언해야 하는 API예요. |
+
+## 메모리에만 저장하면 다음 실행에서 사라져요
+
+독서 목표를 일반 저장 프로퍼티로 관리해 볼게요.
+
+```swift
+final class ReadingSettings {
+  var dailyGoal = 30
+}
+```
+
+사용자가 `dailyGoal`을 60으로 바꿔도 이 값은 현재 `ReadingSettings` 인스턴스의 메모리에만 있어요. 앱 프로세스가 종료되면 인스턴스도 사라지고, 다음 실행에서는 다시 `30`으로 시작해요.
+
+설정 하나를 직접 파일에 저장하려면 다음 책임을 모두 작성해야 해요.
+
+1. 저장할 파일의 안전한 위치를 찾습니다.
+2. 값을 `Data`로 인코딩합니다.
+3. 쓰기 실패와 파일 손상을 처리합니다.
+4. 다음 실행에서 파일을 읽고 디코딩합니다.
+5. 값이 없거나 예전 형식이면 기본값을 결정합니다.
+
+작은 설정 몇 개에는 이 비용이 커요. `UserDefaults`를 사용하면 key와 값에 집중할 수 있어요.
+
+## standard는 현재 앱의 기본 설정 저장소예요
+
+`UserDefaults.standard`는 현재 앱의 표준 설정을 읽고 쓰는 공유 인스턴스예요.
+
+```swift
+import Foundation
+
+enum PreferenceKey {
+  static let dailyGoal = "reading.dailyGoal"
+  static let reminderEnabled = "reading.reminderEnabled"
+}
+
+let defaults = UserDefaults.standard
+
+defaults.set(45, forKey: PreferenceKey.dailyGoal)
+defaults.set(true, forKey: PreferenceKey.reminderEnabled)
+
+let dailyGoal = defaults.integer(forKey: PreferenceKey.dailyGoal)
+let reminderEnabled = defaults.bool(forKey: PreferenceKey.reminderEnabled)
+
+print(dailyGoal)
+// 45
+
+print(reminderEnabled)
+// true
+```
+
+`set(_:forKey:)`로 쓴 값은 앱의 persistent domain에 연결돼요. 다음 실행에서도 같은 bundle의 `UserDefaults.standard`가 같은 key를 검색해 값을 가져와요.
+
+문자열 key를 코드 여러 곳에 직접 반복하면 오타가 생겨도 컴파일러가 찾지 못해요. 한쪽은 `reading.dailyGoal`, 다른 쪽은 `reading.dailygoal`을 사용하면 서로 다른 값으로 취급돼요. 작은 `enum`이나 전용 저장 타입에 key를 모으면 이름 변경과 검색이 쉬워져요.
+
+## 등록 기본값은 저장값이 없을 때 사용하는 fallback이에요
+
+정수 getter인 `integer(forKey:)`는 key가 없거나 정수로 바꿀 수 없으면 `0`을 반환해요. 하지만 독서 목표의 기본값이 `30`이라면 매번 `0`인지 검사하는 방식은 의미가 불분명해요.
+
+앱 시작 직후 기본값을 등록해 두는 편이 명확해요.
+
+```swift
+import Foundation
+
+enum DefaultPreferences {
+  static let values: [String: Any] = [
+    PreferenceKey.dailyGoal: 30,
+    PreferenceKey.reminderEnabled: false,
+  ]
+}
+
+let defaults = UserDefaults.standard
+defaults.register(defaults: DefaultPreferences.values)
+
+print(defaults.integer(forKey: PreferenceKey.dailyGoal))
+// 저장값이 없다면 30
+```
+
+`register(defaults:)`는 값을 앱의 persistent domain에 저장하지 않아요. 가장 낮은 우선순위의 **registration domain**에 fallback을 넣어요. 이 domain은 volatile이므로 앱을 실행할 때마다 다시 등록해야 해요.
+
+사용자가 목표를 `45`로 저장하면 앱 domain의 값이 registration domain보다 먼저 발견돼 `45`가 반환돼요. 나중에 저장값을 제거하면 다시 등록 기본값 `30`이 보여요.
+
+```swift
+defaults.set(45, forKey: PreferenceKey.dailyGoal)
+print(defaults.integer(forKey: PreferenceKey.dailyGoal))
+// 45
+
+defaults.removeObject(forKey: PreferenceKey.dailyGoal)
+print(defaults.integer(forKey: PreferenceKey.dailyGoal))
+// 30
+```
+
+등록 기본값은 **아직 사용자가 선택하지 않은 상태**를 표현할 때 유용해요. 반대로 “사용자가 이 기능을 한 번 설정했는가?”를 구분해야 한다면 `object(forKey:)`로 실제 값의 존재 여부를 확인하거나 별도 key를 두어야 해요.
+
+```swift
+let hasSavedGoal = defaults.object(forKey: PreferenceKey.dailyGoal) != nil
+```
+
+registration domain에도 같은 key가 있으면 `object(forKey:)`가 fallback을 찾을 수 있으므로, 실제 앱 domain만 검사해야 하는 고급 상황에서는 `persistentDomain(forName:)`처럼 domain을 명시하는 API를 검토해야 해요. 대부분의 앱에서는 명시적인 `hasConfiguredGoal` key가 의도를 더 잘 드러내요.
+
+## property list로 표현할 수 있는 값을 저장해요
+
+Apple 공식 문서에서 안내하는 주요 저장 타입은 다음과 같아요.
+
+| 분류       | 예시                                              | 사용 기준                                            |
+| ---------- | ------------------------------------------------- | ---------------------------------------------------- |
+| 문자열     | `String`                                          | 이름, 선택한 옵션 식별자처럼 짧은 텍스트에 사용해요. |
+| 숫자       | `Int`, `Float`, `Double`, `NSNumber`              | 횟수, 비율, 임계값 같은 설정에 사용해요.             |
+| 논리값     | `Bool`                                            | 기능 켜기·끄기 설정에 사용해요.                      |
+| 시간과 URL | `Date`, `URL`                                     | 마지막 확인 시각이나 작은 URL 설정에 사용해요.       |
+| 바이너리   | `Data`                                            | 꼭 필요한 작은 직렬화 결과에 사용해요.               |
+| 컬렉션     | property list 값으로 구성된 `Array`, `Dictionary` | 작고 구조가 단순한 목록이나 매핑에 사용해요.         |
+
+`UserDefaults`에 임의의 Swift 구조체를 그대로 넣을 수는 없어요.
+
+```swift
+struct ReadingProfile: Codable {
+  let nickname: String
+  let favoriteGenres: [String]
+}
+
+let profile = ReadingProfile(
+  nickname: "Blob",
+  favoriteGenres: ["Swift", "Architecture"]
+)
+
+let data = try JSONEncoder().encode(profile)
+defaults.set(data, forKey: "reading.profile")
+
+guard let savedData = defaults.data(forKey: "reading.profile") else {
+  throw CocoaError(.fileReadNoSuchFile)
+}
+
+let restored = try JSONDecoder().decode(
+  ReadingProfile.self,
+  from: savedData
+)
+```
+
+코드는 가능하지만 모든 모델을 `Data`로 바꿔 넣어도 된다는 뜻은 아니에요. 모델이 커질수록 다음 문제가 생겨요.
+
+- 작은 필드 하나만 바꿔도 전체 `Data`를 다시 인코딩하고 저장해야 해요.
+- 모델 구조가 바뀌면 이전 데이터의 migration을 직접 처리해야 해요.
+- 검색, 정렬, 부분 갱신, 관계 표현이 어려워요.
+- 앱 시작 시 큰 값을 읽고 디코딩하면 성능에 영향을 줄 수 있어요.
+
+작은 설정은 `UserDefaults`, 큰 문서나 이미지와 원자적으로 교체할 snapshot은 파일, 검색과 관계가 필요한 모델은 SwiftData·Core Data·SQLite 같은 데이터베이스를 고려해요.
+
+## UserDefaults는 값을 찾을 때 domain을 순서대로 검색해요
+
+`UserDefaults`는 하나의 딕셔너리만 읽는 것처럼 보이지만 내부적으로 여러 **설정 domain**을 우선순위대로 검색해요. 높은 우선순위에서 key를 찾으면 더 아래 domain은 보지 않아요.
+
+Apple 공식 문서가 설명하는 주요 순서는 다음과 같아요. 일부 domain은 특정 기기나 실행 환경에서만 존재해요.
+
+| 검색 순서 | domain              | 저장 성격  | 역할                                                                                      |
+| --------- | ------------------- | ---------- | ----------------------------------------------------------------------------------------- |
+| 1         | Managed             | persistent | 관리자가 관리 기기에 강제로 제공한 설정이에요. 앱은 이 값을 직접 쓸 수 없어요.            |
+| 2         | Argument            | volatile   | Xcode 실행 인자나 명령줄로 전달한 임시 override예요. 테스트 후 프로세스 종료 시 사라져요. |
+| 3         | Educational managed | persistent | 교육 기관의 관리 환경에서 제공하는 설정이에요.                                            |
+| 4         | App                 | persistent | 현재 앱 또는 `suiteName`으로 지정한 App Group이 저장한 값이에요.                          |
+| 5         | Suite               | persistent | `addSuite(named:)`로 검색 목록에 추가한 사용자 정의 domain이에요.                         |
+| 6         | Global              | persistent | 시스템이 모든 앱에 제공하는 전역 설정이에요. 앱은 여기에 쓸 수 없어요.                    |
+| 7         | Registration        | volatile   | 앱이 `register(defaults:)`로 등록한 마지막 fallback이에요.                                |
+
+이 구조 때문에 등록 기본값과 저장값이 같은 key를 사용해도 충돌하지 않아요. 앱 domain에 값이 있으면 먼저 반환되고, 없을 때만 registration domain까지 내려가요.
+
+`addSuite(named:)`는 다른 domain을 **검색 목록에 추가**할 뿐 쓰기 대상을 바꾸지 않아요. App Group domain에 직접 쓰려면 해당 식별자로 별도 인스턴스를 만들어야 해요.
+
+```swift
+let defaults = UserDefaults.standard
+defaults.addSuite(named: "group.com.example.Reading")
+
+// 읽기는 앱 domain 다음에 추가한 suite도 검색해요.
+let goal = defaults.integer(forKey: PreferenceKey.dailyGoal)
+
+// 쓰기 대상은 여전히 현재 앱의 domain이에요.
+defaults.set(60, forKey: PreferenceKey.dailyGoal)
+```
+
+공유 App Group에 읽고 쓰려면 다음처럼 `init(suiteName:)`을 사용해요. 실제 앱에서는 같은 App Group entitlement가 target에 있어야 해요.
+
+```swift
+guard let sharedDefaults = UserDefaults(
+  suiteName: "group.com.example.Reading"
+) else {
+  preconditionFailure("App Group 설정을 확인하세요.")
+}
+
+sharedDefaults.set(60, forKey: PreferenceKey.dailyGoal)
+```
+
+App과 Widget이 이 suite를 공유하는 전체 과정은 [App Groups와 Widget 데이터 공유](./app-groups) 문서에서 이어서 설명해요.
+
+## 쓰기는 메모리에 즉시 반영되고 디스크에는 비동기로 저장돼요
+
+`set`을 호출했을 때의 흐름을 단순화하면 다음과 같아요.
+
+```text
+호출 코드
+   │ set(value, forKey:)
+   ▼
+UserDefaults의 메모리 표현 ── 즉시 갱신 ──▶ 같은 프로세스의 다음 읽기
+   │
+   └──────── 비동기 기록 ────────────────▶ defaults 영속 저장소
+```
+
+`set` 직후 같은 `UserDefaults`에서 값을 읽으면 갱신된 메모리 값을 얻어요. Apple은 값을 쓰면 [메모리 표현을 즉시 갱신하고 디스크에는 비동기로 기록한다](https://developer.apple.com/documentation/foundation/userdefaults)고 설명해요. 매번 저장 완료를 기다리며 UI를 막는 구조가 아니에요.
+
+이 구현 세부 때문에 defaults 파일 경로를 추측해서 직접 열거나 수정하면 안 돼요. Apple은 내부 파일을 직접 바꾸면 데이터 손실, 변경 반영 지연, 앱 crash가 발생할 수 있다고 경고해요. 논리적인 key-value API만 사용해야 해요.
+
+### synchronize는 호출하지 않아요
+
+오래된 코드에서는 앱 종료 전 `synchronize()`를 호출하는 예를 볼 수 있어요.
+
+```swift
+defaults.set(45, forKey: PreferenceKey.dailyGoal)
+defaults.synchronize() // 사용하지 않아요.
+```
+
+현재 Apple 문서는 `synchronize()`가 불필요하며 사용하지 말아야 한다고 명시해요. 시스템이 변경을 자동으로 영속 저장소에 반영하도록 두고, 저장 완료를 강제로 제어해야 하는 데이터라면 `UserDefaults`가 아니라 원자적 파일 쓰기나 transaction을 제공하는 데이터베이스가 더 적합한지 검토해요.
+
+## UserDefaults 인스턴스는 thread-safe지만 여러 단계 연산은 따로 보호해요
+
+Apple은 `UserDefaults`를 여러 thread나 task에서 동시에 사용할 수 있는 thread-safe 타입으로 문서화해요. 개별 `set`과 getter 호출 때문에 내부 저장 구조가 깨지지는 않아요.
+
+하지만 읽고 계산하고 다시 쓰는 세 호출 전체가 하나의 원자적 연산이 되는 것은 아니에요.
+
+```swift
+func increaseLaunchCount(defaults: UserDefaults) {
+  let oldValue = defaults.integer(forKey: "app.launchCount")
+  defaults.set(oldValue + 1, forKey: "app.launchCount")
+}
+```
+
+두 task가 동시에 `oldValue`를 읽으면 같은 값에 각각 1을 더해 한 번의 증가가 사라질 수 있어요. 이런 read-modify-write를 정확히 직렬화해야 한다면 actor나 lock으로 상위 연산을 보호해야 해요. 여러 프로세스가 함께 쓰는 복잡한 데이터라면 transaction을 지원하는 저장소를 선택해요.
+
+```swift
+actor LaunchCounter {
+  private let defaults: UserDefaults
+  private let key = "app.launchCount"
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+  }
+
+  func increase() -> Int {
+    let nextValue = defaults.integer(forKey: key) + 1
+    defaults.set(nextValue, forKey: key)
+    return nextValue
+  }
+}
+```
+
+## 변경을 관찰할 수 있지만 화면 연결에는 AppStorage가 간단해요
+
+`UserDefaults`는 설정 변경 notification을 제공해요. 모든 key 변경을 넓게 관찰할 때는 `didChangeNotification`을 사용할 수 있어요.
+
+```swift
+import Foundation
+
+let token = NotificationCenter.default.addObserver(
+  forName: UserDefaults.didChangeNotification,
+  object: UserDefaults.standard,
+  queue: .main
+) { _ in
+  let goal = UserDefaults.standard.integer(
+    forKey: PreferenceKey.dailyGoal
+  )
+  print("목표 변경:", goal)
+}
+
+// 관찰이 더 필요하지 않을 때 해제해요.
+NotificationCenter.default.removeObserver(token)
+```
+
+notification은 어떤 key가 바뀌었는지 직접 전달하지 않으므로 필요한 값을 다시 읽어야 해요. SwiftUI View의 작은 설정 하나를 연결하려는 목적이라면 UserDefaults notification을 직접 관리하는 대신 [`@AppStorage`](./appstorage)를 사용하면 값 변경과 View 갱신을 함께 처리할 수 있어요.
+
+App과 Widget은 서로 다른 프로세스이므로 notification이나 SwiftUI Binding으로 화면이 실시간 연결된다고 가정하면 안 돼요. 공유 저장소에 값을 쓴 뒤 WidgetKit에 timeline reload를 요청하는 별도 흐름이 필요해요.
+
+## 저장 접근을 한 타입에 모으면 key와 기본값이 일관돼요
+
+화면마다 `UserDefaults.standard`와 문자열 key를 직접 사용하면 저장 정책이 UI 코드에 퍼져요. 전용 타입이 key, 기본값, 값 검증을 담당하게 만들 수 있어요.
+
+```swift
+import Foundation
+
+struct ReadingPreferences {
+  private enum Key {
+    static let dailyGoal = "reading.dailyGoal"
+    static let reminderEnabled = "reading.reminderEnabled"
+  }
+
+  private let defaults: UserDefaults
+
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+    defaults.register(defaults: [
+      Key.dailyGoal: 30,
+      Key.reminderEnabled: false,
+    ])
+  }
+
+  var dailyGoal: Int {
+    get {
+      defaults.integer(forKey: Key.dailyGoal)
+    }
+    nonmutating set {
+      defaults.set(max(newValue, 1), forKey: Key.dailyGoal)
+    }
+  }
+
+  var reminderEnabled: Bool {
+    get {
+      defaults.bool(forKey: Key.reminderEnabled)
+    }
+    nonmutating set {
+      defaults.set(newValue, forKey: Key.reminderEnabled)
+    }
+  }
+}
+```
+
+호출 코드는 저장 key를 몰라도 돼요.
+
+```swift
+let preferences = ReadingPreferences()
+preferences.dailyGoal = 45
+preferences.reminderEnabled = true
+```
+
+이 구조는 `UserDefaults`를 데이터베이스처럼 추상화하기 위한 목적이 아니에요. 문자열 key와 검증 규칙이 여러 화면에 퍼지는 것을 막고, 테스트에서 저장소를 바꾸기 쉽게 만드는 작은 경계예요.
+
+## 테스트에서는 전용 suite를 만들고 흔적을 제거해요
+
+테스트가 `UserDefaults.standard`를 사용하면 이전 테스트나 개발 중 저장한 값에 영향을 받을 수 있어요. 테스트마다 고유한 suite 이름을 만들면 값을 격리할 수 있어요.
+
+```swift
+import Foundation
+import Testing
+
+@Test
+func dailyGoalIsClampedToPositiveValue() {
+  let suiteName = "ReadingPreferencesTests.\(UUID().uuidString)"
+  let defaults = UserDefaults(suiteName: suiteName)!
+
+  defer {
+    defaults.removePersistentDomain(forName: suiteName)
+  }
+
+  let preferences = ReadingPreferences(defaults: defaults)
+  preferences.dailyGoal = -10
+
+  #expect(preferences.dailyGoal == 1)
+}
+```
+
+테스트가 끝나면 `removePersistentDomain(forName:)`으로 suite를 정리해 다른 실행에 영향을 주지 않게 해요. 실제 App Group suite를 사용하는 통합 테스트에서는 test target의 entitlement와 서명 환경도 함께 확인해야 해요.
+
+## 민감한 정보와 큰 데이터는 저장하지 않아요
+
+Apple은 defaults 시스템의 정보가 디스크에 암호화되지 않은 형태로 저장될 수 있으므로 개인 정보나 민감한 정보를 넣지 말라고 안내해요.
+
+| 데이터                                 | 권장 저장소                            |
+| -------------------------------------- | -------------------------------------- |
+| 다크 모드, 정렬 방식, 작은 기능 flag   | `UserDefaults`                         |
+| 인증 token, 비밀번호, 암호화 key       | Keychain                               |
+| 이미지, 문서, 큰 JSON snapshot         | 앱 또는 App Group 파일 container       |
+| 검색·정렬·관계·부분 수정이 필요한 모델 | SwiftData, Core Data, SQLite           |
+| 여러 기기의 같은 사용자 설정           | `NSUbiquitousKeyValueStore`나 CloudKit |
+
+또한 `UserDefaults`는 required reason API예요. 앱이나 SDK에서 사용할 때 `PrivacyInfo.xcprivacy`의 `NSPrivacyAccessedAPITypes`에 [Apple이 허용한 실제 사용 이유](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype)를 선언해야 해요.
+
+- 앱 자체만 접근하는 설정에는 Apple이 정의한 `CA92.1` reason을 검토해요.
+- 같은 App Group의 앱·extension·App Clip이 함께 접근하는 설정에는 `1C8F.1` reason을 검토해요.
+
+reason code를 단순 복사하지 말고 현재 Apple 문서의 허용 범위와 실제 구현이 일치하는지 확인해야 해요. fingerprinting 목적으로 기기 신호를 수집하는 것은 허용되지 않아요.
+
+## 언제 UserDefaults를 사용해야 하나요
+
+다음 조건을 대부분 만족하면 적합해요.
+
+- 앱의 시작 상태나 동작을 바꾸는 작은 설정이에요.
+- 값이 property list 타입으로 자연스럽게 표현돼요.
+- key 하나로 전체 값을 읽고 쓰는 방식이 충분해요.
+- 민감한 정보가 아니에요.
+- 기기 간 동기화가 필요하지 않아요.
+- transaction, 복잡한 검색, 관계, 대량 데이터가 필요하지 않아요.
+
+값을 “저장할 수 있다”는 사실과 “저장하기 적합하다”는 판단은 달라요. `Data`로 인코딩할 수 있다는 이유만으로 모든 앱 모델을 넣지 않아요.
+
+## 적용 순서를 정리해요
+
+1. 저장하려는 값이 작은 비민감 설정인지 확인해요.
+2. 문자열 key를 한 위치에 모으고 의미가 드러나는 namespace를 사용해요.
+3. 앱 시작 시 `register(defaults:)`로 fallback을 등록해요.
+4. 타입에 맞는 getter와 `set(_:forKey:)`를 사용해요.
+5. `synchronize()`나 내부 defaults 파일 직접 접근을 제거해요.
+6. 여러 단계 갱신에는 actor·lock·transaction이 필요한지 검토해요.
+7. 테스트 저장소를 격리하고 종료 후 persistent domain을 정리해요.
+8. `PrivacyInfo.xcprivacy`의 UserDefaults required reason이 실제 사용과 맞는지 확인해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### UserDefaults의 값은 set을 호출하면 즉시 디스크에 저장되나요?
+
+메모리 표현에는 즉시 반영되지만 영속 저장소에는 비동기로 기록돼요. 같은 프로세스에서 이어지는 읽기는 새 값을 얻지만 디스크 파일을 직접 확인하거나 `synchronize()`로 강제하는 방식에 의존하면 안 돼요.
+
+### register(defaults:)와 set의 차이는 무엇인가요?
+
+`register(defaults:)`는 저장값이 없을 때 사용할 volatile fallback을 registration domain에 넣어요. `set`은 앱이나 suite의 persistent domain에 실제 선택값을 기록해 다음 실행에서도 유지해요.
+
+### UserDefaults가 thread-safe라면 동시성 처리가 필요 없나요?
+
+개별 API 호출은 thread-safe하지만 여러 호출로 구성된 read-modify-write 전체가 원자적인 것은 아니에요. 경쟁하면 안 되는 복합 연산은 actor나 lock으로 보호하고, 여러 프로세스 transaction이 필요하면 다른 저장소를 선택해요.
+
+### UserDefaults에 Codable 모델을 Data로 저장해도 되나요?
+
+작고 단순한 snapshot에는 가능하지만 모델이 커지면 전체 재인코딩, migration, 검색과 부분 수정 비용이 커져요. 저장 가능 여부보다 데이터 크기와 접근 패턴을 기준으로 파일이나 데이터베이스와 비교해야 해요.
+
+### standard와 suiteName으로 만든 UserDefaults는 어떻게 다른가요?
+
+`standard`는 현재 앱의 기본 domain을 읽고 쓰고, `init(suiteName:)`은 지정한 custom domain을 쓰기 대상으로 사용해요. App Group 식별자를 suite 이름으로 사용하고 entitlement가 맞으면 앱과 extension이 같은 설정을 공유할 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer — UserDefaults](https://developer.apple.com/documentation/foundation/userdefaults)
+- [Apple Developer — register(defaults:)](<https://developer.apple.com/documentation/foundation/userdefaults/register(defaults:)>)
+- [Apple Developer — init(suiteName:)](<https://developer.apple.com/documentation/foundation/userdefaults/init(suitename:)>)
+- [Apple Developer — synchronize()](<https://developer.apple.com/documentation/foundation/userdefaults/synchronize()>)
+- [Apple Developer — Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy-manifest-files)
+- [Apple Developer — UserDefaults required reason API](https://developer.apple.com/documentation/bundleresources/app-privacy-configuration/nsprivacyaccessedapitypes/nsprivacyaccessedapitype)
+- [Swift-KR — @AppStorage](./appstorage)
+- [Swift-KR — App Groups와 Widget 데이터 공유](./app-groups)
+- [Swift-KR — Property Wrapper](../swift/property-wrappers)


### PR DESCRIPTION
## Summary

- `UserDefaults`, SwiftUI의 `@AppStorage`, App Groups와 Widget 데이터 공유를 세 개의 상세 학습 문서로 추가합니다.
- 새 `데이터 저장` 섹션에서 Foundation 저장 원리부터 SwiftUI 연결, App–Widget 프로세스 간 공유까지 순서대로 학습할 수 있게 구성합니다.

## Changes

- `UserDefaults`의 지원 타입, 등록 기본값, domain 검색 순서, 메모리·비동기 디스크 반영, thread safety와 개인정보 보호 기준을 설명했습니다.
- `@AppStorage`의 View invalidation, Binding, 지원 타입, custom store, `defaultAppStorage`, `@State`·`@SceneStorage` 비교를 추가했습니다.
- App Groups의 capability, entitlement, code signing, process별 sandbox와 shared container 구조를 상세히 설명했습니다.
- App이 shared suite에 값을 저장하고 `WidgetCenter`로 reload를 요청한 뒤 Widget provider가 `TimelineEntry` snapshot을 만드는 전체 예제를 추가했습니다.
- shared UserDefaults, 원자적 파일, transaction 저장소와 Keychain의 선택 기준 및 다중 프로세스 동시 쓰기 주의점을 정리했습니다.
- UserDefaults required reason API의 `CA92.1`, App Group 공유의 `1C8F.1` privacy manifest 기준을 포함했습니다.
- 상단 내비게이션과 guide metadata에 `데이터 저장` 섹션을 연결했습니다.

## Testing

- Xcode 26.4 / iOS 17 Simulator SDK에서 Foundation, SwiftUI, WidgetKit 예제 타입 검사
- `npm run format`
- `npm run lint`
- `npx prettier --check .`
- `npm run build`
- 세 문서의 internal link와 내비게이션 JSON 검증
- Apple 공식 참고 링크 17개 HTTP 200 확인
- 개발 서버에서 세 신규 문서 경로 HTTP 200 확인
- 생성 HTML의 frontmatter와 description metadata 검증
- `git diff --check`
- 최신 `origin/main` 기준 `git merge-tree` 충돌 검사

## Related Issues

Closes #31

## Notes

- 세 주제는 저장소, SwiftUI 연결, 프로세스 간 공유라는 책임과 분량이 달라 각각의 문서로 분리했습니다.
- API 동작, Widget 갱신 제약, entitlement와 privacy manifest 내용은 Apple 공식 문서를 기준으로 작성했습니다.
