### PR TITLE
[#35] Swift 테스트, 핵심 프로토콜과 DifferenceKit 문서를 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -18,6 +18,12 @@
     "position": "left"
   },
   {
+    "text": "테스트",
+    "link": "/guide/testing/xctest-unit-testing",
+    "activeMatch": "/guide/testing/",
+    "position": "left"
+  },
+  {
     "text": "UIKit",
     "link": "/guide/uikit/collection-views/index",
     "activeMatch": "/guide/uikit/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -16,6 +16,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "testing",
+    "label": "테스트"
+  },
+  {
+    "type": "dir-section-header",
     "name": "uikit",
     "label": "UIKit"
   },

--- a/docs/guide/swift/_meta.json
+++ b/docs/guide/swift/_meta.json
@@ -15,6 +15,11 @@
     "label": "제네릭"
   },
   {
+    "type": "dir-section-header",
+    "name": "protocols",
+    "label": "핵심 프로토콜"
+  },
+  {
     "type": "file",
     "name": "opaque-types",
     "label": "some과 불투명 타입"

--- a/docs/guide/swift/protocols/_meta.json
+++ b/docs/guide/swift/protocols/_meta.json
@@ -1,0 +1,37 @@
+[
+  {
+    "type": "file",
+    "name": "equatable",
+    "label": "Equatable"
+  },
+  {
+    "type": "file",
+    "name": "hashable",
+    "label": "Hashable"
+  },
+  {
+    "type": "file",
+    "name": "identifiable",
+    "label": "Identifiable"
+  },
+  {
+    "type": "file",
+    "name": "codable",
+    "label": "Codable"
+  },
+  {
+    "type": "file",
+    "name": "comparable",
+    "label": "Comparable"
+  },
+  {
+    "type": "file",
+    "name": "sequence-and-collection",
+    "label": "Sequence와 Collection"
+  },
+  {
+    "type": "file",
+    "name": "sendable",
+    "label": "Sendable"
+  }
+]

--- a/docs/guide/swift/protocols/codable.md
+++ b/docs/guide/swift/protocols/codable.md
@@ -1,0 +1,440 @@
+---
+title: Swift로 이해하는 Codable
+description: Codable과 Encodable·Decodable의 관계, 자동 합성, CodingKeys, JSON 전략, custom decoding과 schema 변경 대응을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Codable
+
+> **면접 답변 한 줄 요약:** `Codable`은 `Encodable & Decodable`의 type alias로 Swift 값을 encoder가 다루는 외부 표현으로 내보내고 decoder로 복원하는 공통 계약이며, 실제 JSON 형식과 호환성은 `CodingKeys`, 전략과 custom 구현으로 설계해요.
+
+서버 JSON을 dictionary로 직접 읽으면 key 오타, type 변환과 optional 처리가 앱 전체에 흩어져요. 저장할 때는 반대 변환 코드를 다시 작성해야 하고 model이 바뀔수록 두 방향이 어긋나기 쉬워요.
+
+Swift 표준 라이브러리는 `Encodable`과 `Decodable`이라는 형식 독립적인 계약을 제공하고 Foundation은 `JSONEncoder`, `JSONDecoder`, property list encoder 같은 구체 형식 도구를 제공해요. `Codable` 자체가 JSON protocol인 것은 아니에요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- `Encodable`, `Decodable`, `Codable`의 관계
+- 저장 프로퍼티를 이용한 자동 합성
+- `CodingKeys`로 외부 key를 매핑하고 제외하는 방법
+- 날짜와 snake case 같은 `JSONEncoder`·`JSONDecoder` 전략
+- 누락 key, `null`, 기본값과 `DecodingError` 처리
+- schema version 변경과 DTO·domain model 분리 기준
+
+## 먼저 알아둘 serialization 용어
+
+| 용어                   | 쉬운 뜻                                                                                                        |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| encoding               | 메모리의 Swift 값을 JSON, property list 같은 외부 표현으로 변환하는 과정이에요.                                |
+| decoding               | 외부 표현을 읽어 Swift 값으로 복원하는 과정이에요.                                                             |
+| serialization          | 값을 저장하거나 전송할 수 있는 연속된 표현으로 바꾸고 다시 복원하는 전체 과정이에요.                           |
+| encoder·decoder        | 구체 형식의 container를 만들고 값을 쓰거나 읽는 객체예요.                                                      |
+| schema                 | 외부 data가 어떤 key, type과 중첩 구조를 가지는지 정한 계약이에요.                                             |
+| `CodingKey`            | keyed container에서 외부 field 이름이나 index를 표현하는 프로토콜이에요.                                       |
+| keyed container        | JSON object처럼 이름 있는 key와 value를 읽고 쓰는 coding container예요.                                        |
+| unkeyed container      | JSON array처럼 순서대로 값을 읽고 쓰는 container예요.                                                          |
+| single-value container | 문자열이나 숫자처럼 하나의 값을 읽고 쓰는 container예요.                                                       |
+| DTO                    | Data Transfer Object의 줄임말로 network나 저장 schema 전달에 맞춘 타입이에요. domain model과 분리할 수 있어요. |
+
+## dictionary로 직접 읽으면 type 안전성이 사라져요
+
+```swift
+let object = try JSONSerialization.jsonObject(
+  with: data
+)
+let dictionary = object as? [String: Any]
+
+let title = dictionary?["book_title"] as? String
+let minutes = dictionary?["minutes"] as? Int
+```
+
+`book_title` 오타와 type 불일치는 실행할 때 발견돼요. 중첩 object와 array가 늘어나면 casting code가 길어지고 어떤 field가 필수인지 타입만 보고 알기 어려워요.
+
+`Decodable` model은 schema 기대를 Swift type으로 옮겨요.
+
+```swift
+import Foundation
+
+struct ReadingRecord: Decodable {
+  let bookTitle: String
+  let minutes: Int
+
+  enum CodingKeys: String, CodingKey {
+    case bookTitle = "book_title"
+    case minutes
+  }
+}
+
+let record = try JSONDecoder().decode(
+  ReadingRecord.self,
+  from: data
+)
+```
+
+필수 문자열이나 정수가 없거나 type이 다르면 decoder가 구체적인 오류를 던져요. 호출부는 optional casting 여러 개 대신 성공한 `ReadingRecord` 또는 decoding 실패를 다뤄요.
+
+## `Codable`은 두 프로토콜을 묶은 type alias예요
+
+표준 라이브러리의 관계는 다음과 같아요.
+
+```swift
+protocol Encodable {
+  func encode(to encoder: any Encoder) throws
+}
+
+protocol Decodable {
+  init(from decoder: any Decoder) throws
+}
+
+typealias Codable = Encodable & Decodable
+```
+
+실제 선언의 세부 표기는 Swift 버전에 따라 달라질 수 있지만 역할은 같아요.
+
+| 준수        | 가능한 방향          | 예시                                     |
+| ----------- | -------------------- | ---------------------------------------- |
+| `Encodable` | Swift 값 → 외부 표현 | analytics event request를 보내기만 해요. |
+| `Decodable` | 외부 표현 → Swift 값 | 서버 response를 읽기만 해요.             |
+| `Codable`   | 두 방향 모두         | local 저장 값을 쓰고 다시 읽어요.        |
+
+한 방향만 필요한 type에 무조건 `Codable`을 붙이면 사용하지 않는 방향까지 schema 계약으로 약속해요. request-only와 response-only DTO는 각각 필요한 protocol만 선택할 수 있어요.
+
+## 모든 저장 값이 Codable이면 자동 합성해요
+
+```swift
+import Foundation
+
+struct ReadingRecord: Codable, Equatable {
+  let id: UUID
+  let bookTitle: String
+  var minutes: Int
+  var tags: [String]
+  var note: String?
+}
+
+let record = ReadingRecord(
+  id: UUID(),
+  bookTitle: "Swift",
+  minutes: 30,
+  tags: ["protocol"],
+  note: nil
+)
+
+let data = try JSONEncoder().encode(record)
+let decoded = try JSONDecoder().decode(
+  ReadingRecord.self,
+  from: data
+)
+
+assert(decoded == record)
+```
+
+`UUID`, `String`, `Int`, `Array`와 `Optional`의 구성 type이 모두 `Codable`이므로 compiler가 `encode(to:)`와 `init(from:)`를 합성해요. nested custom type도 같은 조건을 만족하면 계속 합성할 수 있어요.
+
+자동 합성은 편리하지만 저장 프로퍼티 변경이 외부 schema 변경으로 이어질 수 있어요. private cache처럼 producer와 consumer를 동시에 배포하는지, 장기 저장이나 외부 API처럼 이전 data와 호환해야 하는지 구분하세요.
+
+## `CodingKeys`로 Swift 이름과 외부 key를 분리해요
+
+```swift
+struct ReadingRecord: Codable {
+  let id: UUID
+  let bookTitle: String
+  let minutes: Int
+  var localSelection = false
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case bookTitle = "book_title"
+    case minutes
+  }
+}
+```
+
+`bookTitle`은 Swift naming convention을 유지하면서 JSON의 `book_title`과 연결해요. `localSelection`은 `CodingKeys`에 없으므로 encode와 decode 대상에서 제외돼요.
+
+주의할 점은 제외한 non-optional property를 decoding할 때 초기값이나 custom initializer로 채울 수 있어야 한다는 것이에요. 위의 `localSelection`은 declaration 기본값이 있어 합성된 decoding 뒤 사용할 수 있어요.
+
+외부 key가 type의 핵심 schema라면 명시적인 `CodingKeys`가 변경 review에 잘 드러나요. 모든 endpoint가 동일한 규칙을 사용한다면 encoder·decoder의 snake case 전략도 검토할 수 있어요.
+
+## JSON 전략은 호출 경계에서 두 방향을 맞춰요
+
+```swift
+import Foundation
+
+struct ReadingSummary: Codable {
+  let bookTitle: String
+  let startedAt: Date
+}
+
+let decoder = JSONDecoder()
+decoder.keyDecodingStrategy = .convertFromSnakeCase
+decoder.dateDecodingStrategy = .iso8601
+
+let encoder = JSONEncoder()
+encoder.keyEncodingStrategy = .convertToSnakeCase
+encoder.dateEncodingStrategy = .iso8601
+```
+
+전략은 model 선언이 아니라 구체 JSON 경계에 속해요. 같은 model도 다른 server나 file format에서 날짜 표현이 다를 수 있기 때문이에요.
+
+`convertFromSnakeCase`와 `convertToSnakeCase`는 각 key를 변환하므로 기본 key 전략보다 추가 비용이 있을 수 있어요. acronym과 기존 underscore가 섞인 API에서는 기대한 이름이 나오지 않을 수도 있으니 실제 payload로 검사하세요. 중요한 예외 key는 `CodingKeys`로 명시하는 편이 분명해요.
+
+encoder와 decoder를 호출할 때마다 다르게 구성하지 말고 API client나 persistence boundary에서 하나의 설정을 관리해요.
+
+## 누락 key와 `null`은 다른 입력이지만 optional은 둘 다 nil로 받을 수 있어요
+
+다음 두 JSON을 생각해요.
+
+```json
+{}
+```
+
+```json
+{ "note": null }
+```
+
+합성된 `String?` decoding은 두 경우 모두 `nil`로 처리할 수 있어요. schema에서 “field가 없음”과 “명시적으로 값을 지움”을 구분해야 한다면 synthesized optional만으로는 정보가 부족해요. custom decoding에서 `contains(_:)`와 `decodeNil(forKey:)`를 함께 확인하거나 별도 patch type을 사용하세요.
+
+non-optional property에 declaration 기본값이 있어도 synthesized `Decodable`이 누락 key에 그 값을 자동 적용한다고 기대하면 안 돼요. 기본값 migration이 필요하면 직접 decode해요.
+
+```swift
+struct ReadingPreferences: Decodable {
+  let dailyGoal: Int
+  let showsNotes: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case dailyGoal
+    case showsNotes
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(
+      keyedBy: CodingKeys.self
+    )
+    dailyGoal = try container.decode(
+      Int.self,
+      forKey: .dailyGoal
+    )
+    showsNotes = try container.decodeIfPresent(
+      Bool.self,
+      forKey: .showsNotes
+    ) ?? true
+  }
+}
+```
+
+이 구현은 이전 data에 `showsNotes`가 없을 때 `true`로 migration해요. `decodeIfPresent`는 key 누락과 `null`을 모두 `nil`로 처리하므로 둘을 구분해야 하면 더 세밀한 container API를 사용하세요.
+
+## 외부 구조가 다르면 custom decoding을 구현해요
+
+JSON이 다음처럼 중첩되어 있다고 해 볼게요.
+
+```json
+{
+  "book": {
+    "title": "Swift"
+  },
+  "minutes": 30
+}
+```
+
+앱에서는 평평한 model이 더 편할 수 있어요.
+
+```swift
+struct ReadingRecord: Decodable {
+  let bookTitle: String
+  let minutes: Int
+
+  private enum CodingKeys: String, CodingKey {
+    case book
+    case minutes
+  }
+
+  private enum BookKeys: String, CodingKey {
+    case title
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(
+      keyedBy: CodingKeys.self
+    )
+    let book = try container.nestedContainer(
+      keyedBy: BookKeys.self,
+      forKey: .book
+    )
+
+    bookTitle = try book.decode(
+      String.self,
+      forKey: .title
+    )
+    minutes = try container.decode(
+      Int.self,
+      forKey: .minutes
+    )
+  }
+}
+```
+
+custom implementation은 외부 schema와 domain-friendly shape를 분리할 수 있지만 boilerplate와 유지 비용이 생겨요. 단순 이름 변경은 `CodingKeys`, 전체 key convention은 strategy, 구조 변환과 migration은 custom decoding처럼 가장 작은 도구를 선택해요.
+
+## custom encoding은 decoding의 반대 구조를 작성해요
+
+```swift
+extension ReadingRecord: Encodable {
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(
+      keyedBy: CodingKeys.self
+    )
+    var book = container.nestedContainer(
+      keyedBy: BookKeys.self,
+      forKey: .book
+    )
+
+    try book.encode(bookTitle, forKey: .title)
+    try container.encode(minutes, forKey: .minutes)
+  }
+}
+```
+
+양방향 round trip이 필요한 model은 encoding과 decoding 구조가 서로 맞는지 test해요. 하지만 `decode(encode(value)) == value`만으로 외부 schema 호환이 전부 증명되지는 않아요. encoder와 decoder가 같은 잘못된 key를 사용해도 round trip은 통과할 수 있으므로 실제 fixture JSON도 별도로 검사해요.
+
+## `DecodingError`에서 실패 위치를 읽어요
+
+```swift
+do {
+  _ = try decoder.decode(
+    ReadingRecord.self,
+    from: data
+  )
+} catch let DecodingError.keyNotFound(key, context) {
+  print("누락 key:", key.stringValue)
+  print("경로:", context.codingPath)
+} catch let DecodingError.typeMismatch(type, context) {
+  print("type 불일치:", type)
+  print("설명:", context.debugDescription)
+} catch let DecodingError.valueNotFound(type, context) {
+  print("값 누락:", type, context.codingPath)
+} catch let DecodingError.dataCorrupted(context) {
+  print("손상된 data:", context.debugDescription)
+}
+```
+
+`codingPath`는 중첩 object와 array에서 어느 key를 읽다가 실패했는지 보여 줘요. production log에 전체 payload를 무조건 기록하면 개인정보나 token이 노출될 수 있으므로 안전한 field와 request ID만 남겨요.
+
+사용자에게는 내부 schema 메시지 대신 다시 시도, 앱 업데이트나 지원 문의처럼 해결 가능한 안내를 제공해요.
+
+## Codable 성공은 domain validation 성공이 아니에요
+
+```swift
+enum ValidationError: Error {
+  case emptyTitle
+  case invalidMinutes
+}
+
+struct ReadingRecordDTO: Decodable {
+  let title: String
+  let minutes: Int
+}
+
+struct ReadingRecord {
+  let title: String
+  let minutes: Int
+
+  init(dto: ReadingRecordDTO) throws {
+    guard !dto.title.isEmpty else {
+      throw ValidationError.emptyTitle
+    }
+    guard (1...1_440).contains(dto.minutes) else {
+      throw ValidationError.invalidMinutes
+    }
+
+    title = dto.title
+    minutes = dto.minutes
+  }
+}
+```
+
+JSON이 `String`과 `Int` type을 만족해 decode됐어도 빈 제목이나 하루보다 긴 독서 시간이 domain에서 유효하다는 뜻은 아니에요. 외부 data는 decode한 뒤 validation하고, 필요하면 DTO에서 domain model로 변환해요.
+
+`Codable`은 암호화나 신뢰 검증 기능도 아니에요. 민감한 data의 저장 위치, 전송 보안, 서명과 접근 제어는 별도로 설계해야 해요.
+
+## 장기 저장과 API schema는 version 변경을 견뎌야 해요
+
+model에 non-optional property를 추가하면 이전 파일과 server response가 decode되지 않을 수 있어요. 다음 기준을 검토해요.
+
+- 새 field가 없어도 만들 수 있으면 custom decoding에서 기본값을 제공해요.
+- 이름을 바꿀 때 이전 key와 새 key를 함께 읽는 migration 기간을 둬요.
+- 제거할 field를 decoder가 무시할 수 있는지 확인해요.
+- enum에 server가 새 case를 추가할 가능성이 있으면 unknown fallback 정책을 정해요.
+- 저장 형식에 schema version을 두고 단계별 migration을 수행해요.
+- public API DTO와 앱 내부 domain model의 변경 주기가 다르면 타입을 분리해요.
+
+자동 합성은 현재 type 구조를 편리하게 serialize하지만 장기 호환 정책을 대신 결정하지 않아요.
+
+## Codable과 다른 프로토콜을 비교해요
+
+| 프로토콜                         | 보장하는 질문                                  | 보장하지 않는 것                          |
+| -------------------------------- | ---------------------------------------------- | ----------------------------------------- |
+| `Encodable`                      | 외부 표현으로 쓸 수 있나요?                    | 다시 읽을 수 있는지는 몰라요.             |
+| `Decodable`                      | 외부 표현에서 값을 만들 수 있나요?             | 다시 같은 형식으로 쓸 수 있는지는 몰라요. |
+| `Codable`                        | 두 방향을 모두 지원하나요?                     | JSON 전용 형식이나 domain 유효성          |
+| [`Equatable`](./equatable)       | 두 현재 값이 같은가요?                         | 저장과 전송 가능성                        |
+| [`Identifiable`](./identifiable) | 같은 entity를 추적할 ID가 있나요?              | 값 전체의 serialization                   |
+| [`Sendable`](./sendable)         | concurrency domain 사이에 안전하게 공유되나요? | 외부 data 형식                            |
+
+각 프로토콜은 독립된 계약이에요. network DTO가 `Decodable & Sendable`일 수 있고, 저장 model이 `Codable & Identifiable`일 수 있어요. 실제 사용 경계에 필요한 준수만 선택하세요.
+
+## 언제 `Codable`을 사용해야 하나요
+
+- typed model을 JSON이나 property list로 encode·decode해요.
+- local file, UserDefaults의 `Data`나 network payload에 값을 저장·전송해요.
+- model 구조와 외부 schema가 비교적 명확하고 정적으로 표현돼요.
+- custom encoder·decoder와 독립된 공통 계약이 필요해요.
+
+임의 JSON 편집기처럼 schema가 실행 중 계속 달라지는 data, streaming parser나 특수 binary format에는 전용 parser가 더 적합할 수 있어요. type을 만들지 않고 JSON 일부만 잠깐 확인하는 작업에도 `JSONSerialization`이 단순할 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. type이 encode, decode 또는 두 방향 중 무엇을 실제로 지원해야 하는지 정해요.
+2. 외부 schema와 Swift property가 그대로 맞으면 자동 합성부터 사용해요.
+3. field 이름 차이는 `CodingKeys`, 공통 naming과 날짜 규칙은 encoder·decoder 전략으로 처리해요.
+4. 중첩 구조, 기본값과 migration이 필요할 때 custom 구현을 작성해요.
+5. decoding 뒤 domain validation을 별도로 수행해요.
+6. round-trip test와 실제 fixture JSON test를 함께 작성해요.
+7. 장기 저장과 public API에는 version 호환·개인정보·보안 정책을 명시해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `Codable`은 protocol인가요?
+
+정확히는 `Decodable & Encodable`을 묶은 type alias예요. 두 protocol을 모두 준수하는 type을 제약하거나 표현할 때 사용해요.
+
+### `CodingKeys`는 언제 필요한가요?
+
+Swift property 이름과 외부 key가 다르거나 일부 property를 coding에서 제외할 때 사용해요. 단순한 전체 snake case 규칙은 decoder 전략으로 처리할 수도 있지만 예외와 schema 가독성을 함께 고려해야 해요.
+
+### non-optional property에 기본값을 쓰면 누락 key도 자동으로 decode되나요?
+
+일반적으로 synthesized `Decodable`이 declaration 기본값을 migration fallback으로 사용한다고 기대하면 안 돼요. 누락을 허용하려면 custom `init(from:)`에서 `decodeIfPresent`와 명시적인 기본값을 사용해요.
+
+### `Codable` model을 바로 domain model로 써도 되나요?
+
+작고 내부적인 schema라면 가능해요. 외부 API와 앱 domain의 이름, validation과 변경 주기가 다르면 DTO를 분리하고 변환 경계에서 유효성을 검사하는 편이 안전해요.
+
+### round-trip test만 통과하면 schema 호환이 보장되나요?
+
+아니요. 같은 encoder와 decoder가 동일하게 잘못된 key를 사용해도 round trip은 통과할 수 있어요. 실제 외부 fixture의 key와 type을 검증하는 test도 필요해요.
+
+## 참고 자료
+
+- [Apple Developer — Codable](https://developer.apple.com/documentation/swift/codable)
+- [Apple Developer — Encodable](https://developer.apple.com/documentation/swift/encodable)
+- [Apple Developer — Decodable](https://developer.apple.com/documentation/swift/decodable)
+- [Apple Developer — Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/encoding-and-decoding-custom-types)
+- [Apple Developer — JSONEncoder](https://developer.apple.com/documentation/foundation/jsonencoder)
+- [Apple Developer — JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
+- [Apple Developer — CodingKey](https://developer.apple.com/documentation/swift/codingkey)
+- [Swift Evolution SE-0166 — Swift Archival & Serialization](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0166-swift-archival-serialization.md)
+- [Swift-KR — Swift로 이해하는 Identifiable](./identifiable)
+- [Swift-KR — Swift로 이해하는 Sendable](./sendable)

--- a/docs/guide/swift/protocols/comparable.md
+++ b/docs/guide/swift/protocols/comparable.md
@@ -1,0 +1,336 @@
+---
+title: Swift로 이해하는 Comparable
+description: Comparable의 strict total order, Equatable과의 일관성, < 구현, tuple 비교와 sorted·range에 적합한 자연스러운 순서 설계를 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Comparable
+
+> **면접 답변 한 줄 요약:** `Comparable`은 `Equatable`을 바탕으로 같은 타입의 모든 정상 값을 하나의 일관된 전체 순서에 놓는 프로토콜이며, `==`와 `<`만 올바르게 구현하면 나머지 관계 연산과 정렬 API를 사용할 수 있어요.
+
+독서 기록을 날짜순, 제목순, 시간순으로 정렬할 수 있어요. 하지만 이 세 기준이 모두 타입의 `Comparable`이 되어야 하는 것은 아니에요. `Comparable`은 “호출마다 고르는 정렬 옵션”보다 타입 자체에 누구나 동의할 자연스러운 기본 순서가 있을 때 적합해요.
+
+잘못된 `<`는 `sorted()`, 범위와 이진 검색 같은 알고리즘의 전제를 깨요. 단순히 예제 몇 개에서 정렬되는지보다 equality와 order가 함께 지켜야 할 법칙을 이해해야 해요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- `Comparable`과 `Equatable`의 관계
+- strict total order와 비교 법칙
+- `<` 하나로 `>`, `<=`, `>=`를 얻는 방법
+- tuple을 이용한 다중 field 순서
+- 자연스러운 순서와 화면별 sort closure의 선택 기준
+- 문자열 locale, optional과 부동소수점 예외 값의 주의점
+
+## 먼저 알아둘 순서 용어
+
+| 용어                | 쉬운 뜻                                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
+| 관계 연산자         | 두 값의 순서를 비교하는 `<`, `<=`, `>`, `>=` 연산자예요.                                            |
+| strict order        | `<`처럼 같은 값은 자기보다 앞서지 않는 엄격한 순서 관계예요.                                        |
+| total order         | 임의의 두 정상 값이 같거나 어느 한쪽이 앞선다고 반드시 결정되는 전체 순서예요.                      |
+| irreflexivity       | 어떤 값도 자기 자신보다 작지 않다는 성질로 `a < a`는 항상 `false`예요.                              |
+| asymmetry           | `a < b`이면 동시에 `b < a`일 수 없다는 성질이에요.                                                  |
+| transitivity        | `a < b`, `b < c`이면 `a < c`여야 한다는 성질이에요.                                                 |
+| lexicographic order | 첫 요소를 비교하고 같으면 다음 요소를 비교하는 사전식 순서예요. tuple과 문자열 비교가 대표적이에요. |
+| sort descriptor     | 화면이나 기능마다 선택한 정렬 기준과 방향을 표현하는 값 또는 closure예요.                           |
+
+## 호출부마다 비교 closure를 반복하면 기본 순서가 흩어져요
+
+version을 major, minor, patch 순으로 비교한다고 해 볼게요.
+
+```swift
+struct AppVersion: Equatable {
+  let major: Int
+  let minor: Int
+  let patch: Int
+}
+
+let versions = [
+  AppVersion(major: 2, minor: 0, patch: 0),
+  AppVersion(major: 1, minor: 9, patch: 1),
+]
+
+let sorted = versions.sorted { lhs, rhs in
+  if lhs.major != rhs.major {
+    return lhs.major < rhs.major
+  }
+  if lhs.minor != rhs.minor {
+    return lhs.minor < rhs.minor
+  }
+  return lhs.patch < rhs.patch
+}
+```
+
+version의 순서는 domain 자체에 하나로 정해져 있는데 호출할 때마다 closure를 반복해요. 어떤 곳이 patch 비교를 빼먹으면 서로 다른 순서를 사용하게 돼요.
+
+## `Comparable`은 타입의 자연스러운 순서를 선언해요
+
+```swift
+struct AppVersion: Comparable {
+  let major: Int
+  let minor: Int
+  let patch: Int
+
+  static func < (
+    lhs: AppVersion,
+    rhs: AppVersion
+  ) -> Bool {
+    (lhs.major, lhs.minor, lhs.patch) <
+      (rhs.major, rhs.minor, rhs.patch)
+  }
+}
+```
+
+저장 프로퍼티가 모두 `Equatable`이므로 `==`는 자동 합성돼요. `<`는 comparable tuple의 사전식 비교를 사용해 major가 같을 때 minor, 둘 다 같을 때 patch를 비교해요.
+
+이제 표준 라이브러리 API를 사용할 수 있어요.
+
+```swift
+let current = AppVersion(major: 1, minor: 9, patch: 1)
+let required = AppVersion(major: 2, minor: 0, patch: 0)
+
+current < required
+required > current
+current <= current
+versions.sorted()
+versions.min()
+versions.max()
+```
+
+`Comparable`이 요구하는 핵심은 `<`와 상속한 `Equatable`의 `==`예요. 표준 라이브러리가 `>`, `<=`, `>=`의 기본 구현을 제공해요.
+
+## equality와 order는 같은 구성 요소를 사용해야 해요
+
+임의의 정상 값 `a`, `b`에 대해 정확히 하나가 참이어야 해요.
+
+```text
+a == b
+a < b
+b < a
+```
+
+`==`는 `id`만 비교하면서 `<`는 날짜와 제목을 비교하면 같은 두 값 사이에도 순서가 생길 수 있어요. 반대로 `<`가 일부 field를 무시하면 `a != b`인데 어느 쪽도 작지 않은 incomparability가 생겨요.
+
+```swift
+struct Edition: Comparable {
+  let volume: Int
+  let revision: Int
+
+  static func < (lhs: Edition, rhs: Edition) -> Bool {
+    (lhs.volume, lhs.revision) <
+      (rhs.volume, rhs.revision)
+  }
+}
+```
+
+자동 합성된 `==`와 `<`가 모두 `volume`, `revision`을 사용해 일관돼요.
+
+## `<`는 세 가지 순서 법칙을 지켜요
+
+| 법칙                    | 조건                               | 깨졌을 때 문제                                    |
+| ----------------------- | ---------------------------------- | ------------------------------------------------- |
+| 비반사성(irreflexivity) | `a < a`는 항상 `false`예요.        | 자기 자신이 앞선다고 판단해 algorithm이 흔들려요. |
+| 비대칭성(asymmetry)     | `a < b`이면 `b < a`는 `false`예요. | 두 값이 동시에 서로 앞선다고 나와요.              |
+| 추이성(transitivity)    | `a < b`, `b < c`이면 `a < c`예요.  | 정렬 결과가 비교 순서에 따라 달라져요.            |
+
+`Equatable`의 반사성·대칭성·추이성과 함께 strict total order를 만들어요. 직접 구현한 비교는 작은 예제뿐 아니라 임의 입력을 생성하는 property-based test로 법칙을 확인할 수도 있어요.
+
+## 여러 정렬 기준이 있다면 Comparable 하나에 숨기지 않아요
+
+독서 session은 날짜순, 시간 많은 순, 제목순 모두 자연스러울 수 있어요. 타입 전체의 유일한 기본 순서가 아니라 화면 목적에 따른 선택이에요.
+
+```swift
+import Foundation
+
+struct ReadingSession: Equatable {
+  let title: String
+  let minutes: Int
+  let startedAt: Date
+}
+
+let newestFirst = sessions.sorted {
+  $0.startedAt > $1.startedAt
+}
+
+let longestFirst = sessions.sorted {
+  if $0.minutes != $1.minutes {
+    return $0.minutes > $1.minutes
+  }
+  return $0.title < $1.title
+}
+```
+
+이 경우 `ReadingSession: Comparable`에 임의의 기준 하나를 넣으면 `sorted()`만 보고 어떤 순서인지 알기 어려워요. 이름 있는 comparator를 만들면 의도를 재사용할 수 있어요.
+
+```swift
+extension ReadingSession {
+  static func byLongestReading(
+    _ lhs: Self,
+    _ rhs: Self
+  ) -> Bool {
+    if lhs.minutes != rhs.minutes {
+      return lhs.minutes > rhs.minutes
+    }
+    return lhs.title < rhs.title
+  }
+}
+
+let sorted = sessions.sorted(
+  by: ReadingSession.byLongestReading
+)
+```
+
+`Comparable`은 타입의 본질적인 순서, `sorted(by:)`는 use case별 순서라고 생각하면 선택이 쉬워요.
+
+## tie-breaker를 넣어 전체 순서를 완성해요
+
+날짜만 비교하면 같은 날짜의 서로 다른 값은 어느 쪽도 앞서지 않을 수 있어요. equality가 날짜와 ID를 모두 사용한다면 `<`에도 ID tie-breaker가 필요해요.
+
+```swift
+import Foundation
+
+struct DailyRecord: Comparable {
+  let day: Date
+  let id: UUID
+
+  static func < (
+    lhs: DailyRecord,
+    rhs: DailyRecord
+  ) -> Bool {
+    if lhs.day != rhs.day {
+      return lhs.day < rhs.day
+    }
+    return lhs.id.uuidString < rhs.id.uuidString
+  }
+}
+```
+
+UUID 문자열 순서는 사용자 의미가 있는 순서라기보다 deterministic tie-breaker예요. API 문서에서 이런 선택을 설명하고, UI에는 사용자가 이해할 기준을 별도로 제공하세요.
+
+## `Comparable`로 범위와 clamp를 표현해요
+
+```swift
+let allowedMinutes = 1...1_440
+
+allowedMinutes.contains(30) // true
+```
+
+range bound는 `Comparable`을 이용해 값이 구간 안에 있는지 판단해요. 제네릭 clamp도 같은 제약으로 작성할 수 있어요.
+
+```swift
+func clamped<Value: Comparable>(
+  _ value: Value,
+  to range: ClosedRange<Value>
+) -> Value {
+  min(max(value, range.lowerBound), range.upperBound)
+}
+
+clamped(1_500, to: 1...1_440) // 1440
+```
+
+함수는 `Int`를 몰라도 `Comparable`의 순서만으로 lower와 upper bound 사이 값을 만들어요.
+
+## 문자열의 `<`가 사용자 언어 정렬과 같지는 않아요
+
+`String`은 `Comparable`이지만 기본 순서가 모든 locale의 사전 정렬 요구를 충족한다는 뜻은 아니에요. 사용자가 보는 이름과 제목은 locale, 숫자 포함 문자열과 대소문자 규칙에 따라 원하는 순서가 달라져요.
+
+```swift
+let titles = ["Book 10", "Book 2"]
+let localized = titles.sorted {
+  $0.localizedStandardCompare($1) == .orderedAscending
+}
+```
+
+UI의 자연어 정렬에는 Foundation의 localized comparison이나 `SortDescriptor`처럼 요구에 맞는 API를 검토해요. domain identifier와 version처럼 locale 독립 순서는 타입의 `Comparable`로 정의할 수 있어요.
+
+## Optional에는 일반적인 전체 순서를 임의로 만들지 않아요
+
+`nil`을 모든 값보다 앞이나 뒤에 둘지는 use case 선택이에요.
+
+```swift
+let records: [ReadingSession?] = [session, nil]
+
+let nilLast = records.sorted { lhs, rhs in
+  switch (lhs, rhs) {
+  case (nil, nil): return false
+  case (nil, _): return false
+  case (_, nil): return true
+  case let (lhs?, rhs?):
+    return lhs.startedAt < rhs.startedAt
+  }
+}
+```
+
+optional 전체에 하나의 보편적 순서를 가정하지 않고 해당 화면의 `nil` 위치 정책을 명시해요.
+
+## 부동소수점 NaN은 일반적인 전체 순서의 예외예요
+
+`Double.nan`은 자신과도 같지 않고 정상 숫자보다 작거나 크지도 않아요.
+
+```swift
+let value = Double.nan
+
+value == value // false
+value < 10     // false
+value > 10     // false
+```
+
+Apple의 `Comparable` 문서도 NaN 같은 exceptional value는 strict total order 밖에 있을 수 있다고 설명해요. 측정값을 정렬한다면 NaN을 사전에 거르거나 처음·마지막에 둘 명시적인 정책을 사용하세요.
+
+## Comparable과 관련 선택지를 비교해요
+
+| 선택                       | 적합한 질문                                  | 예시                                    |
+| -------------------------- | -------------------------------------------- | --------------------------------------- |
+| [`Equatable`](./equatable) | 같은 값인가요?                               | 상태 비교, `contains`                   |
+| `Comparable`               | 타입에 하나의 자연스러운 전체 순서가 있나요? | version, 날짜, 순서가 있는 domain value |
+| `sorted(by:)`              | 이 화면에서 어떤 기준으로 정렬할까요?        | 최신순, 긴 독서 시간순                  |
+| localized comparison       | 사용자 언어 규칙에 맞는 문자열 순서인가요?   | 사람 이름, 제목                         |
+
+`Comparable`을 채택했다고 모든 정렬에서 `sorted()`만 사용해야 하는 것은 아니에요. 기본 순서가 있어도 UI는 다른 명시적 기준을 선택할 수 있어요.
+
+## 언제 `Comparable`을 사용해야 하나요
+
+- version, 날짜 구성 값처럼 타입 자체에 명확한 기본 순서가 있어요.
+- `<`, `>`, range, `min`, `max`, `sorted()`를 일관된 기준으로 제공해야 해요.
+- 임의의 두 정상 값을 같음 또는 앞뒤 중 하나로 결정할 수 있어요.
+- equality와 order가 같은 구성 요소를 사용하도록 설계할 수 있어요.
+
+정렬 기준이 여러 개이고 어느 하나도 본질적이지 않다면 `Equatable`과 이름 있는 comparator를 사용하세요. 순서를 정할 수 없는 graph node나 service 객체에 억지로 채택하지 않아요.
+
+## 적용 순서를 정리해요
+
+1. 타입에 호출 맥락과 무관한 자연스러운 기본 순서가 있는지 확인해요.
+2. equality에 참여하는 모든 구성 요소를 순서에도 반영해요.
+3. `<`를 구현하고 나머지 관계 연산자는 표준 기본 구현을 사용해요.
+4. 다중 field는 lexicographic 순서와 tie-breaker를 명시해요.
+5. 비반사성·비대칭성·추이성과 equality 일관성을 test해요.
+6. locale 문자열, optional과 NaN에는 use case별 예외 정책을 제공해요.
+7. 화면별 정렬은 `sorted(by:)`나 sort descriptor로 의도를 드러내요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `Comparable`을 준수하려면 어떤 연산자를 구현해야 하나요?
+
+상속한 `Equatable`의 `==`와 `Comparable`의 `<`를 구현해요. `>`, `<=`, `>=`와 `!=`는 표준 라이브러리의 기본 구현을 사용할 수 있어요.
+
+### `==`와 `<`는 어떤 관계여야 하나요?
+
+정상적인 임의의 두 값에서 `a == b`, `a < b`, `b < a` 중 정확히 하나만 참이어야 해요. 두 구현이 다른 구성 요소를 사용하면 이 전체 순서가 깨질 수 있어요.
+
+### 정렬할 수 있는 타입은 모두 Comparable이어야 하나요?
+
+아니요. 맥락마다 기준이 달라지는 타입은 `sorted(by:)`가 더 명확해요. `Comparable`은 타입 자체에 하나의 자연스러운 기본 순서가 있을 때 채택해요.
+
+### 문자열 title 정렬에 기본 `<`만 사용하면 안 되나요?
+
+기계적인 순서가 목적이면 사용할 수 있지만 사용자 언어의 사전식 순서와는 다를 수 있어요. UI title과 이름에는 locale과 숫자 규칙을 고려한 localized comparison을 검토해요.
+
+## 참고 자료
+
+- [Apple Developer — Comparable](https://developer.apple.com/documentation/swift/comparable)
+- [Apple Developer — sorted()](<https://developer.apple.com/documentation/swift/sequence/sorted()>)
+- [Apple Developer — ClosedRange](https://developer.apple.com/documentation/swift/closedrange)
+- [The Swift Programming Language — Basic Operators](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/)
+- [Swift-KR — Swift로 이해하는 Equatable](./equatable)
+- [Swift-KR — Swift로 이해하는 Sequence와 Collection](./sequence-and-collection)

--- a/docs/guide/swift/protocols/equatable.md
+++ b/docs/guide/swift/protocols/equatable.md
@@ -1,0 +1,289 @@
+---
+title: Swift로 이해하는 Equatable
+description: Equatable의 값 동등성, 자동 합성, == 구현 규칙과 클래스 identity 차이를 이해하고 안전한 비교 기준을 설계하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Equatable
+
+> **면접 답변 한 줄 요약:** `Equatable`은 같은 타입의 두 값이 의미상 서로 바꿔 써도 되는지를 `==`로 정의하는 프로토콜이며, 일관된 동등성 규칙을 통해 비교·검색·테스트와 상위 프로토콜의 기반을 제공해요.
+
+앱은 같은 책인지, 검색 결과에 특정 항목이 있는지, 변경 전후 상태가 같은지를 계속 판단해요. 프로퍼티를 호출할 때마다 직접 비교하면 기준이 흩어지고 새 프로퍼티가 생겼을 때 빠뜨리기 쉬워요.
+
+`Equatable`을 채택하면 타입 자체가 “어떤 두 값이 같은가”를 정의해요. `==`, `!=`뿐 아니라 `contains`, `firstIndex(of:)`와 테스트 assertion도 그 규칙을 재사용할 수 있어요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- 값 동등성과 클래스 인스턴스 identity의 차이
+- 구조체와 enum의 `Equatable` 자동 합성
+- 직접 `==`를 구현할 때 지켜야 할 동등성 법칙
+- 컬렉션과 제네릭에서 `Equatable`을 사용하는 방법
+- `Hashable`, `Comparable`, `Identifiable`과의 경계
+
+## 먼저 알아둘 비교 용어
+
+| 용어             | 쉬운 뜻                                                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 동등성(equality) | 두 값이 프로그램의 의미상 같아서 서로 바꿔 써도 되는지를 판단하는 규칙이에요.                                       |
+| identity         | 두 참조가 메모리의 같은 클래스 인스턴스를 가리키는지를 뜻해요. Swift에서는 `===`로 확인해요.                        |
+| 값 의미론        | 값의 내용으로 의미가 결정되고 복사한 뒤 각각 변경할 수 있는 성질이에요. 구조체와 enum이 주로 사용해요.              |
+| 자동 합성        | 저장 프로퍼티나 연관 값이 조건을 만족하면 컴파일러가 프로토콜 구현을 만들어 주는 기능이에요.                        |
+| 치환 가능성      | 같다고 판정한 두 값을 공개된 동작에서 서로 바꿔도 관찰 결과가 달라지지 않아야 한다는 원칙이에요.                    |
+| 동등 관계        | 반사성·대칭성·추이성을 모두 만족하는 비교 관계예요. `Equatable`의 사용자 정의 `==`가 지켜야 하는 수학적 성질이에요. |
+| `Self`           | 프로토콜을 실제로 따르는 구체 타입이에요. `==`는 왼쪽과 오른쪽에 같은 `Self` 타입을 요구해요.                       |
+
+## 프로퍼티를 매번 비교하면 동등성 기준이 흩어져요
+
+독서 기록 두 개가 같은 값인지 확인한다고 해 볼게요.
+
+```swift
+struct ReadingRecord {
+  let bookID: String
+  var minutes: Int
+  var note: String
+}
+
+let before = ReadingRecord(
+  bookID: "swift-guide",
+  minutes: 20,
+  note: "프로토콜"
+)
+let after = ReadingRecord(
+  bookID: "swift-guide",
+  minutes: 20,
+  note: "프로토콜"
+)
+
+let isSame =
+  before.bookID == after.bookID &&
+  before.minutes == after.minutes &&
+  before.note == after.note
+```
+
+호출하는 곳마다 이 코드를 반복하면 어떤 곳은 `note`를 비교하고 어떤 곳은 빼먹을 수 있어요. “같은 독서 기록”의 의미가 타입이 아니라 각 호출부에 흩어져요.
+
+## `Equatable`은 타입의 값 동등성을 선언해요
+
+저장 프로퍼티가 모두 `Equatable`이면 구조체는 `==`를 자동으로 합성할 수 있어요.
+
+```swift
+struct ReadingRecord: Equatable {
+  let bookID: String
+  var minutes: Int
+  var note: String
+}
+
+let isSame = before == after
+let hasChanged = before != after
+```
+
+합성된 구현은 모든 저장 프로퍼티를 비교해요. `String`과 `Int`가 이미 `Equatable`이므로 추가 구현이 필요하지 않아요. `!=`는 `==`의 결과를 반대로 만드는 기본 구현을 사용해요.
+
+이제 같은 규칙이 여러 API에 전달돼요.
+
+```swift
+let records = [before]
+
+records.contains(after)       // true
+records.firstIndex(of: after) // 0
+```
+
+`contains(_:)`가 특정 값을 직접 받을 수 있는 이유도 배열의 원소가 `Equatable`이기 때문이에요.
+
+## enum도 연관 값까지 비교하도록 합성해요
+
+연관 값이 모두 `Equatable`이면 enum도 자동 합성할 수 있어요.
+
+```swift
+enum SyncState: Equatable {
+  case idle
+  case syncing(progress: Double)
+  case failed(message: String)
+}
+
+SyncState.idle == .idle
+SyncState.syncing(progress: 0.5) ==
+  .syncing(progress: 0.5)
+```
+
+case가 다르면 같지 않고, 같은 case라면 연관 값을 함께 비교해요. 연관 값이 없는 enum은 명시적으로 `Equatable`을 쓰지 않아도 동등 비교가 가능한 경우가 있지만, 제네릭 제약이나 공개 API에서 준수 사실을 드러내려면 명시할 수 있어요.
+
+## 직접 구현할 때는 공개된 값 의미를 반영해요
+
+모든 저장 값이 아닌 정규화된 의미로 비교해야 할 때 직접 `==`를 구현해요. 이메일 주소를 대소문자와 양끝 공백을 무시하고 비교하는 도메인 규칙을 예로 들어요.
+
+```swift
+import Foundation
+
+struct EmailAddress: Equatable {
+  let rawValue: String
+
+  private var normalized: String {
+    rawValue
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+  }
+
+  static func == (
+    lhs: EmailAddress,
+    rhs: EmailAddress
+  ) -> Bool {
+    lhs.normalized == rhs.normalized
+  }
+}
+
+EmailAddress(rawValue: " reader@example.com ") ==
+  EmailAddress(rawValue: "READER@example.com") // true
+```
+
+이 비교가 올바르려면 타입의 나머지 공개 동작도 정규화된 주소를 같은 값으로 취급해야 해요. `rawValue` 철자 차이가 프로그램에서 중요한 관찰 결과라면 두 값을 같다고 정의하면 치환 가능성이 깨질 수 있어요.
+
+단순히 성능을 줄이려고 큰 프로퍼티를 `==`에서 제외하지 마세요. 제외한 프로퍼티가 동작을 바꾼다면 동등성의 의미가 잘못된 거예요.
+
+## 동등성은 세 가지 법칙을 지켜야 해요
+
+임의의 같은 타입 값 `a`, `b`, `c`에 대해 사용자 정의 `==`는 다음 조건을 만족해야 해요.
+
+| 법칙                 | 조건                                 | 깨졌을 때 생기는 문제                                        |
+| -------------------- | ------------------------------------ | ------------------------------------------------------------ |
+| 반사성(reflexivity)  | `a == a`는 항상 `true`예요.          | 값이 자기 자신과도 다르다고 나와 검색과 캐시가 불안정해져요. |
+| 대칭성(symmetry)     | `a == b`이면 `b == a`예요.           | 피연산자 순서에 따라 결과가 달라져요.                        |
+| 추이성(transitivity) | `a == b`, `b == c`이면 `a == c`예요. | 그룹화와 중복 제거 결과를 신뢰할 수 없어요.                  |
+
+허용 오차를 단순히 `==`에 넣은 부동소수점 비교는 추이성을 깨기 쉬워요.
+
+```swift
+func isApproximatelyEqual(
+  _ lhs: Double,
+  _ rhs: Double,
+  tolerance: Double
+) -> Bool {
+  abs(lhs - rhs) <= tolerance
+}
+```
+
+근삿값 비교는 타입 전체의 동등성으로 숨기기보다 목적이 드러나는 별도 메서드로 제공하는 편이 안전해요.
+
+## 클래스의 `==`와 `===`는 다른 질문에 답해요
+
+클래스는 참조 타입이므로 값 동등성과 인스턴스 identity를 구분해야 해요.
+
+```swift
+final class BookCopy: Equatable {
+  let barcode: String
+
+  init(barcode: String) {
+    self.barcode = barcode
+  }
+
+  static func == (lhs: BookCopy, rhs: BookCopy) -> Bool {
+    lhs.barcode == rhs.barcode
+  }
+}
+
+let first = BookCopy(barcode: "A-001")
+let sameValue = BookCopy(barcode: "A-001")
+let sameReference = first
+
+first == sameValue      // true: 정의한 값이 같아요.
+first === sameValue     // false: 서로 다른 인스턴스예요.
+first === sameReference // true: 같은 인스턴스예요.
+```
+
+`Equatable`은 클래스를 자동 합성하지 않으므로 `==`를 직접 구현해요. 객체가 정말 같은 메모리 인스턴스인지 확인하려는 경우에만 `===`를 사용하세요.
+
+## 제네릭 제약은 필요한 비교 능력만 요구해요
+
+어떤 타입이든 받되 동등 비교가 필요한 함수는 `Equatable` 제약을 사용해요.
+
+```swift
+func hasDuplicate<Element: Equatable>(
+  _ values: [Element]
+) -> Bool {
+  for index in values.indices {
+    let remaining = values.index(after: index)..<values.endIndex
+    if values[remaining].contains(values[index]) {
+      return true
+    }
+  }
+  return false
+}
+```
+
+함수는 `Element`의 구체 타입을 몰라도 `==`가 있다는 사실을 알아요. 중복 검색을 더 빠르게 하려고 `Set`을 사용한다면 더 강한 [`Hashable`](./hashable) 제약이 필요해요. 필요한 능력보다 강한 제약을 먼저 요구하지 마세요.
+
+## `Equatable`, `Hashable`, `Identifiable`은 같은 의미가 아니에요
+
+| 프로토콜                         | 답하는 질문                                     | 대표 사용처                          |
+| -------------------------------- | ----------------------------------------------- | ------------------------------------ |
+| `Equatable`                      | 두 값이 의미상 같은가요?                        | `==`, `contains`, 테스트 기대값      |
+| [`Hashable`](./hashable)         | 값을 hash 기반 저장소의 key로 쓸 수 있나요?     | `Set`, `Dictionary` key              |
+| [`Identifiable`](./identifiable) | 변화 전후에도 같은 entity임을 나타내는 ID는?    | SwiftUI `List`, diffing, entity 추적 |
+| [`Comparable`](./comparable)     | 이 타입에 하나의 자연스러운 전체 순서가 있나요? | `<`, 범위, `sorted()`                |
+
+이름이 바뀐 같은 사용자는 `Identifiable.id`는 같지만 전체 값은 달라 `Equatable` 비교가 `false`일 수 있어요. 반대로 내용이 같은 임시 입력 두 개가 같은 값이어도 서로 다른 entity일 수 있어요.
+
+## 자주 하는 실수를 피해요
+
+### ID만 비교하고 모든 값을 같다고 가정해요
+
+entity ID만 같은 두 값을 `==`로 처리할 수는 있지만, 이름이나 상태처럼 공개된 값 차이가 중요한 타입에서는 치환 가능성을 깨요. ID 비교가 목적이면 `lhs.id == rhs.id`라고 호출부에 명시하거나 identity 전용 타입을 사용하세요.
+
+### 현재 시각이나 난수를 비교에 넣어요
+
+계산할 때마다 달라지는 값으로 `==`를 구현하면 같은 값의 비교 결과가 시점마다 바뀌어요. 동등성에 참여하는 요소는 비교하는 동안 안정적이어야 해요.
+
+### 상속 계층에서 값 동등성을 억지로 만들어요
+
+서브클래스가 새 값을 추가하면 대칭성과 치환 가능성을 유지하기 어려워요. 값 동등성이 핵심이라면 `final` 클래스나 구조체를 우선 검토하세요.
+
+### `==`를 구현하고 `Hashable`은 다른 필드를 사용해요
+
+같은 값은 반드시 같은 hash 입력을 사용해야 해요. 이 계약은 [Hashable 문서](./hashable)에서 자세히 설명해요.
+
+## 언제 `Equatable`을 사용해야 하나요
+
+- 두 값의 의미상 동등 여부가 도메인에 명확히 존재해요.
+- 컬렉션에서 값 검색, 중복 확인이나 테스트 비교가 필요해요.
+- `Hashable` 또는 `Comparable`을 채택하려고 해요.
+- 상태 변경 전후를 한 규칙으로 비교하고 싶어요.
+
+모든 타입에 습관적으로 붙이지는 마세요. 서비스 객체, 네트워크 세션처럼 값 동등성보다 수명과 행위가 중요한 객체는 자연스러운 `==`가 없을 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. “두 값을 같다고 했을 때 서로 바꿔도 되는가?”를 먼저 정의해요.
+2. 구조체와 enum의 모든 저장 값이 의미에 참여한다면 자동 합성을 사용해요.
+3. 정규화 같은 도메인 규칙이 있을 때만 `==`를 직접 구현해요.
+4. 반사성·대칭성·추이성과 치환 가능성을 예제로 검사해요.
+5. 클래스라면 값 비교 `==`와 참조 identity `===` 중 질문을 구분해요.
+6. `Hashable`도 채택한다면 같은 필드와 정규화 규칙을 사용해요.
+7. 여러 정렬 기준 중 하나를 선택하는 문제라면 `Equatable`과 별도의 sort closure를 사용해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 구조체의 `Equatable`은 언제 자동 합성되나요?
+
+원래 타입 선언에서 준수를 선언하고 모든 저장 프로퍼티가 `Equatable`이면 합성돼요. enum은 모든 연관 값이 `Equatable`이면 case와 연관 값을 기준으로 합성할 수 있어요.
+
+### `==`와 `===`는 어떻게 다른가요?
+
+`==`는 타입이 정의한 값 동등성을 비교하고 `===`는 두 참조가 같은 클래스 인스턴스를 가리키는지 확인해요. 구조체에는 클래스 identity가 없으므로 `===`를 사용하지 않아요.
+
+### `Equatable`의 법칙이 중요한 이유는 무엇인가요?
+
+컬렉션 검색과 상위 프로토콜이 `==`의 일관성을 전제로 동작하기 때문이에요. 반사성·대칭성·추이성이 깨지면 같은 입력에서도 검색과 그룹화 결과를 신뢰할 수 없어요.
+
+### 모든 프로퍼티를 `==`에 포함해야 하나요?
+
+공개적으로 관찰되는 값 의미를 바꾸는 프로퍼티는 포함해야 해요. 캐시처럼 결과 의미에 참여하지 않는 내부 구현 세부 정보는 제외할 수 있지만 그 선택을 타입의 계약으로 명확히 해야 해요.
+
+## 참고 자료
+
+- [Apple Developer — Equatable](https://developer.apple.com/documentation/swift/equatable)
+- [The Swift Programming Language — Protocols](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/)
+- [The Swift Programming Language — Structures and Classes](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/classesandstructures/)
+- [Swift-KR — Swift로 이해하는 제네릭](../generics)
+- [Swift-KR — Swift로 이해하는 Hashable](./hashable)
+- [Swift-KR — Swift로 이해하는 Identifiable](./identifiable)

--- a/docs/guide/swift/protocols/hashable.md
+++ b/docs/guide/swift/protocols/hashable.md
@@ -1,0 +1,300 @@
+---
+title: Swift로 이해하는 Hashable
+description: Hashable과 Equatable의 계약, hash 충돌, 자동 합성, hash(into:) 구현과 Set·Dictionary key를 안전하게 설계하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Hashable
+
+> **면접 답변 한 줄 요약:** `Hashable`은 값의 핵심 구성 요소를 `Hasher`에 제공해 `Set`과 `Dictionary`가 후보 위치를 빠르게 찾게 하는 `Equatable` 기반 프로토콜이며, 같은 값은 반드시 같은 hash 입력을 사용해야 해요.
+
+독서한 책의 ID를 중복 없이 보관하거나 ID로 기록을 빠르게 찾으려면 `Set`과 `Dictionary`를 사용해요. 이 자료구조는 모든 원소를 처음부터 비교하지 않고 먼저 hash를 이용해 값이 있을 법한 위치를 좁혀요.
+
+`Hashable`을 “고유한 정수를 만드는 기능”으로 이해하면 잘못된 key와 영속 저장 형식을 만들기 쉬워요. hash는 identity도 암호화도 아니며 서로 다른 값이 같은 hash를 가질 수 있어요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- hash와 hash collision의 의미
+- `Hashable`이 `Equatable`을 상속하는 이유
+- 구조체와 enum의 자동 합성
+- `hash(into:)`와 `==`를 같은 기준으로 구현하는 방법
+- `Set`과 `Dictionary` key를 변경할 때 생기는 문제
+- `hashValue`, `Identifiable`, 암호학적 hash의 차이
+
+## 먼저 알아둘 hash 용어
+
+| 용어           | 쉬운 뜻                                                                                                          |
+| -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| hash           | 값을 일정한 계산에 넣어 제한된 크기의 정수 표현으로 요약한 결과예요.                                             |
+| hash function  | 입력 값을 hash로 바꾸는 계산이에요. Swift에서는 `Hasher`가 표준 컬렉션용 계산을 담당해요.                        |
+| hash collision | 서로 다른 값이 같은 hash 결과를 가지는 상황이에요. 가능한 정상 상황이므로 최종적으로 `==` 비교가 필요해요.       |
+| bucket         | hash table이 비슷한 hash 위치의 후보를 모아 두는 개념적인 칸이에요. 구현 세부 구조는 표준 라이브러리가 결정해요. |
+| key            | `Dictionary`에서 값을 찾는 기준이 되는 값이에요. key 타입은 `Hashable`이어야 해요.                               |
+| 핵심 구성 요소 | 타입의 값 동등성을 결정하는 프로퍼티예요. `==`에 참여한다면 같은 방식으로 `Hasher`에도 제공해야 해요.            |
+| 암호학적 hash  | 위변조 검증과 보안 목적의 특성을 가진 별도 알고리즘이에요. `Hasher`는 이런 목적으로 설계되지 않았어요.           |
+
+## 배열 검색은 원소를 차례로 비교해요
+
+읽은 책 ID를 배열로 보관하면 중복 확인 때 앞에서부터 비교해요.
+
+```swift
+let completedBookIDs = ["swift", "ios", "testing"]
+
+completedBookIDs.contains("testing")
+```
+
+배열의 `contains`는 최악의 경우 모든 원소를 살펴봐요. 원소가 많고 membership 확인을 자주 한다면 중복 없는 hash 기반 `Set`이 목적에 더 잘 맞아요.
+
+```swift
+let completedBookIDs: Set<String> = [
+  "swift",
+  "ios",
+  "testing",
+]
+
+completedBookIDs.contains("testing")
+```
+
+`String`이 `Hashable`이므로 `Set<String>`을 만들 수 있어요. 평균적인 검색 비용은 상수 시간에 가까울 수 있지만, 구체 성능은 데이터와 구현 상태에 따라 달라져요.
+
+## `Hashable`은 먼저 후보를 좁히고 `==`로 확정해요
+
+hash 값의 가능한 개수는 제한되어 있지만 입력 값의 수는 훨씬 많아요. 따라서 서로 다른 값이 같은 hash를 가지는 collision을 완전히 피할 수 없어요.
+
+```text
+값 ── hash ──▶ 후보 bucket ── == ──▶ 실제 같은 값인지 확정
+```
+
+`Hashable`이 [`Equatable`](./equatable)을 상속하는 이유예요. hash가 다르면 두 값이 다르다고 빠르게 판단할 수 있지만, hash가 같다고 값까지 같다고 결론 내리면 안 돼요.
+
+반드시 지켜야 할 한 방향 계약은 다음과 같아요.
+
+```text
+a == b  이면  a와 b는 같은 구성 요소를 같은 순서로 hash해야 해요.
+```
+
+반대는 성립하지 않아요. 같은 hash를 가진 두 값이 `==`에서는 다를 수 있어요.
+
+## 저장 프로퍼티가 모두 Hashable이면 자동 합성해요
+
+```swift
+struct ReadingKey: Hashable {
+  let userID: Int
+  let bookID: String
+}
+
+var minutesByBook: [ReadingKey: Int] = [:]
+let key = ReadingKey(userID: 42, bookID: "swift")
+
+minutesByBook[key] = 30
+print(minutesByBook[key] as Any) // Optional(30)
+```
+
+`Int`와 `String`이 `Hashable`이므로 컴파일러가 `==`와 `hash(into:)`를 함께 합성해요. 모든 저장 프로퍼티가 값 의미에 참여할 때 가장 안전하고 간결한 방법이에요.
+
+연관 값이 모두 `Hashable`인 enum도 합성할 수 있어요.
+
+```swift
+enum LibraryRoute: Hashable {
+  case home
+  case bookDetail(id: String)
+  case search(query: String)
+}
+```
+
+navigation path나 상태 집합처럼 enum 값을 hash 기반 컬렉션에 저장할 때 유용해요.
+
+## 직접 구현할 때 `==`와 같은 구성 요소를 사용해요
+
+ISBN의 하이픈을 무시해 같은 판본인지 판단하는 타입을 만들게요.
+
+```swift
+struct ISBN: Hashable {
+  let rawValue: String
+
+  private var digits: String {
+    rawValue.filter(\.isNumber)
+  }
+
+  static func == (lhs: ISBN, rhs: ISBN) -> Bool {
+    lhs.digits == rhs.digits
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(digits)
+  }
+}
+
+let formatted = ISBN(rawValue: "978-1-2345-6789-0")
+let plain = ISBN(rawValue: "9781234567890")
+
+formatted == plain // true
+Set([formatted, plain]).count // 1
+```
+
+`==`와 `hash(into:)`가 모두 정규화된 `digits`를 사용해요. `==`는 `digits`를 쓰면서 `hash(into:)`는 `rawValue`를 사용하면 같은 값이 서로 다른 bucket으로 들어가 collection lookup이 실패할 수 있어요.
+
+`Hasher.combine(_:)` 호출 순서도 값 의미의 일부로 일관되게 유지해요. 직접 정수 hash 공식을 만들거나 프로퍼티의 `hashValue`를 XOR하는 방식보다 `Hasher`에 핵심 값을 차례로 전달하세요.
+
+## `hashValue`를 저장하거나 전송하지 마세요
+
+다음 코드는 안정적인 식별자를 만드는 방법이 아니에요.
+
+```swift
+let cacheFileName = String(key.hashValue) // 사용하지 마세요.
+```
+
+Swift 표준 `Hasher`는 실행마다 무작위 seed를 사용하므로 같은 값의 `hashValue`가 다른 process 실행에서 달라질 수 있어요. 표준 라이브러리는 hash 계산 방식을 버전 사이에 바꿀 수도 있어요.
+
+따라서 `hashValue`를 다음 목적으로 사용하지 않아요.
+
+- database primary key
+- 파일 이름이나 영속 cache key
+- network payload
+- 사용자 identity
+- 암호화, 서명이나 무결성 검증
+
+지속되는 ID에는 명시적인 문자열, UUID나 database key를 사용하고, 보안 hash에는 CryptoKit 같은 목적에 맞는 API를 사용해요.
+
+## key가 컬렉션 안에 있는 동안 hash 기준을 바꾸지 마세요
+
+참조 타입을 `Set` 원소나 `Dictionary` key로 사용하면서 hash에 참여하는 프로퍼티를 바꾸면 저장된 위치와 새 hash가 어긋날 수 있어요.
+
+```swift
+final class MutableBookKey: Hashable {
+  var id: String
+
+  init(id: String) {
+    self.id = id
+  }
+
+  static func == (
+    lhs: MutableBookKey,
+    rhs: MutableBookKey
+  ) -> Bool {
+    lhs.id == rhs.id
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+}
+
+let key = MutableBookKey(id: "old")
+var keys: Set = [key]
+key.id = "new" // Set 내부 위치와 현재 hash 기준이 달라질 수 있어요.
+```
+
+이후 `contains`와 `remove` 결과는 신뢰할 수 없어요. hash key에는 불변 값 타입을 우선 사용하세요. 꼭 바꿔야 한다면 컬렉션에서 기존 값을 제거한 뒤 변경하고 다시 삽입해야 하지만, 별도의 불변 key 타입이 더 안전해요.
+
+구조체 key를 `Set` 안에서 직접 변경할 수 없는 이유도 같은 invariant를 보호하는 데 도움이 돼요.
+
+## `Set`과 `Dictionary`는 서로 다른 문제를 해결해요
+
+```swift
+let favoriteBookIDs: Set<String> = ["swift", "testing"]
+
+let minutesByBookID: [String: Int] = [
+  "swift": 40,
+  "testing": 25,
+]
+```
+
+| 자료구조     | 저장하는 관계                  | 같은 key를 다시 넣으면                 |
+| ------------ | ------------------------------ | -------------------------------------- |
+| `Set`        | 중복 없는 값의 membership      | 기존 동등 값과 하나로 유지돼요.        |
+| `Dictionary` | 고유 key와 value의 association | 해당 key의 value가 새 값으로 교체돼요. |
+
+순서와 중복이 중요하면 `Array`, membership과 key lookup이 중요하면 hash 기반 collection을 검토해요. `Set`과 `Dictionary`의 iteration 순서에 비즈니스 의미를 기대하지 마세요.
+
+## 제네릭 알고리즘은 필요한 곳에서 Hashable을 요구해요
+
+```swift
+func unique<Element: Hashable>(
+  _ values: [Element]
+) -> [Element] {
+  var seen: Set<Element> = []
+
+  return values.filter { value in
+    seen.insert(value).inserted
+  }
+}
+```
+
+이 함수는 첫 등장 순서를 결과 배열에 유지하면서 중복 여부를 `Set`으로 확인해요. 단순히 두 값만 비교하는 함수에 `Hashable`까지 요구하면 불필요하게 강한 제약이에요. 그 경우에는 `Equatable`이면 충분해요.
+
+## Hashable, Identifiable과 암호학적 hash를 구분해요
+
+| 개념                                | 목적                                  | 실행 사이 안정성                              |
+| ----------------------------------- | ------------------------------------- | --------------------------------------------- |
+| `Hashable`                          | 표준 hash collection의 후보 위치 찾기 | 보장하지 않아요.                              |
+| [`Identifiable.id`](./identifiable) | entity를 변화 전후에 추적             | 선택한 ID 계약에 따라 달라요.                 |
+| UUID·database key                   | 영속 또는 지정 범위의 고유 identity   | 설계한 저장 범위에서 유지해요.                |
+| 암호학적 digest                     | 무결성·서명 같은 보안 목적            | 같은 알고리즘과 입력이면 재현되도록 설계해요. |
+
+`Hashable` 준수는 값이 전 세계에서 고유하다는 뜻이 아니고, hash 결과가 충돌하지 않는다는 뜻도 아니에요.
+
+## 자주 하는 실수를 정리해요
+
+### `hashValue`만 같으면 같은 값이라고 판단해요
+
+collision이 가능하므로 틀린 판단이에요. 동등성은 `==`가 결정하고 hash는 후보 검색을 돕기만 해요.
+
+### `==`에는 ID만, hash에는 모든 프로퍼티를 넣어요
+
+같다고 판정되는 값이 다른 hash를 갖게 되어 계약을 깨요. 같은 정규화와 같은 핵심 구성 요소를 사용하세요.
+
+### hash에 난수나 현재 시각을 넣어요
+
+호출마다 hash가 달라져 collection 내부 위치를 찾을 수 없어요. 한 값이 컬렉션에 있는 동안 hash 기준은 안정적이어야 해요.
+
+### 중복 제거만 하려고 결과를 무조건 Set으로 반환해요
+
+호출자가 원래 순서나 중복 횟수를 필요로 할 수 있어요. API의 결과 의미를 먼저 정하고 필요하면 위의 `unique`처럼 순서 있는 배열을 반환하세요.
+
+## 언제 `Hashable`을 사용해야 하나요
+
+- 사용자 정의 타입을 `Set` 원소로 저장해야 해요.
+- 사용자 정의 타입을 `Dictionary` key로 사용해야 해요.
+- hash 기반 중복 제거와 membership lookup이 필요해요.
+- `Equatable` 값에 안정적인 핵심 구성 요소가 이미 정의되어 있어요.
+
+단순 비교만 필요하거나 값이 자주 바뀌는 참조 객체에는 먼저 `Equatable`이나 별도의 불변 key 타입을 검토하세요.
+
+## 적용 순서를 정리해요
+
+1. 타입의 값 동등성을 먼저 정의하고 `Equatable` 계약을 확인해요.
+2. 모든 저장 값이 의미에 참여한다면 `Hashable` 자동 합성을 사용해요.
+3. 직접 구현할 때 `==`와 `hash(into:)`에 정확히 같은 정규화 기준을 적용해요.
+4. key가 collection 안에 있는 동안 핵심 구성 요소를 바꾸지 않아요.
+5. `hashValue`를 process 밖에 저장하거나 전송하지 않아요.
+6. 순서가 필요한지 확인해 `Array`, `Set`, `Dictionary` 중 목적에 맞게 선택해요.
+7. 사용자 identity와 보안 digest가 필요하면 별도의 전용 타입과 API를 사용해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `Hashable`이 `Equatable`을 상속하는 이유는 무엇인가요?
+
+hash collision이 가능해서 hash가 같은 후보를 최종적으로 `==`로 구분해야 하기 때문이에요. hash는 검색 범위를 좁히고 동등성은 실제 같은 값을 확정해요.
+
+### 서로 다른 값의 hash는 반드시 달라야 하나요?
+
+아니요. 서로 다른 값이 같은 hash를 갖는 collision은 허용돼요. 반드시 필요한 계약은 `a == b`라면 두 값이 같은 핵심 구성 요소를 같은 순서로 hash해야 한다는 것이에요.
+
+### `hashValue`를 database key로 쓰면 안 되는 이유는 무엇인가요?
+
+Swift의 hash는 실행마다 달라질 수 있고 구현도 영속 형식으로 보장되지 않기 때문이에요. database에는 UUID나 명시적인 primary key를 사용해야 해요.
+
+### mutable class를 Dictionary key로 쓸 때 무엇을 조심해야 하나요?
+
+key가 저장된 동안 equality와 hash에 참여하는 값을 변경하면 안 돼요. 조회에 사용할 새 hash와 저장 위치가 달라질 수 있으므로 불변 값 타입 key를 우선 사용해요.
+
+## 참고 자료
+
+- [Apple Developer — Hashable](https://developer.apple.com/documentation/swift/hashable)
+- [Apple Developer — Hasher](https://developer.apple.com/documentation/swift/hasher)
+- [The Swift Programming Language — Collection Types](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/collectiontypes/)
+- [Swift Evolution SE-0206 — Hashable Enhancements](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0206-hashable-enhancements.md)
+- [Swift-KR — Swift로 이해하는 Equatable](./equatable)
+- [Swift-KR — Swift로 이해하는 Identifiable](./identifiable)

--- a/docs/guide/swift/protocols/identifiable.md
+++ b/docs/guide/swift/protocols/identifiable.md
@@ -1,0 +1,297 @@
+---
+title: Swift로 이해하는 Identifiable
+description: Identifiable의 stable identity와 ID 범위·수명, SwiftUI List diffing, ObjectIdentifier 기본 구현과 안전한 ID 설계 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Identifiable
+
+> **면접 답변 한 줄 요약:** `Identifiable`은 값의 다른 프로퍼티가 바뀌어도 같은 entity임을 추적할 수 있도록 `Hashable`한 `id`를 제공하는 프로토콜이며, ID의 고유 범위와 유지 기간은 타입과 소비자가 함께 합의해야 해요.
+
+독서 기록의 메모나 시간이 바뀌어도 화면은 기존 row가 수정된 것인지 새 row가 생긴 것인지 알아야 해요. 값 전체를 identity로 사용하면 변경할 때마다 다른 항목으로 보이고, 배열 index를 사용하면 삽입과 정렬 때 다른 항목이 같은 identity를 차지할 수 있어요.
+
+`Identifiable`은 entity의 stable identity를 `id` 하나로 표현해요. 하지만 프로토콜이 전 세계에서 영구히 유일한 ID를 자동으로 보장하지는 않아요. 현재 collection 안에서만 고유한 index부터 database에 영속하는 UUID까지 범위가 다양해요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- entity identity와 값 동등성의 차이
+- `ID: Hashable`과 associated type의 의미
+- SwiftUI `List`와 `ForEach`가 identity를 사용하는 이유
+- UUID, database ID, 임시 ID와 `ObjectIdentifier`의 수명
+- 계산할 때마다 바뀌는 ID와 `\.self` 오용
+- ID를 API와 persistence 경계에서 설계하는 방법
+
+## 먼저 알아둘 identity 용어
+
+| 용어               | 쉬운 뜻                                                                                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| entity             | 시간이 지나 프로퍼티가 바뀌어도 같은 대상으로 추적할 개체예요. 사용자, 주문과 독서 기록이 예예요.                       |
+| identity           | 변화 전후의 값이 같은 entity를 나타내는지 판단하는 기준이에요.                                                          |
+| stable identity    | 소비자가 추적해야 하는 기간 동안 바뀌지 않는 identity예요.                                                              |
+| associated type    | 프로토콜을 따르는 각 구체 타입이 정하는 내부 타입 자리예요. `Identifiable.ID`가 한 예예요.                              |
+| diffing            | 이전 collection과 새 collection을 비교해 삽입·삭제·이동·수정을 찾는 과정이에요.                                         |
+| scope              | ID가 서로 겹치지 않는다고 보장하는 범위예요. 한 배열, 한 process, 한 database나 전체 service일 수 있어요.               |
+| lifetime           | ID가 같은 entity를 계속 가리킨다고 보장하는 기간이에요. 화면 표시 동안, process 동안 또는 영구 저장 기간일 수 있어요.   |
+| `ObjectIdentifier` | 실행 중 특정 클래스 인스턴스나 metatype의 identity를 나타내는 값이에요. 객체가 살아 있는 동안만 그 identity를 의미해요. |
+
+## 값 전체를 identity로 사용하면 수정도 삭제·삽입처럼 보여요
+
+```swift
+struct ReadingSession: Hashable {
+  var bookTitle: String
+  var minutes: Int
+}
+
+let before = ReadingSession(
+  bookTitle: "Swift",
+  minutes: 20
+)
+let after = ReadingSession(
+  bookTitle: "Swift",
+  minutes: 30
+)
+```
+
+두 값은 독서 시간이 달라 `Hashable`과 `Equatable` 관점에서 다른 값이에요. 하지만 사용자가 기존 session의 시간을 수정한 것이라면 entity 관점에서는 같은 기록이에요.
+
+SwiftUI에서 다음처럼 `\.self`를 ID로 사용하면 모든 hashable 값이 identity가 돼요.
+
+```swift
+ForEach(sessions, id: \.self) { session in
+  Text("\(session.bookTitle): \(session.minutes)분")
+}
+```
+
+`minutes`가 바뀌면 ID도 바뀌므로 framework가 기존 row의 수정이 아니라 이전 row 삭제와 새 row 삽입으로 해석할 수 있어요. animation, selection과 row 내부 state가 의도와 다르게 연결될 수 있어요.
+
+## `Identifiable`은 별도의 stable ID를 제공해요
+
+```swift
+import Foundation
+
+struct ReadingSession: Identifiable, Equatable {
+  let id: UUID
+  var bookTitle: String
+  var minutes: Int
+}
+
+let id = UUID()
+let before = ReadingSession(
+  id: id,
+  bookTitle: "Swift",
+  minutes: 20
+)
+let after = ReadingSession(
+  id: id,
+  bookTitle: "Swift",
+  minutes: 30
+)
+
+before.id == after.id // true: 같은 entity예요.
+before == after       // false: 현재 값은 달라요.
+```
+
+`id`는 수정 전후에 유지되고 나머지 값은 자유롭게 바뀔 수 있어요. 이것이 identity와 equality가 분리되는 대표적인 예예요.
+
+프로토콜의 핵심 모양은 다음과 같아요.
+
+```swift
+protocol Identifiable<ID> {
+  associatedtype ID: Hashable
+  var id: ID { get }
+}
+```
+
+실제 표준 라이브러리 선언은 언어 버전에 따른 세부 제약을 더 포함할 수 있어요. 중요한 점은 각 타입이 `String`, `Int`, UUID 같은 자신의 ID 타입을 선택하고, 그 ID가 `Hashable`해야 한다는 것이에요.
+
+## SwiftUI는 ID로 row의 수명을 연결해요
+
+원소가 `Identifiable`이면 `List`와 `ForEach`에서 `id` key path를 생략할 수 있어요.
+
+```swift
+import SwiftUI
+
+struct ReadingListView: View {
+  let sessions: [ReadingSession]
+
+  var body: some View {
+    List(sessions) { session in
+      Text("\(session.bookTitle): \(session.minutes)분")
+    }
+  }
+}
+```
+
+SwiftUI는 이전과 새 data의 ID를 비교해 어떤 row가 유지·삽입·삭제·이동됐는지 판단해요. ID가 같다고 모든 내용이 같다는 뜻은 아니며, 같은 ID의 내용 변경은 기존 view identity 안에서 다시 rendering할 근거가 돼요.
+
+좋은 row ID는 다음 조건을 만족해요.
+
+- 같은 collection snapshot 안에서 중복되지 않아요.
+- 해당 entity를 추적해야 하는 동안 바뀌지 않아요.
+- 정렬 순서나 화면 위치와 독립적이에요.
+- 서버나 database가 identity를 소유한다면 그 값을 유지해요.
+- 임시 entity라면 서버 ID를 받기 전후의 migration 규칙이 있어요.
+
+## 계산할 때마다 UUID를 만들면 stable identity가 아니에요
+
+다음 구현은 `id`를 읽을 때마다 다른 값을 반환해요.
+
+```swift
+struct UnstableSession: Identifiable {
+  var id: UUID { UUID() } // 잘못된 예예요.
+  var minutes: Int
+}
+```
+
+같은 instance에서도 `session.id == session.id`가 `false`가 될 수 있어요. diffing은 매 update마다 모든 row를 새 항목으로 볼 수 있어요.
+
+ID는 저장하거나 외부의 안정적인 key에서 계산해요.
+
+```swift
+import Foundation
+
+struct DraftSession: Identifiable {
+  let id = UUID()
+  var minutes: Int
+}
+```
+
+이 ID는 `DraftSession` value를 새로 만드는 시점에 한 번 생성돼요. 하지만 앱을 종료하고 복원할 때도 같은 entity여야 한다면 `id`도 함께 encode해 저장해야 해요.
+
+## ID의 범위와 수명을 문서화해요
+
+Apple의 공식 `Identifiable` 문서는 identity의 범위와 기간을 일부러 고정하지 않아요. 다음 선택이 모두 가능해요.
+
+| ID 예시                    | 고유 범위와 수명                            | 적합한 상황                                |
+| -------------------------- | ------------------------------------------- | ------------------------------------------ |
+| collection index           | 현재 collection 구성과 순서가 유지되는 동안 | 변경되지 않는 정적 목록의 일시적 표시      |
+| 증가하는 process 내부 번호 | 현재 process가 살아 있는 동안               | 디버깅용 작업 추적                         |
+| `ObjectIdentifier`         | 해당 class instance가 살아 있는 동안        | 같은 메모리 객체인지 추적                  |
+| database primary key       | database가 record를 유지하는 동안           | 저장된 entity 추적                         |
+| UUID                       | 생성 충돌 가능성이 매우 낮은 넓은 범위      | client가 새 entity identity를 먼저 만들 때 |
+| server가 발급한 ID         | service의 계약이 보장하는 기간과 namespace  | 여러 device가 공유하는 원격 entity         |
+
+한 화면 안에서만 유일한 ID를 app 전체 cache key로 사용하면 충돌할 수 있어요. 반대로 짧게 표시할 값에 항상 전역 UUID가 필요한 것은 아니에요. 소비자가 요구하는 범위를 먼저 정하세요.
+
+## 클래스의 기본 ID는 객체 수명만 보장해요
+
+클래스는 `ObjectIdentifier` 기반 기본 구현을 사용할 수 있어요.
+
+```swift
+final class ReadingController: Identifiable {
+  var minutes = 0
+}
+
+let first = ReadingController()
+let alias = first
+let second = ReadingController()
+
+first.id == alias.id  // true
+first.id == second.id // false
+```
+
+이 기본 ID는 같은 class instance를 추적하는 데 적합하지만 앱 재실행 뒤 같은 database record를 나타내지 못해요. 객체가 사라지면 identity의 의미도 끝나고, 나중에 메모리 주소가 재사용될 수 있어요.
+
+도메인에 더 강한 identity가 있다면 직접 제공해요.
+
+```swift
+final class User: Identifiable {
+  let id: String
+  var displayName: String
+
+  init(id: String, displayName: String) {
+    self.id = id
+    self.displayName = displayName
+  }
+}
+```
+
+## 배열 index는 변경 가능한 목록의 entity ID가 아니에요
+
+```swift
+ForEach(sessions.indices, id: \.self) { index in
+  SessionRow(session: sessions[index])
+}
+```
+
+첫 원소를 삭제하면 뒤 원소의 index가 모두 바뀌어요. `1`이라는 ID가 이전에는 두 번째 session을, 이후에는 원래 세 번째 session을 가리킬 수 있어요. row state가 다른 data에 붙는 문제가 생길 수 있어요.
+
+index는 위치를 나타내지 entity를 나타내지 않아요. 목록이 삽입·삭제·정렬될 수 있다면 원소가 가진 stable ID를 사용하세요. 정말 변하지 않는 정적 범위라면 index도 해당 짧은 scope에서 유효할 수 있어요.
+
+## 임시 ID와 서버 ID가 바뀌는 순간을 설계해요
+
+새 기록을 offline에서 만든 뒤 server가 ID를 발급하는 앱을 생각해요.
+
+```swift
+struct SessionID: Hashable, Codable {
+  enum Storage: Hashable, Codable {
+    case local(UUID)
+    case remote(String)
+  }
+
+  let storage: Storage
+}
+```
+
+local ID를 remote ID로 단순 교체하면 UI 관점의 identity도 바뀌어요. 화면에서 새 row로 전환되어도 괜찮은지, mapping table로 local identity를 계속 유지할지, server가 client UUID를 받아 같은 ID를 쓸지 결정해야 해요.
+
+정답은 backend 계약에 따라 달라요. 중요한 점은 ID 전환을 우연히 일어나게 두지 않고 selection, cache, navigation과 sync queue가 어떤 key를 사용하는지 함께 설계하는 것이에요.
+
+## `Identifiable`과 다른 프로토콜을 비교해요
+
+| 프로토콜                   | 기준                                      | 같은 ID인데 다른 값이 가능한가요? |
+| -------------------------- | ----------------------------------------- | --------------------------------- |
+| [`Equatable`](./equatable) | 현재 값 전체의 의미상 동등성              | 네.                               |
+| [`Hashable`](./hashable)   | 동등한 값을 hash collection에서 찾는 규칙 | 네.                               |
+| `Identifiable`             | entity를 추적하는 stable ID               | 네. 일반적인 변경 상황이에요.     |
+| [`Codable`](./codable)     | 외부 표현으로 encode·decode 가능한지      | identity를 보장하지 않아요.       |
+
+`Identifiable`은 `Equatable`이나 `Codable`을 상속하지 않아요. ID만 있으면 되고 나머지 값 비교와 serialization 여부는 별도의 선택이에요.
+
+## 언제 `Identifiable`을 사용해야 하나요
+
+- SwiftUI `List`와 `ForEach`에서 변경 가능한 entity 목록을 표시해요.
+- 이전 snapshot과 새 snapshot 사이에서 같은 항목을 추적해야 해요.
+- navigation destination, selection이나 cache가 entity key를 필요로 해요.
+- 값의 내용과 별개로 유지되는 database 또는 server identity가 있어요.
+
+순수 계산 결과처럼 값 동등성만 중요하고 entity 수명이 없다면 `Equatable`만으로 충분할 수 있어요. 모든 작은 value type에 UUID를 추가하면 불필요한 identity와 저장 비용이 생겨요.
+
+## 적용 순서를 정리해요
+
+1. 이 타입이 시간이 지나도 같은 대상으로 추적할 entity인지 판단해요.
+2. ID가 고유해야 하는 scope와 유지해야 하는 lifetime을 정의해요.
+3. database·server가 ID를 소유한다면 그 key를 사용해요.
+4. client에서 새 entity를 만든다면 ID를 한 번 생성하고 필요한 저장 경계에 포함해요.
+5. 계산 프로퍼티에서 매번 UUID를 만들거나 변경 목록에 index를 사용하지 않아요.
+6. ID 변경이 불가피하면 UI, cache, navigation과 sync의 migration을 함께 설계해요.
+7. equality, hashing과 encoding은 identity와 별도 계약으로 검토해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `Identifiable`의 `ID`는 왜 `Hashable`이어야 하나요?
+
+framework와 collection이 ID를 key로 빠르게 저장하고 비교할 수 있어야 하기 때문이에요. ID 자체의 hash 가능성이 entity 전체가 `Hashable`이라는 뜻은 아니에요.
+
+### `Identifiable`이면 `Equatable`도 자동으로 준수하나요?
+
+아니요. 두 프로토콜은 독립적이에요. `Identifiable`은 같은 entity를 추적하고 `Equatable`은 현재 두 값이 의미상 같은지를 정의해요.
+
+### SwiftUI에서 `id: \.self`는 언제 안전한가요?
+
+원소 값 자체가 고유하고 표시되는 동안 절대 바뀌지 않을 때만 적합해요. 중복되거나 수정 가능한 값이라면 별도의 stable ID를 제공하는 편이 안전해요.
+
+### 클래스가 제공하는 기본 `id`를 database ID로 써도 되나요?
+
+안 돼요. 기본 `ObjectIdentifier`는 해당 객체가 살아 있는 동안의 instance identity만 나타내요. 영속 entity에는 database나 server가 보장하는 ID를 직접 구현해야 해요.
+
+## 참고 자료
+
+- [Apple Developer — Identifiable](https://developer.apple.com/documentation/swift/identifiable)
+- [Apple Developer — ObjectIdentifier](https://developer.apple.com/documentation/swift/objectidentifier)
+- [Apple Developer — ForEach](https://developer.apple.com/documentation/swiftui/foreach)
+- [Apple Developer — List](https://developer.apple.com/documentation/swiftui/list)
+- [Swift Evolution SE-0261 — Identifiable Protocol](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0261-identifiable.md)
+- [Swift-KR — Swift로 이해하는 Equatable](./equatable)
+- [Swift-KR — Swift로 이해하는 Hashable](./hashable)

--- a/docs/guide/swift/protocols/sendable.md
+++ b/docs/guide/swift/protocols/sendable.md
@@ -1,0 +1,396 @@
+---
+title: Swift로 이해하는 Sendable
+description: Swift 6의 Sendable과 @Sendable이 concurrency domain 사이 data race를 막는 방식, actor·class 준수와 @unchecked 사용 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Sendable
+
+> **면접 답변 한 줄 요약:** `Sendable`은 값이 task와 actor 같은 concurrency domain 사이에서 공유되어도 data race를 만들지 않는다는 의미 계약을 compiler가 검사하는 marker protocol이고, closure에는 `@Sendable`로 같은 안전 조건을 표현해요.
+
+비동기 함수가 많다고 data race가 생기는 것은 아니에요. 서로 다른 task가 같은 mutable memory에 동시에 접근하고 그중 하나 이상이 값을 쓸 수 있을 때 문제가 생겨요. 결과는 실행 순서에 따라 달라지고 재현하기 어려워요.
+
+Swift Concurrency는 actor isolation과 `Sendable` 검사를 함께 사용해 unsafe한 공유를 compile time에 막아요. `Sendable`에는 호출할 method가 없지만 준수를 잘못 선언하면 안전성 보장이 깨질 수 있으므로 단순히 warning을 없애는 annotation으로 사용하면 안 돼요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- concurrency domain과 data race의 의미
+- marker protocol인 `Sendable`의 semantic requirement
+- 구조체·enum, final class, actor와 global actor의 준수 규칙
+- generic collection의 conditional sendability
+- `@Sendable` closure와 capture 검사
+- `@unchecked Sendable`, `@preconcurrency`와 `sending`의 경계
+
+## 먼저 알아둘 동시성 용어
+
+| 용어                  | 쉬운 뜻                                                                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| concurrency domain    | mutable state에 순차적으로 접근하는 하나의 격리 영역이에요. task와 actor instance가 경계를 만들 수 있어요.                            |
+| data race             | 여러 실행 흐름이 같은 memory에 동시에 접근하고 하나 이상이 쓰면서 synchronization되지 않은 상황이에요.                                |
+| actor isolation       | actor가 자신의 mutable state 접근을 한 번에 하나씩 실행하도록 보호하는 규칙이에요.                                                    |
+| marker protocol       | method나 property 요구사항 없이 타입이 특정 의미 조건을 만족한다는 사실을 표시하는 protocol이에요.                                    |
+| sendable type         | 여러 concurrency domain에서 동시에 공유해도 data race 위험이 없도록 설계된 타입이에요.                                                |
+| `@Sendable` closure   | concurrency domain을 넘어 실행될 수 있어 capture한 값도 sendable이어야 하는 closure예요.                                              |
+| `@unchecked Sendable` | compiler 검사를 끄고 작성자가 locking 등으로 안전을 직접 보증하는 준수예요.                                                           |
+| global actor          | 여러 declaration을 하나의 전역 actor에 격리하는 기능이에요. `@MainActor`가 UI state를 보호하는 대표적인 global actor예요.             |
+| region transfer       | non-sendable 값의 소유 영역을 다른 격리 경계로 완전히 넘겨 원래 쪽에서 더 사용하지 못하게 하는 방식이에요. `sending`이 이를 표현해요. |
+
+## mutable class를 task 사이에 공유하면 race가 생길 수 있어요
+
+```swift
+final class ReadingCounter {
+  var minutes = 0
+
+  func addTenMinutes() {
+    minutes += 10
+  }
+}
+```
+
+`minutes += 10`은 값을 읽고 10을 더해 다시 쓰는 여러 단계예요. 두 task가 같은 instance에서 동시에 실행하면 둘 다 이전 값 0을 읽고 각각 10을 써서 최종 결과가 20이 아닌 10이 될 수 있어요.
+
+```swift
+let counter = ReadingCounter()
+
+// strict concurrency에서는 mutable reference를
+// task 경계로 보내는 code를 compiler가 진단할 수 있어요.
+```
+
+단순히 class에 `Sendable`을 붙이는 것으로 mutation이 직렬화되지는 않아요. type의 실제 구현이 sharing에 안전해야 해요.
+
+## `Sendable`은 실행 method가 없는 의미 계약이에요
+
+현재 Swift 표준 라이브러리에서 `Sendable`은 required method나 property가 없는 marker protocol이에요. compiler는 stored property, associated value, class finality와 isolation을 검사해 준수가 안전한지 판단해요.
+
+```swift
+import Foundation
+
+struct ReadingSnapshot: Sendable {
+  let id: UUID
+  let minutes: Int
+  let note: String
+}
+```
+
+`UUID`, `Int`, `String`이 sendable이고 구조체가 value semantics를 가지므로 snapshot을 actor 사이에 전달할 수 있어요.
+
+```swift
+actor ReadingStore {
+  private var snapshots: [ReadingSnapshot] = []
+
+  func append(_ snapshot: ReadingSnapshot) {
+    snapshots.append(snapshot)
+  }
+}
+
+let store = ReadingStore()
+let snapshot = ReadingSnapshot(
+  id: UUID(),
+  minutes: 30,
+  note: "Sendable"
+)
+
+await store.append(snapshot)
+```
+
+actor method를 외부에서 호출하면 argument가 isolation boundary를 건너요. `ReadingSnapshot`의 value를 안전하게 전달할 수 있다는 사실을 compiler가 알아요.
+
+## 구조체와 enum은 모든 내부 값이 sendable이어야 해요
+
+```swift
+enum SyncCommand: Sendable {
+  case upload(ReadingSnapshot)
+  case delete(id: UUID)
+}
+```
+
+구조체의 stored property와 enum의 associated value가 모두 `Sendable`이면 명시적으로 준수할 수 있어요. 내부 type이 unsafe한 mutable reference라면 compiler가 진단해요.
+
+```swift
+final class MutableFormatter {
+  var prefix = ""
+}
+
+struct ExportRequest: Sendable {
+  let snapshot: ReadingSnapshot
+  // let formatter: MutableFormatter
+  // error: non-Sendable stored property예요.
+}
+```
+
+module 내부의 일부 value type은 조건을 만족하면 implicit `Sendable`을 얻을 수 있어요. public API와 `@usableFromInline`처럼 resilient boundary에서는 compiler가 미래의 stored property 변경을 알 수 없으므로 명시적 준수가 필요한 경우가 있어요. API 계약으로 중요하다면 선언에 `Sendable`을 써 의도를 드러내세요.
+
+## generic type은 원소가 sendable일 때만 안전해요
+
+```swift
+struct Page<Element: Sendable>: Sendable {
+  let items: [Element]
+  let nextCursor: String?
+}
+```
+
+`Array`도 `Element`가 `Sendable`일 때 conditionally sendable해요. `Page<ReadingSnapshot>`은 안전하지만 non-sendable mutable class를 원소로 가진 page는 이 제약을 만족하지 못해요.
+
+모든 generic type에 무조건 `Element: Sendable`을 붙이지 마세요. concurrency boundary를 전혀 넘지 않는 container까지 제한할 수 있어요. API가 값을 다른 domain으로 보내는 역할일 때 필요한 제약을 선언해요.
+
+## actor는 mutable state 접근을 직렬화해요
+
+```swift
+actor ReadingCounter {
+  private var minutes = 0
+
+  func addTenMinutes() {
+    minutes += 10
+  }
+
+  func currentMinutes() -> Int {
+    minutes
+  }
+}
+```
+
+actor type은 자신의 mutable state 접근을 isolation하고 암시적으로 `Sendable`이에요. 외부 code는 `await`로 actor-isolated method를 호출하고 actor가 한 번에 하나씩 실행하도록 조정해요.
+
+```swift
+let counter = ReadingCounter()
+
+async let first: Void = counter.addTenMinutes()
+async let second: Void = counter.addTenMinutes()
+_ = await (first, second)
+
+let total = await counter.currentMinutes() // 20
+```
+
+`Sendable`과 actor는 역할이 달라요. `Sendable`은 경계를 넘어 공유할 type의 안전성을 표현하고 actor는 자신의 mutable state 접근을 격리해요.
+
+## 일반 class의 checked conformance는 제한적이에요
+
+일반 class가 compiler가 검사하는 `Sendable`을 만족하려면 보통 다음 조건이 필요해요.
+
+- `final`이라 subclass가 unsafe stored property를 추가할 수 없어요.
+- stored property가 immutable `let`이고 sendable해요.
+- superclass가 없거나 허용된 안전한 superclass 조건을 만족해요.
+
+```swift
+import Foundation
+
+final class ReadingConfiguration: Sendable {
+  let apiBaseURL: URL
+  let maximumRetries: Int
+
+  init(apiBaseURL: URL, maximumRetries: Int) {
+    self.apiBaseURL = apiBaseURL
+    self.maximumRetries = maximumRetries
+  }
+}
+```
+
+instance가 생성된 뒤 공개된 state가 바뀌지 않으므로 여러 domain에서 같은 reference를 읽어도 race가 없어요.
+
+`let` property가 가리키는 reference 내부가 mutable하다면 안전하지 않을 수 있어요. `let`은 reference 자체를 다른 객체로 바꾸지 못하게 할 뿐, 참조된 객체의 내부 mutation까지 자동으로 막지 않아요.
+
+## `@MainActor` class는 main actor가 state를 보호해요
+
+```swift
+@MainActor
+final class ReadingViewModel {
+  private(set) var minutes = 0
+
+  func addTenMinutes() {
+    minutes += 10
+  }
+}
+```
+
+global actor로 격리된 class는 mutable property가 있어도 해당 actor가 접근을 조정하므로 암시적으로 sendable해요. 다른 domain은 main actor로 hop한 뒤 state를 읽거나 변경해요.
+
+```swift
+await viewModel.addTenMinutes()
+```
+
+UI state라서 main actor에 있어야 하는 경우에는 적절하지만 단지 `Sendable` warning을 없애려고 모든 model을 `@MainActor`에 두면 background 작업도 main actor에 묶여요. 실제 state 소유와 실행 요구에 따라 isolation을 선택하세요.
+
+## closure는 `@Sendable`로 capture 안전성을 표현해요
+
+closure는 주변 값을 capture할 수 있으므로 function type 자체에 concurrency 안전 조건이 필요해요.
+
+```swift
+let prefix = "독서"
+
+let format: @Sendable (Int) -> String = { minutes in
+  "\(prefix) \(minutes)분"
+}
+```
+
+`prefix`는 immutable sendable `String`이라 안전하게 capture할 수 있어요. `@Sendable` closure는 capture한 값이 sendable이어야 하고 mutable variable을 unsafe하게 동시에 capture할 수 없어요.
+
+```swift
+var total = 0
+
+// let add: @Sendable (Int) -> Void = { value in
+//   total += value
+// }
+// strict concurrency에서 concurrently mutated capture를 진단해요.
+```
+
+여러 task가 누계를 공유해야 한다면 actor처럼 mutation을 격리하는 type을 capture해요.
+
+```swift
+actor TotalMinutes {
+  private var value = 0
+
+  func add(_ minutes: Int) {
+    value += minutes
+  }
+}
+
+let totalMinutes = TotalMinutes()
+let add: @Sendable (Int) async -> Void = { minutes in
+  await totalMinutes.add(minutes)
+}
+```
+
+`Sendable`은 type 준수이고 `@Sendable`은 function·closure type attribute라는 차이를 기억하세요.
+
+## `@unchecked Sendable`은 compiler 대신 작성자가 증명해요
+
+legacy class가 내부 lock으로 모든 mutation을 보호하지만 compiler가 그 사실을 분석하지 못할 수 있어요.
+
+```swift
+import Foundation
+
+final class LockedReadingCounter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var minutes = 0
+
+  func add(_ value: Int) {
+    lock.lock()
+    defer { lock.unlock() }
+    minutes += value
+  }
+
+  func current() -> Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return minutes
+  }
+}
+```
+
+모든 state 접근이 같은 lock을 사용하므로 작성자가 thread safety를 보증해요. 하지만 새 property나 method가 lock을 빠뜨려도 compiler가 알려 주지 않아요.
+
+`@unchecked Sendable`을 사용할 때는 다음을 확인해요.
+
+- 모든 mutable state 접근이 같은 synchronization 규칙을 따라요.
+- 내부 reference가 밖으로 노출되어 lock 없이 바뀌지 않아요.
+- callback을 lock을 잡은 채 호출해 deadlock을 만들지 않아요.
+- 동시 실행 stress test와 code review를 유지해요.
+- actor나 immutable snapshot으로 바꿀 수 없는 이유를 문서화해요.
+
+warning을 빠르게 없애기 위한 기본 선택으로 사용하지 마세요.
+
+## unavailable conformance로 암시적 준수를 막을 수 있어요
+
+구조상 implicit sendable 조건을 만족해도 domain 의미상 넘기면 안 되는 type에는 unavailable conformance를 선언할 수 있어요.
+
+```swift
+struct FileHandleToken {
+  let rawValue: Int32
+}
+
+@available(*, unavailable)
+extension FileHandleToken: Sendable {}
+```
+
+integer 자체는 sendable이지만 열린 file resource의 ownership은 단순 복사와 다를 수 있어요. 값의 stored property 형태뿐 아니라 resource 의미 때문에 보내면 안 된다는 계약을 드러내요.
+
+최신 language mode에는 `~Sendable`처럼 implicit conformance를 억제하는 문법도 추가되고 있지만 compiler version에 따라 experimental feature flag가 필요할 수 있어요. library 문서는 최소 compiler version을 명시하고, 넓은 호환성이 필요하면 위의 unavailable conformance를 사용하세요.
+
+## `sending`은 type 전체의 공유 가능성과 다른 선택이에요
+
+최신 Swift는 일부 parameter와 result에 `sending`을 사용해 특정 non-sendable value 영역을 다른 isolation domain으로 완전히 transfer할 수 있어요. transfer 뒤 원래 domain에서 그 값을 다시 사용하지 못하게 compiler가 검사해 concurrent alias를 막아요.
+
+| 표현       | 보장하는 관점                                                               |
+| ---------- | --------------------------------------------------------------------------- |
+| `Sendable` | 해당 type의 value를 여러 concurrency domain에서 안전하게 공유할 수 있어요.  |
+| `sending`  | 이 호출에서 특정 value 영역의 소유를 넘기고 이전 쪽의 후속 사용을 제한해요. |
+
+모든 non-sendable type을 `@unchecked Sendable`로 만드는 대신 ownership transfer로 문제가 풀리는지 검토할 수 있어요. 다만 API와 compiler version에 따라 사용할 수 있는 위치가 달라지므로 공식 language guide와 proposal을 확인하세요.
+
+## `@preconcurrency`는 migration 도구예요
+
+concurrency annotation이 없는 오래된 module을 import할 때 `@preconcurrency import ModuleName`으로 일부 검사를 완화할 수 있어요. 이는 imported API가 실제 thread-safe해진다는 뜻이 아니에요.
+
+- dependency의 최신 version이 concurrency annotation을 제공하는지 먼저 확인해요.
+- 완화된 경계에서 어떤 type을 어느 actor에서 사용하는지 직접 검토해요.
+- module migration이 끝나면 annotation을 제거해 compiler 검사를 복원해요.
+
+`@preconcurrency`와 `@unchecked Sendable`은 점진적 migration의 책임을 작성자에게 옮기는 도구예요.
+
+## Sendable과 관련 개념을 비교해요
+
+| 개념                  | 보호하는 대상                                | 핵심 질문                                      |
+| --------------------- | -------------------------------------------- | ---------------------------------------------- |
+| `Sendable`            | 경계를 넘어 공유되는 value                   | 여러 domain에서 사용해도 race가 없나요?        |
+| `@Sendable`           | 경계를 넘어 실행되는 closure와 capture       | closure가 안전한 값만 capture하나요?           |
+| actor                 | actor instance의 mutable state               | 이 state 접근을 누가 순차 실행하나요?          |
+| `@MainActor`          | UI 등 main actor 소유 state와 code           | 이 접근은 main actor에서 실행되어야 하나요?    |
+| `@unchecked Sendable` | compiler가 증명 못 하는 수동 synchronization | 작성자가 모든 공유 안전성을 실제로 보증했나요? |
+| `sending`             | 한 호출에서 transfer되는 value region        | 공유 대신 소유를 완전히 넘길 수 있나요?        |
+
+`Sendable`이 “항상 background thread에서 실행된다”는 뜻은 아니에요. 실행 위치가 아니라 data를 isolation boundary 사이에 둘 수 있는지를 표현해요.
+
+## 언제 `Sendable`을 사용해야 하나요
+
+- public API의 argument나 result가 task·actor boundary를 건너요.
+- closure를 task group, detached task나 concurrent callback에 전달해요.
+- immutable snapshot과 message type의 동시성 안전 계약을 드러내요.
+- generic container가 sendable 원소만 담아 경계를 넘어야 해요.
+- Swift 6 strict concurrency 진단을 근거로 실제 공유 구조를 개선해요.
+
+한 actor 안에서만 수명이 끝나는 private helper까지 무조건 public `Sendable`로 만들 필요는 없어요. 경계를 찾고 immutable value, actor isolation, ownership transfer 중 문제에 맞는 도구를 선택하세요.
+
+## 적용 순서를 정리해요
+
+1. task와 actor 사이에서 실제로 넘어가는 값과 capture를 찾아요.
+2. 가능한 data를 immutable value snapshot으로 만들고 `Sendable`을 명시해요.
+3. shared mutable state는 actor나 적절한 synchronization owner 안에 둬요.
+4. generic API에는 경계를 넘을 때만 `Element: Sendable` 제약을 추가해요.
+5. closure가 concurrent context로 가면 `@Sendable`과 capture를 확인해요.
+6. legacy lock type은 모든 접근 규칙을 증명할 때만 `@unchecked Sendable`을 사용해요.
+7. `@preconcurrency`는 migration 기간으로 제한하고 strict checking을 다시 켜요.
+8. 공유가 필요 없는 non-sendable value는 `sending` transfer가 맞는지 검토해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `Sendable`에는 왜 required method가 없나요?
+
+실행 기능이 아니라 concurrency domain 사이 공유 안전성이라는 의미를 표시하는 marker protocol이기 때문이에요. compiler가 type의 stored data와 isolation을 검사해 semantic requirement를 확인해요.
+
+### `Sendable`과 `@Sendable`은 어떻게 다른가요?
+
+`Sendable`은 value type과 reference type의 protocol 준수이고 `@Sendable`은 function·closure type에 붙는 attribute예요. `@Sendable` closure가 capture하는 값도 sendable이어야 해요.
+
+### mutable class를 `Sendable`로 만들 수 있나요?
+
+일반 checked conformance로는 제한적이에요. actor나 global actor로 state를 격리하거나 모든 접근을 lock으로 보호한 뒤 `@unchecked Sendable`로 작성자가 책임질 수 있지만 immutable value로 바꿀 수 있는지 먼저 검토해요.
+
+### actor는 왜 암시적으로 Sendable인가요?
+
+actor가 자신의 mutable state 접근을 순차적으로 격리하기 때문이에요. actor reference가 여러 domain에 전달되어도 state를 직접 동시에 읽고 쓸 수 없어요.
+
+### `@unchecked Sendable`을 쓰면 compiler가 무엇을 확인하나요?
+
+준수의 내부 thread safety는 확인하지 않아요. 작성자가 locking과 encapsulation이 모든 code path에서 올바르다는 책임을 지므로 최소 범위와 강한 review가 필요해요.
+
+## 참고 자료
+
+- [Apple Developer — Sendable](https://developer.apple.com/documentation/swift/sendable)
+- [The Swift Programming Language — Concurrency](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html)
+- [The Swift Programming Language — Protocols](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/)
+- [Swift Evolution SE-0302 — Sendable and @Sendable closures](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md)
+- [Swift Evolution SE-0337 — Incremental migration to concurrency checking](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0337-support-incremental-migration-to-concurrency-checking.md)
+- [Swift Evolution SE-0430 — sending parameter and result values](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0430-transferring-parameters-and-results.md)
+- [Swift-KR — Swift로 이해하는 Codable](./codable)
+- [Swift-KR — Swift로 이해하는 제네릭](../generics)

--- a/docs/guide/swift/protocols/sequence-and-collection.md
+++ b/docs/guide/swift/protocols/sequence-and-collection.md
@@ -1,0 +1,377 @@
+---
+title: Swift로 이해하는 Sequence와 Collection
+description: Sequence의 iteration과 single-pass 가능성, Collection의 반복 접근·index·slice·성능 계약과 custom collection 구현 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Sequence와 Collection
+
+> **면접 답변 한 줄 요약:** `Sequence`는 iterator로 원소를 한 번씩 꺼낼 수 있다는 최소 계약이고, `Collection`은 유한한 원소를 손상 없이 여러 번 순회하며 유효한 index로 접근할 수 있다는 더 강한 계약이라 더 많은 알고리즘과 성능 보장을 제공해요.
+
+배열, 문자열, dictionary와 range는 모두 `for-in`으로 순회할 수 있어요. 하지만 “순회할 수 있다”는 사실만으로 두 번 반복해도 같은 값이 나오는지, 원하는 위치를 subscript로 읽을 수 있는지, `count`가 빠른지는 알 수 없어요.
+
+Swift는 이런 능력을 `Sequence`, `Collection`, `BidirectionalCollection`, `RandomAccessCollection` 같은 프로토콜 계층으로 표현해요. 제네릭 함수가 실제로 필요한 가장 약한 계약을 받으면 array뿐 아니라 lazy sequence와 custom collection에도 재사용할 수 있어요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- `IteratorProtocol`과 `Sequence.makeIterator()`의 관계
+- single-pass sequence를 두 번 순회하면 안 되는 이유
+- `Collection`의 multipass, 유한성, subscript와 index 계약
+- `startIndex`, `endIndex`, slice와 index invalidation
+- bidirectional·random access·mutable collection의 차이
+- lazy algorithm과 custom collection 구현
+
+## 먼저 알아둘 순회 용어
+
+| 용어            | 쉬운 뜻                                                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| iteration       | 원소를 하나씩 순서대로 방문하는 과정이에요.                                                                             |
+| iterator        | 현재 순회 위치를 기억하고 `next()`마다 다음 원소를 내주는 값이에요.                                                     |
+| single-pass     | 한 번 읽으면 소비되어 같은 값에서 다시 처음부터 순회할 수 있다고 보장하지 않는 성질이에요.                              |
+| multipass       | 같은 collection을 여러 번 순회해도 같은 원소와 순서를 다시 얻을 수 있는 성질이에요.                                     |
+| index           | collection 안의 특정 위치를 나타내는 값이에요. 반드시 `Int`이거나 0부터 시작하는 것은 아니에요.                         |
+| `endIndex`      | 마지막 원소 뒤의 위치예요. 순회 종료를 표시하지만 실제 원소가 없으므로 subscript하면 안 돼요.                           |
+| slice           | 원본 collection의 일부 구간을 같은 index 체계로 보여 주는 view예요. `ArraySlice`와 `Substring`이 대표적이에요.          |
+| eager operation | 호출 시 모든 원소를 즉시 처리하고 결과를 만드는 연산이에요.                                                             |
+| lazy operation  | 결과 원소가 실제로 필요할 때까지 변환을 미루는 연산이에요.                                                              |
+| Big O           | 입력 크기가 커질 때 연산 시간이 어떻게 늘어나는지 나타내는 표기예요. `O(1)`은 크기와 무관, `O(n)`은 원소 수에 비례해요. |
+
+## `for-in`은 iterator의 `next()`를 반복해요
+
+가장 작은 순회 계약은 `IteratorProtocol`이에요.
+
+```swift
+protocol IteratorProtocol<Element> {
+  mutating func next() -> Element?
+}
+```
+
+`next()`는 다음 원소가 있으면 반환하고 끝나면 `nil`을 반환해요. `Sequence`는 새 iterator를 만드는 `makeIterator()`를 제공해요.
+
+```swift
+protocol Sequence<Element> {
+  associatedtype Iterator: IteratorProtocol
+    where Iterator.Element == Element
+
+  func makeIterator() -> Iterator
+}
+```
+
+실제 표준 라이브러리 선언에는 Swift 버전에 따른 추가 제약과 기본 구현이 있어요. 개념적으로 `for-in`은 다음과 비슷하게 동작해요.
+
+```swift
+var iterator = values.makeIterator()
+
+while let element = iterator.next() {
+  print(element)
+}
+```
+
+호출자는 iterator의 내부 위치를 몰라도 `next()`라는 공통 인터페이스로 원소를 소비해요.
+
+## Sequence는 두 번 순회할 수 있다고 보장하지 않아요
+
+`Sequence`는 iteration이 원본을 파괴적으로 소비하는지 요구하지 않아요. 다음 custom sequence는 자기 자신이 iterator인 참조 타입이에요.
+
+```swift
+final class OnePassCounter: Sequence, IteratorProtocol {
+  private var current: Int
+
+  init(from start: Int) {
+    current = start
+  }
+
+  func next() -> Int? {
+    guard current > 0 else { return nil }
+    defer { current -= 1 }
+    return current
+  }
+}
+
+let counter = OnePassCounter(from: 3)
+print(Array(counter)) // [3, 2, 1]
+print(Array(counter)) // []
+```
+
+첫 순회가 같은 객체의 iteration state를 끝까지 소비했어요. 모든 `Sequence`가 이 방식이라는 뜻은 아니고, `Sequence` 계약만으로는 반복 순회의 결과를 가정할 수 없다는 뜻이에요.
+
+따라서 제네릭 함수가 같은 원소를 여러 번 살펴봐야 한다면 다음 중 하나를 선택해요.
+
+- 입력을 `Collection`으로 더 강하게 제한해요.
+- sequence를 한 번 `Array`로 materialize해요.
+- 한 번 순회하는 알고리즘으로 다시 설계해요.
+
+## Sequence만으로 많은 공통 알고리즘을 얻어요
+
+```swift
+let minutes = [10, 20, 30, 40]
+
+let longSessions = minutes.filter { $0 >= 30 }
+let doubled = minutes.map { $0 * 2 }
+let total = minutes.reduce(0, +)
+let hasShortSession = minutes.contains { $0 < 15 }
+```
+
+`map`, `filter`, `reduce`, `contains(where:)`, `first(where:)`와 `sorted` 같은 연산은 순차 접근만으로 구현할 수 있어 `Sequence`에 제공돼요. generic API가 index를 사용하지 않는다면 `Collection`보다 `Sequence`를 받는 편이 더 넓은 입력을 지원해요.
+
+```swift
+func totalMinutes<Values: Sequence>(
+  in values: Values
+) -> Int where Values.Element == Int {
+  values.reduce(0, +)
+}
+```
+
+이 함수는 배열, set, range와 custom sequence에 모두 사용할 수 있어요.
+
+## Collection은 유한하고 multipass이며 index 접근을 제공해요
+
+`Collection`은 `Sequence`를 상속하고 더 강한 계약을 추가해요.
+
+- 원소의 위치가 `startIndex`부터 `endIndex`까지 유한해요.
+- 원소를 손상시키지 않고 여러 번 순회할 수 있어요.
+- 유효한 index로 subscript해 원소를 읽을 수 있어요.
+- `index(after:)`로 다음 위치를 얻을 수 있어요.
+- index로 순회한 원소와 iterator로 순회한 원소의 순서가 같아요.
+
+```swift
+func printFirstAndLast<C: Collection>(
+  _ values: C
+) {
+  guard let first = values.first,
+        let last = values.last
+  else { return }
+
+  print(first, last)
+}
+```
+
+`last`는 collection이 유한하고 다시 접근할 수 있다는 전제가 필요해요. 단순 single-pass sequence에서는 끝까지 소비한 뒤 처음 상태를 유지하지 못할 수 있어요.
+
+## index는 offset 정수가 아니라 collection의 위치 타입이에요
+
+배열 index는 흔히 `Int`라서 모든 collection이 0-based integer라고 오해하기 쉬워요. 문자열 index는 Unicode 경계 정보를 가진 `String.Index`예요.
+
+```swift
+let title = "📘 Swift"
+let first = title.startIndex
+let next = title.index(after: first)
+
+print(title[first]) // 📘
+print(title[next])  // 공백
+```
+
+다음처럼 임의 정수로 문자열을 subscript할 수 없어요.
+
+```swift
+// title[1] // compile error
+```
+
+generic collection code에서는 `index(after:)`, `index(_:offsetBy:)`, `indices`를 사용하고 `Index == Int`라고 가정하지 마세요.
+
+## `endIndex`는 마지막 원소가 아니에요
+
+```swift
+let values = [10, 20, 30]
+
+values.startIndex // 0
+values.endIndex   // 3
+values[values.startIndex] // 10
+// values[values.endIndex] // runtime error
+```
+
+`endIndex`는 “마지막 원소 뒤”를 나타내 순회 종료 조건으로 사용해요. 비어 있는 collection에서는 `startIndex == endIndex`예요.
+
+마지막 원소가 필요하면 `last`를 사용하거나 비어 있지 않음을 확인한 뒤 `index(before:)`를 사용해요. `index(before:)`는 `BidirectionalCollection`에서 제공해요.
+
+## slice는 0부터 다시 시작하지 않을 수 있어요
+
+```swift
+let values = [10, 20, 30, 40]
+let suffix = values.suffix(2)
+
+print(suffix.startIndex) // 2
+print(suffix[suffix.startIndex]) // 30
+```
+
+`ArraySlice`는 원본과 index를 공유하므로 `suffix[0]`을 가정하면 안 돼요. generic code는 항상 전달받은 collection의 `startIndex`를 사용해요.
+
+slice는 원본 storage 일부를 공유할 수 있어요. 큰 array의 작은 slice를 오래 보관하면 큰 backing storage가 유지될 수 있으므로 장기 보관할 작은 결과가 필요하면 새 `Array`로 복사하는 것을 검토해요.
+
+```swift
+let persisted = Array(suffix)
+```
+
+## mutation은 저장해 둔 index를 무효화할 수 있어요
+
+```swift
+var titles = ["Swift", "Testing", "Concurrency"]
+let savedIndex = titles.index(after: titles.startIndex)
+
+titles.removeFirst()
+// savedIndex를 다시 사용해도 되는지는 collection의
+// index invalidation 규칙을 확인해야 해요.
+```
+
+mutation 뒤 index가 계속 유효한지는 `MutableCollection`, `RangeReplaceableCollection`과 구체 타입의 문서가 정해요. 원소 삽입·삭제가 가능한 generic algorithm은 mutation 전 index를 무조건 재사용하지 마세요.
+
+다른 collection에서 얻은 index를 사용해도 안 돼요. index type이 우연히 같아도 그 위치는 원래 collection에만 유효해요.
+
+## Collection 계층은 이동과 mutation 능력을 나눠요
+
+| 프로토콜                     | 추가하는 핵심 능력                           | 대표 타입                      |
+| ---------------------------- | -------------------------------------------- | ------------------------------ |
+| `Sequence`                   | 순서대로 한 번씩 iteration                   | one-pass stream, lazy sequence |
+| `Collection`                 | 유한·multipass·forward index subscript       | `String`, `Set`, `Dictionary`  |
+| `BidirectionalCollection`    | `index(before:)`로 뒤로 이동                 | `String`, `Array`              |
+| `RandomAccessCollection`     | 임의 거리 이동과 distance를 상수 시간에 제공 | `Array`, `Range<Int>`          |
+| `MutableCollection`          | 기존 위치의 원소 교체                        | `Array`                        |
+| `RangeReplaceableCollection` | 구간 삽입·삭제로 collection 길이 변경        | `Array`, `String`              |
+
+`MutableCollection`과 `RangeReplaceableCollection`은 이동 방향 계층과 다른 능력을 표현해요. 원소를 바꿀 수 있다고 길이까지 바꿀 수 있는 것은 아니에요.
+
+가장 강한 `RandomAccessCollection`을 습관적으로 요구하지 말고 algorithm이 실제로 임의 거리 이동을 사용하는지 확인하세요.
+
+## `count`와 offset 접근 비용은 구체 능력에 따라 달라요
+
+`Collection`은 subscript, `startIndex`, `endIndex`가 `O(1)`이기를 기대해요. 하지만 `count`는 모든 collection에서 반드시 `O(1)`은 아니에요.
+
+- `RandomAccessCollection`은 두 index 사이 거리를 빠르게 계산할 수 있어 일반적으로 `count`가 `O(1)`이에요.
+- forward나 bidirectional collection은 거리를 알기 위해 원소를 순회해 `O(n)`일 수 있어요.
+- `Sequence`의 일반적인 전체 순회 연산은 별도 문서가 없다면 `O(n)`으로 생각해요.
+
+loop 조건에서 매번 비용 큰 `count`와 offset을 계산하지 말고 index iteration이나 `isEmpty`, `first`처럼 목적에 맞는 API를 사용해요.
+
+## lazy sequence는 실제로 필요한 원소만 처리해요
+
+일반 `map`과 `filter`는 즉시 결과 array를 만들어요.
+
+```swift
+let result = Array(1...1_000_000)
+  .map { $0 * 2 }
+  .filter { $0.isMultiple(of: 3) }
+  .prefix(3)
+```
+
+앞의 세 결과만 필요해도 큰 intermediate array를 만들 수 있어요. `lazy`를 사용하면 요청된 원소를 만들 때 변환해요.
+
+```swift
+let result = (1...1_000_000)
+  .lazy
+  .map { $0 * 2 }
+  .filter { $0.isMultiple(of: 3) }
+  .prefix(3)
+
+print(Array(result)) // [6, 12, 18]
+```
+
+lazy가 항상 빠른 것은 아니에요. 여러 번 순회하면 계산을 반복할 수 있고 closure와 wrapper 비용이 생겨요. 결과를 재사용하거나 random access가 필요하면 적절한 시점에 `Array`로 materialize해요.
+
+## 작은 wrapper를 Collection으로 만들어요
+
+배열을 감싼 독서 기록 collection이 domain API를 제공하면서 표준 collection algorithm도 사용하게 해 볼게요.
+
+```swift
+struct ReadingSession: Equatable {
+  let title: String
+  let minutes: Int
+}
+
+struct ReadingLog: Collection {
+  private var storage: [ReadingSession]
+
+  init(_ sessions: [ReadingSession]) {
+    storage = sessions
+  }
+
+  var startIndex: Int {
+    storage.startIndex
+  }
+
+  var endIndex: Int {
+    storage.endIndex
+  }
+
+  func index(after index: Int) -> Int {
+    storage.index(after: index)
+  }
+
+  subscript(index: Int) -> ReadingSession {
+    storage[index]
+  }
+
+  var totalMinutes: Int {
+    reduce(0) { $0 + $1.minutes }
+  }
+}
+```
+
+`startIndex`, `endIndex`, `index(after:)`와 subscript라는 최소 요구사항을 backing array에 위임했어요. associated type인 `Element`와 `Index`는 method signature에서 `ReadingSession`, `Int`로 추론돼요.
+
+```swift
+let log = ReadingLog([
+  ReadingSession(title: "Swift", minutes: 30),
+  ReadingSession(title: "Testing", minutes: 20),
+])
+
+log.totalMinutes // 50
+log.map(\.title) // ["Swift", "Testing"]
+log.first?.minutes // 30
+```
+
+custom collection은 index 이동과 subscript의 의미·복잡도 계약을 정확히 지켜야 해요. 단순히 domain 이름을 붙이려는 목적이라면 array를 프로퍼티로 보관하고 필요한 method만 제공하는 것이 더 간단할 수도 있어요.
+
+## 언제 Sequence와 Collection을 사용해야 하나요
+
+- 한 번의 순차 처리만 필요하면 generic 입력을 `Sequence`로 받아요.
+- 여러 번 순회, index, `first`·`last`와 slice가 필요하면 `Collection`을 요구해요.
+- 뒤로 이동해야 하면 `BidirectionalCollection`, 임의 거리 이동 성능이 필요하면 `RandomAccessCollection`을 요구해요.
+- custom storage가 표준 algorithm과 자연스럽게 결합해야 할 때 custom collection을 구현해요.
+- 큰 pipeline에서 일부 결과만 필요하면 `lazy`를 검토해요.
+
+입력이 이미 작은 array이고 domain API 몇 개만 필요하다면 custom collection과 복잡한 generic 제약을 만들지 않아도 돼요.
+
+## 적용 순서를 정리해요
+
+1. algorithm이 원소를 한 번만 순서대로 읽는지 확인해요.
+2. 반복 순회나 index 접근이 필요할 때만 `Collection`으로 제약을 강화해요.
+3. `Index == Int`와 `startIndex == 0`을 가정하지 않아요.
+4. `endIndex`를 subscript하지 않고 slice의 원래 index를 존중해요.
+5. mutation 뒤 저장 index가 유효한지 구체 collection 계약을 확인해요.
+6. 연산 복잡도와 intermediate allocation을 측정해 lazy 또는 materialization을 선택해요.
+7. custom collection은 최소 요구사항과 index·성능 법칙을 test해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `Sequence`와 `Collection`의 가장 중요한 차이는 무엇인가요?
+
+`Sequence`는 순차 iteration만 보장하고 한 번 소비될 수도 있어요. `Collection`은 유한한 원소를 손상 없이 여러 번 순회하고 유효한 index로 subscript할 수 있어요.
+
+### `endIndex`로 마지막 원소를 읽을 수 있나요?
+
+안 돼요. `endIndex`는 마지막 원소 뒤의 sentinel 위치라 유효한 subscript가 아니에요. `last`나 bidirectional collection의 `index(before: endIndex)`를 사용해요.
+
+### 모든 Collection의 index는 Int인가요?
+
+아니요. `Collection.Index`는 associated type이고 문자열은 `String.Index`를 사용해요. generic code는 `startIndex`, `index(after:)`와 `indices`로 이동해야 해요.
+
+### `lazy`를 사용하면 항상 성능이 좋아지나요?
+
+아니요. intermediate allocation과 불필요한 계산을 줄일 수 있지만 반복 순회 때 계산을 다시 하고 wrapper 비용이 생길 수 있어요. 실제 소비 방식과 측정 결과로 선택해요.
+
+### Collection의 `count`는 항상 O(1)인가요?
+
+아니요. random-access collection은 빠르게 계산할 수 있지만 forward나 bidirectional collection은 index 사이를 순회해 `O(n)`일 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer — Sequence](https://developer.apple.com/documentation/swift/sequence)
+- [Apple Developer — IteratorProtocol](https://developer.apple.com/documentation/swift/iteratorprotocol)
+- [Apple Developer — Collection](https://developer.apple.com/documentation/swift/collection)
+- [Apple Developer — BidirectionalCollection](https://developer.apple.com/documentation/swift/bidirectionalcollection)
+- [Apple Developer — RandomAccessCollection](https://developer.apple.com/documentation/swift/randomaccesscollection)
+- [Apple Developer — LazySequenceProtocol](https://developer.apple.com/documentation/swift/lazysequenceprotocol)
+- [The Swift Programming Language — For-In Statement](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/statements/#For-In-Statement)
+- [Swift-KR — Swift로 이해하는 제네릭](../generics)
+- [Swift-KR — Swift로 이해하는 Comparable](./comparable)

--- a/docs/guide/testing/_meta.json
+++ b/docs/guide/testing/_meta.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "file",
+    "name": "xctest-unit-testing",
+    "label": "XCTest 단위 테스트"
+  },
+  {
+    "type": "file",
+    "name": "swift-testing",
+    "label": "Swift Testing"
+  },
+  {
+    "type": "file",
+    "name": "xcuitest",
+    "label": "XCUITest"
+  },
+  {
+    "type": "file",
+    "name": "tca-test-store",
+    "label": "TCA TestStore"
+  }
+]

--- a/docs/guide/testing/swift-testing.md
+++ b/docs/guide/testing/swift-testing.md
@@ -1,0 +1,529 @@
+---
+title: Swift로 이해하는 Swift Testing
+description: Swift Testing의 @Test·@Suite, #expect·#require, parameterized test, trait, tag, async confirmation과 XCTest 전환 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Swift Testing
+
+> **면접 답변 한 줄 요약:** Swift Testing은 macro로 test와 expectation을 선언하고 parameterization, trait와 기본 병렬 실행을 Swift 언어 기능에 맞게 제공해서, unit·integration test를 적은 반복 코드와 자세한 실패 정보로 작성하게 하는 framework예요.
+
+XCTest에서는 `XCTestCase`를 상속하고 `test`로 시작하는 method를 만들어요. Swift Testing에서는 상속과 이름 규칙 대신 `@Test`, `@Suite`, `#expect` 같은 macro로 의도를 직접 표시해요.
+
+```swift
+import Testing
+
+@Test
+func halfProgress() {
+  let goal = ReadingGoal(dailyMinutes: 30)
+
+  #expect(goal.progress(completedMinutes: 15) == 0.5)
+}
+```
+
+코드가 짧아진 것보다 중요한 변화는 test가 **일반 Swift 함수와 타입**에 가까워졌다는 점이에요. parameter를 받는 test function을 여러 입력으로 실행하고, trait로 실행 조건과 metadata를 선언하며, Swift concurrency를 기본 실행 모델로 사용해요.
+
+이 문서에서는 Xcode 16과 Swift 6에서 함께 제공되기 시작한 Swift Testing을 기준으로 다음 내용을 배워요.
+
+- `@Test`, `@Suite`와 test discovery
+- `#expect`와 `#require`의 실패 흐름
+- throws와 optional을 검증하는 방법
+- parameterized test로 입력 조합을 표현하는 방법
+- trait, tag와 test plan의 역할 차이
+- 기본 병렬 실행과 shared state 격리
+- async test와 `confirmation`
+- XCTest와 함께 사용하고 점진적으로 옮기는 기준
+
+## 먼저 알아둘 Swift Testing 용어
+
+| 용어               | 쉬운 뜻                                                                                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| macro              | source code를 분석해 compiler가 추가 code를 만드는 Swift 기능이에요. `@Test`는 test declaration을 등록하고 `#expect`는 expression의 부분값을 실패 정보에 남겨요. |
+| test function      | `@Test`가 붙은 Swift 함수예요. 이름이 `test`로 시작하거나 class method일 필요가 없어요.                                                                          |
+| suite              | 관련 test function을 담은 type이나 type hierarchy예요. `@Suite`로 display name과 trait를 추가할 수 있어요.                                                       |
+| expectation        | 실제 expression이 기대 조건을 만족하는지 검사한 결과예요. `#expect`와 `#require`가 만들어요.                                                                     |
+| trait              | test나 suite의 실행 방식, 조건과 metadata를 선언하는 값이에요. `.enabled`, `.serialized`, `.tags`가 대표적이에요.                                                |
+| tag                | 서로 다른 suite에 있는 test를 하나의 목적별 그룹으로 선택할 수 있게 붙이는 metadata예요.                                                                         |
+| parameterized test | 같은 test logic을 여러 argument로 반복 실행하고 argument마다 독립적인 결과를 만드는 test예요.                                                                    |
+| confirmation       | 직접 `await`할 수 없는 callback event가 정해진 횟수만큼 발생했는지 확인하는 Swift Testing API예요.                                                               |
+
+## `@Test`는 이름 규칙 대신 의도를 선언해요
+
+같은 독서 목표 type을 검증해 볼게요.
+
+```swift
+struct ReadingGoal {
+  let dailyMinutes: Int
+
+  func progress(completedMinutes: Int) -> Double {
+    guard dailyMinutes > 0 else { return 0 }
+
+    return min(
+      Double(max(completedMinutes, 0)) / Double(dailyMinutes),
+      1
+    )
+  }
+}
+```
+
+test function은 global function이나 type의 instance/static function으로 만들 수 있어요.
+
+```swift
+import Testing
+
+@Test
+func halfOfGoalReturnsHalfProgress() {
+  let goal = ReadingGoal(dailyMinutes: 30)
+
+  let progress = goal.progress(completedMinutes: 15)
+
+  #expect(progress == 0.5)
+}
+```
+
+함수 이름은 `test...`일 필요가 없고 sync, async, throws와 generic function처럼 Swift의 일반 함수 기능을 사용할 수 있어요. `@Test("목표의 절반을 계산해요")`처럼 test report에 보일 display name을 따로 줄 수도 있어요.
+
+```swift
+@Test("목표를 초과해도 진행률은 100%예요")
+func clampsProgress() {
+  let goal = ReadingGoal(dailyMinutes: 30)
+
+  #expect(goal.progress(completedMinutes: 50) == 1)
+}
+```
+
+Apple의 [Defining test functions](https://developer.apple.com/documentation/testing/definingtests)에서 test declaration과 지원하는 function 형태를 확인할 수 있어요.
+
+## `#expect`는 expression의 어느 값이 달랐는지 보여 줘요
+
+`#expect`는 Boolean expression을 그대로 받아요.
+
+```swift
+let completedMinutes = 15
+let goal = ReadingGoal(dailyMinutes: 30)
+
+#expect(
+  goal.progress(completedMinutes: completedMinutes) == 0.5,
+  "15분은 30분 목표의 절반이어야 해요."
+)
+```
+
+macro는 `XCTAssertTrue`처럼 최종 Boolean만 보는 것이 아니라 왼쪽 계산 결과와 오른쪽 기대값을 분석해 실패 report에 보여 줄 수 있어요. custom message는 실패가 무엇을 의미하는지 domain 맥락을 더할 때 사용하고, code를 그대로 다시 읽는 문장은 반복하지 않아요.
+
+`#expect`가 실패해도 test function은 다음 줄을 계속 실행해 추가 issue를 기록해요. 뒤 검증에 반드시 필요한 값이면 `#require`를 사용해요.
+
+## `#require`는 실패하면 현재 흐름을 중단해요
+
+optional을 먼저 벗겨야 이후 property를 안전하게 확인할 수 있어요.
+
+```swift
+struct ReadingSession {
+  let title: String
+  let minutes: Int
+}
+
+@Test
+func firstSessionHasPositiveMinutes() throws {
+  let sessions = [
+    ReadingSession(title: "Swift", minutes: 20),
+  ]
+
+  let first = try #require(sessions.first)
+
+  #expect(first.title == "Swift")
+  #expect(first.minutes > 0)
+}
+```
+
+`#require`는 조건이 false이거나 optional이 `nil`이면 `ExpectationFailedError`를 던져 현재 test를 멈춰요. 그래서 호출하는 test function을 `throws`로 선언해요.
+
+| API        | 실패 뒤 흐름                    | 알맞은 상황                                                            |
+| ---------- | ------------------------------- | ---------------------------------------------------------------------- |
+| `#expect`  | 다음 검증을 계속해요.           | 서로 독립적인 여러 결과를 한 행동에서 확인해요.                        |
+| `#require` | 오류를 던져 현재 흐름을 멈춰요. | optional value나 선행 조건 없이는 뒤 코드를 안전하게 실행할 수 없어요. |
+
+실패 뒤 crash할 수 있는 force unwrap을 남기기보다 `#require`로 선행 조건을 문서화해요.
+
+## throws는 예상하지 않은 오류와 예상한 오류를 나눠요
+
+성공 경로에서 오류가 발생하면 안 되는 호출은 test function 밖으로 바로 던져도 돼요.
+
+```swift
+@Test
+func loadsSavedMinutes() async throws {
+  let repository = StubReadingRepository(result: .success(20))
+
+  let minutes = try await repository.fetchCompletedMinutes()
+
+  #expect(minutes == 20)
+}
+```
+
+오류 자체가 기대 행동이면 `#expect(throws:)`를 사용해요.
+
+```swift
+enum ReadingError: Error, Equatable {
+  case offline
+}
+
+@Test
+func offlineRepositoryThrowsOfflineError() async {
+  let repository = StubReadingRepository(
+    result: .failure(.offline)
+  )
+
+  await #expect(throws: ReadingError.offline) {
+    _ = try await repository.fetchCompletedMinutes()
+  }
+}
+```
+
+`#expect(throws:)`는 예상한 error type이나 value를 검증하고, 일치하면 error를 반환해서 추가 property도 확인할 수 있어요. 아무 error나 발생하면 통과시키기보다 domain error를 구체적으로 선언해요.
+
+## `@Suite`는 관련 test와 공통 trait를 묶어요
+
+Swift Testing에서 test function을 포함하는 type은 suite가 될 수 있어요. `@Suite`를 붙이면 display name과 trait를 명시할 수 있어요.
+
+```swift
+import Testing
+
+@Suite("독서 목표 진행률")
+struct ReadingGoalTests {
+  @Test
+  func halfProgress() {
+    let goal = ReadingGoal(dailyMinutes: 30)
+    #expect(goal.progress(completedMinutes: 15) == 0.5)
+  }
+
+  @Test
+  func overGoalProgress() {
+    let goal = ReadingGoal(dailyMinutes: 30)
+    #expect(goal.progress(completedMinutes: 50) == 1)
+  }
+}
+```
+
+상속 hierarchy 대신 struct, enum, actor와 class를 사용할 수 있고 suite 안에 nested suite를 둘 수도 있어요. test report의 구조와 production domain의 구조를 비슷하게 유지하면 관련 실패를 찾기 쉬워요.
+
+공통 fixture를 suite의 mutable stored property로 공유하면 병렬 실행에서 경쟁이 생길 수 있어요. 각 test에서 지역 fixture를 만들거나 immutable value를 suite property로 둬요. resource 생명주기가 필요하면 trait와 dependency를 검토하고 global singleton을 reset하는 방식은 피하세요.
+
+## parameterized test는 같은 계약을 여러 입력에 적용해요
+
+XCTest에서 경계값마다 method를 만들면 준비와 assertion이 반복돼요. Swift Testing은 `arguments`에 collection을 전달해 test function의 parameter로 하나씩 실행해요.
+
+```swift
+struct ProgressCase: Sendable, CustomTestStringConvertible {
+  let completedMinutes: Int
+  let expected: Double
+
+  var testDescription: String {
+    "\(completedMinutes)분 → \(expected)"
+  }
+}
+
+@Test(
+  "진행률 경계값",
+  arguments: [
+    ProgressCase(completedMinutes: -10, expected: 0),
+    ProgressCase(completedMinutes: 0, expected: 0),
+    ProgressCase(completedMinutes: 15, expected: 0.5),
+    ProgressCase(completedMinutes: 30, expected: 1),
+    ProgressCase(completedMinutes: 50, expected: 1),
+  ]
+)
+func progressBoundary(testCase: ProgressCase) {
+  let goal = ReadingGoal(dailyMinutes: 30)
+
+  #expect(
+    goal.progress(
+      completedMinutes: testCase.completedMinutes
+    ) == testCase.expected
+  )
+}
+```
+
+각 argument는 test report에서 독립 case로 나타나므로 실패한 입력만 다시 실행할 수 있어요. `CustomTestStringConvertible`로 report에 보일 설명을 domain 중심으로 바꿨어요.
+
+두 collection을 `arguments: first, second`로 전달하면 모든 조합의 Cartesian product가 만들어져요. 위치가 같은 값끼리만 묶으려면 `zip`을 사용해요.
+
+```swift
+@Test(
+  arguments: zip(
+    [0, 15, 30],
+    [0.0, 0.5, 1.0]
+  )
+)
+func progressPair(
+  completedMinutes: Int,
+  expected: Double
+) {
+  let goal = ReadingGoal(dailyMinutes: 30)
+  #expect(
+    goal.progress(completedMinutes: completedMinutes)
+      == expected
+  )
+}
+```
+
+argument가 너무 많아 case별 의도가 사라지면 여러 test로 다시 나눠요. parameterization은 서로 같은 계약과 실행 흐름을 가진 입력에만 사용해요.
+
+## trait는 test의 실행 조건과 metadata를 code에 둬요
+
+trait는 `@Test`나 `@Suite`의 argument로 전달해요.
+
+```swift
+@Test(
+  "동기화 기능이 켜졌을 때 실행해요",
+  .enabled(if: FeatureFlags.readingSync),
+  .timeLimit(.minutes(1))
+)
+func syncReading() async throws {
+  // 동기화 행동을 검증해요.
+}
+```
+
+대표 trait의 역할은 다음과 같아요.
+
+| trait                             | 역할                                                |
+| --------------------------------- | --------------------------------------------------- |
+| `.enabled(if:)`, `.disabled(if:)` | runtime 조건에 따라 실행 여부를 결정해요.           |
+| `.tags(...)`                      | 목적별로 test를 검색하고 선택할 metadata를 붙여요.  |
+| `.serialized`                     | 해당 test나 suite 범위의 case를 직렬로 실행해요.    |
+| `.timeLimit(...)`                 | 너무 오래 실행되는 test를 timeout issue로 기록해요. |
+| `.bug(...)`                       | test와 issue tracker의 bug 정보를 연결해요.         |
+
+조건부 disable을 실패 회피 용도로 남발하지 않아요. 환경이 없어서 실행할 수 없는 조건인지, 실제 bug를 숨기는 것인지 구분해요. 알려진 bug는 `withKnownIssue`처럼 의도를 기록하고 수정 계획과 연결해요.
+
+## tag는 파일 위치와 다른 관점으로 test를 묶어요
+
+같은 기능의 test가 여러 suite에 흩어져 있어도 `fast`, `database`, `critical` 같은 공통 목적을 붙일 수 있어요.
+
+```swift
+extension Tag {
+  @Tag static var critical: Self
+  @Tag static var database: Self
+}
+
+@Test(.tags(.critical))
+func calculatesDailyProgress() {
+  let goal = ReadingGoal(dailyMinutes: 30)
+  #expect(goal.progress(completedMinutes: 30) == 1)
+}
+```
+
+suite는 source structure와 ownership을 나타내고 tag는 실행 선택 관점을 나타내요. feature별 suite 안에 있는 여러 test에 `critical` tag를 붙여 pull request에서 빠르게 실행할 수 있어요.
+
+test plan은 Xcode에서 target, configuration, locale, sanitizer와 반복 횟수 같은 실행 환경을 정해요. tag는 source 안의 test metadata예요. 둘을 함께 사용해 “PR plan에서 critical tag test를 선택”하는 식으로 feedback path를 만들어요.
+
+## Swift Testing은 기본적으로 test를 병렬 실행해요
+
+Apple의 [Swift Testing](https://developer.apple.com/xcode/swift-testing/) 소개는 test가 기본적으로 병렬 실행된다고 설명해요. 순서에 의존하거나 같은 global state를 바꾸는 test는 실행마다 다른 결과를 낼 수 있어요.
+
+```swift
+// 피해야 할 공유 상태예요.
+enum SharedFixture {
+  static var completedMinutes = 0
+}
+```
+
+다음 방법을 먼저 적용해요.
+
+1. 각 test가 자기 SUT와 fixture를 만들어요.
+2. 임시 file과 database 이름에 고유 ID를 사용해요.
+3. clock, random, locale와 network를 dependency로 전달해요.
+4. mutable global과 singleton reset을 없애요.
+5. actor를 사용했다면 test에서 완료를 `await`해요.
+
+외부 resource 때문에 정말 병렬 실행할 수 없다면 가장 작은 suite에 `.serialized`를 적용해요.
+
+```swift
+@Suite(.serialized)
+struct LegacyDatabaseTests {
+  // 이 suite의 test는 서로 직렬로 실행돼요.
+}
+```
+
+`.serialized`는 경쟁 원인을 해결하지 않고 실행 순서만 제한해요. 새 test에는 격리된 저장 공간을 제공하고 legacy resource를 바꿀 수 없는 경우에만 제한적으로 사용해요.
+
+## `async` 함수는 직접 await해요
+
+Swift Testing은 Swift concurrency와 통합돼요.
+
+```swift
+@Test
+func loadsReadingMinutes() async throws {
+  let repository = StubReadingRepository(
+    result: .success(20)
+  )
+
+  let minutes = try await repository.fetchCompletedMinutes()
+
+  #expect(minutes == 20)
+}
+```
+
+main actor에 격리된 ViewModel을 테스트하면 test나 suite에도 `@MainActor`를 붙여요.
+
+```swift
+@MainActor
+@Test
+func loadsDashboard() async throws {
+  let model = ReadingDashboardModel(
+    repository: StubReadingRepository(
+      result: .success(20)
+    )
+  )
+
+  try await model.load()
+
+  #expect(model.completedMinutes == 20)
+}
+```
+
+actor isolation을 맞추기 위해 `MainActor.run`을 여기저기 넣기보다 SUT가 요구하는 actor를 test declaration에 명시해요.
+
+## callback event는 `confirmation`으로 횟수를 확인해요
+
+직접 await할 수 없는 callback, delegate와 event handler에는 `confirmation`을 사용해요.
+
+```swift
+@Test
+func legacyLoaderCallsCompletionOnce() async {
+  let loader = LegacyReadingLoader()
+
+  await confirmation(
+    "독서 시간을 한 번 전달해요",
+    expectedCount: 1
+  ) { completed in
+    loader.load { minutes in
+      #expect(minutes == 20)
+      completed()
+    }
+
+    await loader.waitUntilFinished()
+  }
+}
+```
+
+`confirmation`은 전달한 operation closure가 끝날 때 호출 횟수를 확인해요. XCTest expectation처럼 임의 timeout 동안 event를 기다리는 장치라고 생각하면 안 돼요. callback 작업이 끝나는 시점을 production API에서 await할 수 있게 만들거나 callback을 async adapter로 감싸는 것이 먼저예요.
+
+Apple의 [Testing asynchronous code](https://developer.apple.com/documentation/testing/testing-asynchronous-code)는 직접 await할 수 있는 함수는 standard concurrency로 검증하고, 그럴 수 없는 event에 confirmation을 사용하도록 안내해요.
+
+## Swift Testing과 XCTest는 같은 target에서 함께 실행할 수 있어요
+
+Xcode는 하나의 test target에서 두 framework를 함께 build하고 실행할 수 있어요.
+
+```swift
+import Testing
+import XCTest
+```
+
+기존 XCTest suite를 한 번에 바꾸지 않아도 돼요. 새 unit test는 Swift Testing으로 작성하고, 수정하는 XCTest부터 옮길 수 있어요.
+
+| XCTest                  | Swift Testing                                    |
+| ----------------------- | ------------------------------------------------ |
+| `class ...: XCTestCase` | 일반 `struct`, `class`, `actor`, global function |
+| `func testProgress()`   | `@Test func progress()`                          |
+| `XCTAssertEqual(a, b)`  | `#expect(a == b)`                                |
+| `XCTUnwrap(value)`      | `#require(value)`                                |
+| `XCTestExpectation`     | 직접 `async/await`, 필요한 경우 `confirmation`   |
+| test method 여러 개     | `@Test(arguments:)` parameterization             |
+| class setup/teardown    | 각 test의 지역 fixture, suite와 custom trait     |
+
+Apple의 [Migrating a test from XCTest](https://developer.apple.com/documentation/testing/migratingfromxctest)은 두 framework의 interoperability와 assertion, known issue, expectation 전환 방법을 설명해요.
+
+## XCTest를 바로 대체하지 않는 영역도 있어요
+
+Swift Testing은 unit과 integration test에 적합하지만 현재 Apple platform에서 다음 영역은 XCTest가 중심이에요.
+
+- XCUIAutomation으로 실제 앱 UI를 조작하는 UI test
+- `XCTMetric`과 baseline을 사용하는 performance test
+- Objective-C test와 오래된 XCTest helper에 깊게 연결된 suite
+- XCTest observation, attachment나 특수 API에 의존하는 infrastructure
+
+따라서 framework 선택보다 검증할 경계를 먼저 정해요. 새 logic test는 Swift Testing, [UI workflow는 XCUITest](./xcuitest), performance regression은 XCTest measurement처럼 한 project에서 함께 사용할 수 있어요.
+
+## 자주 생기는 오해를 정리해요
+
+### 모든 입력을 하나의 parameterized test에 넣어요
+
+실행 흐름과 기대 행동이 같은 input만 묶어요. 인증 오류와 형식 validation처럼 setup과 결과 의미가 다르면 별도 test로 이름을 드러내요.
+
+### `.serialized`로 flaky test를 해결해요
+
+병렬 실행에서만 드러난 global state 경쟁을 숨길 수 있어요. fixture와 resource를 격리한 뒤 불가피한 legacy 경계에만 적용해요.
+
+### `confirmation`이 XCTest expectation처럼 기다려 줄 것이라 생각해요
+
+confirmation은 operation이 반환되기 전에 발생한 event를 확인해요. 완료 신호 없이 background task만 시작하고 closure가 끝나면 event를 놓칠 수 있어요. 가능한 API를 `async`로 바꾸고 직접 await해요.
+
+### `#expect`를 여러 줄의 production logic처럼 작성해요
+
+expectation 안에 계산과 side effect가 섞이면 실패 원인을 읽기 어려워요. Act 결과를 지역 상수로 만든 뒤 단순한 비교 expression으로 검증해요.
+
+### 기존 XCTest를 모두 변환해야 도입할 수 있어요
+
+두 framework는 side by side로 실행돼요. 새 test와 변경이 잦은 suite부터 옮기고 UI·performance test는 XCTest에 유지해요.
+
+## 언제 Swift Testing을 사용해야 하나요
+
+다음 조건에서 좋은 기본 선택이에요.
+
+- Swift로 새 unit·integration test를 작성해요.
+- 같은 계약을 여러 argument로 검증해야 해요.
+- async/await와 actor isolation을 자연스럽게 사용하고 싶어요.
+- tag와 trait로 실행 조건과 metadata를 source에 가까이 두고 싶어요.
+- XCTest codebase에 새 test부터 점진적으로 도입해요.
+
+Objective-C 중심 target, UI automation, XCTest performance metric 또는 XCTest-specific infrastructure가 핵심이면 XCTest를 유지해요. framework를 섞는 비용보다 실제 feedback 품질이 좋아지는 범위부터 옮겨요.
+
+## 적용 순서를 정리해요
+
+1. Xcode와 Swift toolchain이 `Testing` module을 제공하는지 확인해요.
+2. 새 test file에서 `import Testing`과 `@testable import`를 설정해요.
+3. 가장 작은 행동을 `@Test`와 `#expect`로 검증해요.
+4. 뒤 검증의 전제인 optional과 조건은 `#require`로 바꿔요.
+5. 같은 계약의 경계값은 parameterized test로 모아요.
+6. suite는 source 구조, tag는 실행 목적에 맞게 구성해요.
+7. 병렬 실행에서도 각 test의 fixture와 resource가 독립적인지 확인해요.
+8. async API는 직접 await하고 callback event만 confirmation으로 확인해요.
+9. XCTest suite는 새 test와 변경하는 test부터 점진적으로 옮겨요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `#expect`와 `#require`는 어떻게 다른가요?
+
+`#expect`는 실패를 기록하고 다음 줄을 계속 실행해요. `#require`는 실패하면 오류를 던져 현재 test 흐름을 멈추고 optional을 안전하게 unwrap하는 데도 사용할 수 있어요.
+
+### parameterized test의 장점은 무엇인가요?
+
+같은 계약을 여러 argument에 적용하면서 setup과 assertion 중복을 줄여요. 각 argument가 독립 test case로 보고되므로 실패한 입력만 찾고 다시 실행할 수 있어요.
+
+### Swift Testing test가 flaky해지는 대표 원인은 무엇인가요?
+
+기본 병렬 실행 상태에서 global mutable state, 같은 file이나 database를 공유하는 것이 대표 원인이에요. `.serialized`부터 붙이기보다 각 test의 dependency와 resource를 격리해야 해요.
+
+### XCTest를 모두 Swift Testing으로 바꿔야 하나요?
+
+아니요. 같은 test target에서 함께 실행할 수 있어 점진적으로 옮길 수 있어요. UI automation과 XCTest performance metric처럼 아직 XCTest가 담당하는 영역도 유지해야 해요.
+
+### suite와 tag는 어떻게 다른가요?
+
+suite는 test를 source hierarchy로 묶는 구조이고 tag는 서로 다른 suite를 공통 실행 목적으로 선택하는 metadata예요. 예를 들어 feature별 suite의 핵심 test에 모두 `critical` tag를 붙일 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer — Swift Testing](https://developer.apple.com/xcode/swift-testing/)
+- [Apple Developer — Testing framework](https://developer.apple.com/documentation/testing)
+- [Apple Developer — Defining test functions](https://developer.apple.com/documentation/testing/definingtests)
+- [Apple Developer — Expectations and confirmations](https://developer.apple.com/documentation/testing/expectations)
+- [Apple Developer — Implementing parameterized tests](https://developer.apple.com/documentation/testing/parameterizedtesting)
+- [Apple Developer — Traits](https://developer.apple.com/documentation/testing/traits)
+- [Apple Developer — Testing asynchronous code](https://developer.apple.com/documentation/testing/testing-asynchronous-code)
+- [Apple Developer — Migrating a test from XCTest](https://developer.apple.com/documentation/testing/migratingfromxctest)
+- [Swift Testing — Official GitHub repository](https://github.com/swiftlang/swift-testing)
+- [Swift Evolution Vision — A New Direction for Testing in Swift](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md)
+- [Swift-KR — Swift로 이해하는 XCTest 단위 테스트](./xctest-unit-testing)
+- [Swift-KR — Swift로 이해하는 XCUITest](./xcuitest)
+- [Swift-KR — Swift로 이해하는 TCA TestStore](./tca-test-store)

--- a/docs/guide/testing/tca-test-store.md
+++ b/docs/guide/testing/tca-test-store.md
@@ -1,0 +1,659 @@
+---
+title: Swift로 이해하는 TCA TestStore
+description: TCA 1.26의 TestStore로 reducer의 action·state·effect를 검증하고 dependency, clock, exhaustivity와 presentation 테스트 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 TCA TestStore
+
+> **면접 답변 한 줄 요약:** TCA `TestStore`는 reducer에 action을 보내고 그때의 state 변화, effect가 되돌려 보내는 action과 effect 완료까지 순서대로 assertion해서, feature의 전체 상태 전이를 deterministic하고 exhaustive하게 검증하는 test runtime이에요.
+
+일반 unit test에서는 reducer를 직접 호출하고 바뀐 state만 비교할 수 있어요. 하지만 The Composable Architecture(TCA)의 feature는 action에 따라 state를 바꾸는 동시에 network, clock과 navigation 같은 effect를 반환해요. state만 확인하면 effect가 잘못된 action을 보내거나 끝나지 않는 문제를 놓칠 수 있어요.
+
+`TestStore`는 production `Store`와 같은 initial state와 reducer로 시작하지만 테스트를 위한 더 엄격한 규칙을 적용해요.
+
+```text
+test가 action을 send
+        │
+        ▼
+Reducer가 state를 변경하고 Effect를 반환
+        │                         │
+        │                         └─ effect가 action을 다시 send
+        ▼                                      │
+예상 state mutation과 비교                    ▼
+                                  test가 receive로 action과 state를 검증
+```
+
+이 문서는 2026년 7월 공개된 **TCA 1.26.1**을 기준으로 해요. 해당 release의 package는 Swift tools 6.1, Swift language mode 6과 iOS 16 이상을 선언해요. TCA는 API 변화가 활발하므로 project가 고정한 version의 공식 documentation과 release note도 함께 확인하세요.
+
+이 문서에서는 독서 기록 feature를 만들며 다음 내용을 배워요.
+
+- reducer의 State, Action, Dependency와 Effect
+- `TestStore` 생성과 `send` state assertion
+- effect action을 `receive`로 빠짐없이 검증하는 방법
+- `withDependencies`로 network와 오류를 고정하는 방법
+- `TestClock`으로 실제 시간을 기다리지 않는 방법
+- exhaustive와 non-exhaustive test의 차이
+- presentation action과 dismissal을 검증하는 방법
+- `TestStore`가 적합한 경계와 흔한 실패 원인
+
+## 먼저 알아둘 TCA 테스트 용어
+
+| 용어         | 쉬운 뜻                                                                                                                                         |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| TCA          | The Composable Architecture의 줄임말이에요. app feature를 State, Action, Reducer, Store와 Dependency로 구성하는 Point-Free의 Swift library예요. |
+| State        | feature가 현재 화면과 logic을 결정하는 데 필요한 value예요. 테스트는 action 전후의 state를 비교해요.                                            |
+| Action       | 사용자 event, system event 또는 effect 결과를 나타내는 value예요. reducer에 들어가는 유일한 event vocabulary예요.                               |
+| Reducer      | 현재 State와 Action을 받아 state를 변경하고 실행할 Effect를 반환하는 logic이에요.                                                               |
+| Effect       | network, clock, database처럼 reducer 밖에서 비동기로 일한 뒤 Action을 store에 다시 보낼 수 있는 작업이에요.                                     |
+| Dependency   | reducer가 외부 세계와 상호작용하는 기능이에요. production에는 live value, 테스트에는 제어 가능한 test value를 제공해요.                         |
+| Store        | state를 보관하고 action을 reducer로 보내며 effect를 실행하는 runtime이에요.                                                                     |
+| `TestStore`  | test 전용 Store로 action, state mutation, effect output과 완료를 assertion하게 해요.                                                            |
+| exhaustivity | 관찰된 모든 state 변화, effect action과 실행 중 effect를 빠짐없이 확인하도록 요구하는 성질이에요.                                               |
+| presentation | sheet, alert나 navigation destination처럼 optional state로 나타나는 자식 feature의 표시 생명주기예요.                                           |
+
+## TCA feature는 state 변경과 effect를 함께 설명해요
+
+독서 시간을 10분 더하고 서버에 동기화하는 feature를 만들게요. 먼저 외부 network 기능을 dependency로 정의해요.
+
+```swift
+import ComposableArchitecture
+
+enum ReadingClientError: Error, Equatable, Sendable {
+  case offline
+}
+
+struct ReadingClient: Sendable {
+  var sync: @Sendable (Int) async throws -> String
+}
+
+private enum ReadingClientKey: DependencyKey {
+  static let liveValue = ReadingClient { minutes in
+    // 실제 앱에서는 server에 minutes를 저장해요.
+    "\(minutes)분을 동기화했어요"
+  }
+
+  static let testValue = ReadingClient { _ in
+    throw ReadingClientError.offline
+  }
+}
+
+extension DependencyValues {
+  var readingClient: ReadingClient {
+    get { self[ReadingClientKey.self] }
+    set { self[ReadingClientKey.self] = newValue }
+  }
+}
+```
+
+`liveValue`는 production runtime에서 사용하고 `testValue`는 override하지 않은 테스트 dependency의 기본값이에요. 실제 project에서는 `@DependencyClient` macro로 client boilerplate와 unimplemented endpoint를 관리할 수도 있어요. 여기서는 dependency boundary를 눈으로 볼 수 있도록 직접 작성했어요.
+
+다음 reducer는 user action, loading state와 effect result를 한 domain에 모아요.
+
+```swift
+import ComposableArchitecture
+
+@Reducer
+struct ReadingFeature {
+  @ObservableState
+  struct State: Equatable {
+    var completedMinutes = 0
+    var isSyncing = false
+    var message: String?
+  }
+
+  enum Action: Equatable, Sendable {
+    case addTenMinutesButtonTapped
+    case syncButtonTapped
+    case syncResponse(
+      Result<String, ReadingClientError>
+    )
+  }
+
+  @Dependency(\.readingClient) var readingClient
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .addTenMinutesButtonTapped:
+        state.completedMinutes += 10
+        return .none
+
+      case .syncButtonTapped:
+        state.isSyncing = true
+        state.message = nil
+        let minutes = state.completedMinutes
+
+        return .run { send in
+          do {
+            let message = try await readingClient.sync(
+              minutes
+            )
+            await send(
+              .syncResponse(.success(message))
+            )
+          } catch {
+            await send(
+              .syncResponse(.failure(.offline))
+            )
+          }
+        }
+
+      case let .syncResponse(.success(message)):
+        state.isSyncing = false
+        state.message = message
+        return .none
+
+      case .syncResponse(.failure):
+        state.isSyncing = false
+        state.message = "연결을 확인해 주세요"
+        return .none
+      }
+    }
+  }
+}
+```
+
+reducer의 sync action은 두 단계예요.
+
+1. 즉시 `isSyncing`을 `true`로 바꾸고 effect를 시작해요.
+2. effect가 client 결과를 `syncResponse` action으로 보내면 loading과 message를 바꿔요.
+
+최종 message만 확인하면 중간 loading state와 effect action을 놓칠 수 있어요. `TestStore`는 이 전체 sequence를 검증해요.
+
+## `TestStore`는 각 test 안에서 만들어요
+
+TCA 1.26의 공식 문서는 Swift Testing과 `@MainActor` suite를 예제로 사용해요.
+
+```swift
+import ComposableArchitecture
+import Testing
+
+@testable import ReadingApp
+
+@MainActor
+struct ReadingFeatureTests {
+  @Test
+  func addsTenMinutes() async {
+    let store = TestStore(
+      initialState: ReadingFeature.State()
+    ) {
+      ReadingFeature()
+    }
+
+    await store.send(.addTenMinutesButtonTapped) {
+      $0.completedMinutes = 10
+    }
+  }
+}
+```
+
+`TestStore`는 main actor에 격리되어 있고 `send`와 `receive`는 suspend할 수 있으므로 suite에 `@MainActor`, test function에 `async`를 사용해요. XCTest를 사용한다면 `@MainActor final class ...: XCTestCase` 안에서도 같은 API를 쓸 수 있어요.
+
+store를 suite의 shared property로 두지 않고 test function 안에서 만들어요.
+
+- 각 test의 initial state와 override dependency가 바로 보여요.
+- test 간 state와 in-flight effect가 공유되지 않아요.
+- test가 끝날 때 store가 deinit되어 미수신 action과 끝나지 않은 effect를 검사해요.
+
+공식 [Testing TCA](https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/testingtca) 문서도 가능한 한 test별로 TestStore를 만들도록 안내해요.
+
+## `send` closure는 기대하는 state를 만들어요
+
+```swift
+await store.send(.addTenMinutesButtonTapped) {
+  $0.completedMinutes = 10
+}
+```
+
+exhaustive mode에서 closure의 `$0`은 action을 보내기 **전 state copy**예요. test author가 expected mutation을 적용해 reducer 실행 후 실제 state와 같은 값을 만들어요.
+
+```text
+Initial State(completedMinutes: 0)
+          │
+          ├─ reducer actual: +10 → 10
+          │
+          └─ test expected:  =10 → 10
+                              │
+                         두 state를 diff
+```
+
+기대값에는 가능한 한 hard-coded final value를 사용해요.
+
+```swift
+// 더 강한 assertion이에요.
+await store.send(.addTenMinutesButtonTapped) {
+  $0.completedMinutes = 10
+}
+
+// reducer logic을 test에서 반복해 약해질 수 있어요.
+await store.send(.addTenMinutesButtonTapped) {
+  $0.completedMinutes += 10
+}
+```
+
+두 번째 test도 “10을 더한다”는 규칙은 확인하지만 시작값과 최종값을 정확히 알고 있다는 보장은 약해요. production 계산을 expected closure에 그대로 복사하지 마세요.
+
+state가 바뀌지 않는 action은 trailing closure를 생략할 수 있어요.
+
+```swift
+await store.send(.refreshButtonTapped)
+```
+
+## effect가 보낸 action은 `receive`로 검증해요
+
+성공하는 sync dependency를 넣고 전체 흐름을 확인해요.
+
+```swift
+@Test
+func syncsCompletedMinutes() async {
+  let store = TestStore(
+    initialState: ReadingFeature.State(
+      completedMinutes: 20
+    )
+  ) {
+    ReadingFeature()
+  } withDependencies: {
+    $0.readingClient.sync = { minutes in
+      #expect(minutes == 20)
+      return "20분을 동기화했어요"
+    }
+  }
+
+  await store.send(.syncButtonTapped) {
+    $0.isSyncing = true
+  }
+
+  await store.receive(
+    .syncResponse(
+      .success("20분을 동기화했어요")
+    )
+  ) {
+    $0.isSyncing = false
+    $0.message = "20분을 동기화했어요"
+  }
+}
+```
+
+`send`는 user나 parent가 넣은 action을, `receive`는 effect가 store에 되돌려 보낸 action을 assertion해요. action의 순서와 state 변화를 모두 명시하므로 다음 regression을 잡을 수 있어요.
+
+- sync action이 잘못된 minutes를 client에 전달해요.
+- loading이 시작되거나 끝나지 않아요.
+- effect가 다른 response action을 보내요.
+- success message가 state에 저장되지 않아요.
+- effect가 끝나지 않고 test 종료 뒤에도 실행돼요.
+
+action enum에 associated value가 많다면 reducer macro가 제공하는 case key path로 case만 matching할 수도 있어요.
+
+```swift
+await store.receive(\.syncResponse.success) {
+  $0.isSyncing = false
+  $0.message = "20분을 동기화했어요"
+}
+```
+
+payload까지 정확히 계약이면 concrete action을 사용하고, 값 일부를 다른 assertion으로 확인할 이유가 있을 때 case key path를 사용해요.
+
+## 오류도 dependency value로 직접 만들어요
+
+```swift
+@Test
+func showsOfflineMessage() async {
+  let store = TestStore(
+    initialState: ReadingFeature.State(
+      completedMinutes: 20
+    )
+  ) {
+    ReadingFeature()
+  } withDependencies: {
+    $0.readingClient.sync = { _ in
+      throw ReadingClientError.offline
+    }
+  }
+
+  await store.send(.syncButtonTapped) {
+    $0.isSyncing = true
+  }
+
+  await store.receive(
+    .syncResponse(.failure(.offline))
+  ) {
+    $0.isSyncing = false
+    $0.message = "연결을 확인해 주세요"
+  }
+}
+```
+
+실제 network를 끊거나 timeout을 기다리지 않아요. 원하는 dependency output을 즉시 만들기 때문에 빠르고 같은 결과를 반복해요.
+
+dependency closure 안의 `#expect(minutes == 20)`은 reducer가 외부 기능에 전달한 값을 확인해요. 모든 호출을 spy로 만들기보다 해당 input이 domain contract일 때만 검증해요.
+
+## clock을 dependency로 만들면 시간을 수동으로 전진시켜요
+
+30초 뒤 reminder를 표시하는 effect가 `Task.sleep`을 직접 사용하면 test도 실제 30초를 기다려야 해요. TCA의 clock dependency를 사용해요.
+
+```swift
+import ComposableArchitecture
+
+@Reducer
+struct ReadingReminderFeature {
+  @ObservableState
+  struct State: Equatable {
+    var isWaiting = false
+    var message: String?
+  }
+
+  enum Action: Equatable {
+    case reminderButtonTapped
+    case reminderReady
+  }
+
+  @Dependency(\.continuousClock) var clock
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .reminderButtonTapped:
+        state.isWaiting = true
+
+        return .run { send in
+          try await clock.sleep(for: .seconds(30))
+          await send(.reminderReady)
+        }
+
+      case .reminderReady:
+        state.isWaiting = false
+        state.message = "다시 읽을 시간이에요"
+        return .none
+      }
+    }
+  }
+}
+```
+
+test에서는 `TestClock`을 주입하고 즉시 시간을 이동해요.
+
+```swift
+import Clocks
+import ComposableArchitecture
+import Testing
+
+@MainActor
+@Test
+func reminderAfterThirtySeconds() async {
+  let clock = TestClock()
+  let store = TestStore(
+    initialState: ReadingReminderFeature.State()
+  ) {
+    ReadingReminderFeature()
+  } withDependencies: {
+    $0.continuousClock = clock
+  }
+
+  await store.send(.reminderButtonTapped) {
+    $0.isWaiting = true
+  }
+
+  await clock.advance(by: .seconds(30))
+
+  await store.receive(.reminderReady) {
+    $0.isWaiting = false
+    $0.message = "다시 읽을 시간이에요"
+  }
+}
+```
+
+이 test는 30초를 기다리지 않아요. `advance`하기 전에는 action이 오지 않고, 정확히 30초를 이동한 뒤 `reminderReady`를 받는 계약을 검증해요.
+
+`ImmediateClock`은 모든 sleep을 즉시 끝내지만 중간 시각별 state를 확인하기 어려워요. debounce, cancellation과 interval을 검증할 때는 `TestClock`으로 필요한 지점만 전진시켜요.
+
+## effect가 끝나지 않으면 테스트가 실패해요
+
+exhaustive TestStore는 test가 끝날 때 다음을 확인해요.
+
+- effect가 보낸 모든 action을 `receive`했나요?
+- 각 action의 state mutation을 확인했나요?
+- 취소하거나 완료해야 하는 effect가 아직 실행 중인가요?
+
+timer나 observation처럼 오래 실행되는 effect는 중지 action을 보내거나 cancellation ID로 취소하는 흐름까지 검증해야 해요.
+
+```swift
+await store.send(.timerStartButtonTapped) {
+  $0.isTimerRunning = true
+}
+
+await store.send(.timerStopButtonTapped) {
+  $0.isTimerRunning = false
+}
+```
+
+store를 test scope 밖에 보관해야 하는 특수 상황이면 끝에서 `await store.finish()`로 모든 in-flight effect가 완료됐는지 명시적으로 기다릴 수 있어요. 기본은 test 안의 지역 store가 deinit 검사까지 수행하게 하는 것이에요.
+
+## exhaustive test는 leaf feature에서 강한 보장을 줘요
+
+TestStore는 기본적으로 exhaustive해요.
+
+```text
+빠진 state mutation  → 실패
+받지 않은 effect action → 실패
+끝나지 않은 effect → 실패
+예상과 다른 action 순서 → 실패
+```
+
+작은 leaf feature에서는 이 엄격함이 큰 장점이에요. 화면 logic의 모든 state와 effect 경로를 정확히 알고 있다는 것을 증명해요. 새 state property나 effect action이 추가되면 관련 test가 어떤 계약을 갱신해야 하는지 알려 줘요.
+
+하지만 여러 child feature를 조합한 app-level integration test에서 내부 변화까지 모두 나열하면 test가 목적보다 길어지고 child refactoring에도 자주 깨질 수 있어요.
+
+## non-exhaustive mode는 관심 있는 변화만 확인해요
+
+```swift
+let store = TestStore(
+  initialState: AppFeature.State()
+) {
+  AppFeature()
+}
+store.exhaustivity = .off(
+  showSkippedAssertions: true
+)
+
+await store.send(\.login.submitButtonTapped)
+await store.receive(\.login.delegate.didLogin) {
+  $0.selectedTab = .activity
+}
+```
+
+이 integration test는 login child의 loading과 response action을 모두 assertion하지 않고 최종 delegate와 tab 변화에 집중해요. `showSkippedAssertions: true`는 무시한 변화와 action을 informational issue로 보여 줘요.
+
+exhaustivity에 따라 assertion closure의 `$0` 의미가 달라요.
+
+| mode   | closure의 시작 state | 작성 방법                                                  |
+| ------ | -------------------- | ---------------------------------------------------------- |
+| `.on`  | action 전 state      | mutation을 적용해 전체 expected state를 만들어요.          |
+| `.off` | action 후 실제 state | 관심 property를 final value로 덮어써 일치 여부를 확인해요. |
+
+non-exhaustive closure에서는 `append`, `removeLast`, `+=` 같은 상대 mutation을 피하고 final value를 지정해요. 이미 action이 적용된 state에서 mutation을 한 번 더 실행할 수 있기 때문이에요.
+
+```swift
+store.exhaustivity = .off
+
+await store.send(.clearButtonTapped) {
+  $0.sessions = []
+}
+```
+
+non-exhaustive mode는 편해서 켜는 option이 아니에요. leaf feature는 exhaustive, 여러 feature의 high-level integration에서는 목적에 맞는 partial assertion처럼 test boundary에 따라 선택해요.
+
+## presentation action과 dismissal도 순서대로 검증해요
+
+TCA는 sheet와 navigation destination을 `@Presents` optional state와 `PresentationAction`으로 모델링해요. parent TestStore에서 child action과 dismissal을 그대로 확인할 수 있어요.
+
+```swift
+await store.send(.showDetailButtonTapped) {
+  $0.detail = ReadingDetailFeature.State(
+    completedMinutes: 20
+  )
+}
+
+await store.send(
+  .detail(.presented(.closeButtonTapped))
+)
+
+await store.receive(.detail(.dismiss)) {
+  $0.detail = nil
+}
+```
+
+child가 `@Dependency(\.dismiss)`를 실행하면 presentation reducer가 `.dismiss` action을 parent domain으로 보내고 optional child state가 `nil`이 돼요. TestStore는 화면이 닫혔다는 visual result만 보는 대신 dismissal action과 state lifecycle을 검증해요.
+
+parent가 직접 destination을 `nil`로 만드는 action이라면 그 `send` closure에서 state가 사라지는 것을 assertion해요. 누가 dismissal을 소유하는지 reducer design에 맞춰 expected sequence를 작성해요.
+
+presentation test에서 child 내부의 모든 동작까지 반복할 필요는 없어요.
+
+- child reducer의 세부 logic은 child TestStore에서 exhaustive하게 검증해요.
+- parent test는 child 표시, delegate와 dismissal처럼 composition contract를 검증해요.
+
+## TestStore의 state를 직접 읽는 것은 보조 수단이에요
+
+```swift
+#expect(store.state.completedMinutes == 20)
+```
+
+computed property나 여러 state를 조합한 결과를 추가로 확인할 때 `store.state`가 유용해요. 하지만 모든 action 뒤 state를 직접 읽기만 하면 TestStore의 state diff와 exhaustivity 장점을 사용하지 못해요.
+
+`send` closure 안에서 `store.state`는 action 전 state이므로 다음처럼 expected state를 복사해 우회할 수도 없어요.
+
+```swift
+await store.send(.addTenMinutesButtonTapped) {
+  $0 = store.state // action 후 state가 아니에요.
+}
+```
+
+기본 state transition은 `send`와 `receive` closure에 쓰고 computed output만 직접 assertion해요.
+
+## dependency override는 test마다 필요한 것만 써요
+
+```swift
+let store = TestStore(
+  initialState: ReadingFeature.State()
+) {
+  ReadingFeature()
+} withDependencies: {
+  $0.readingClient.sync = { _ in "완료" }
+  $0.date.now = Date(timeIntervalSince1970: 0)
+  $0.uuid = .incrementing
+}
+```
+
+TCA dependency system은 test context에서 live dependency를 실수로 사용하는 문제를 찾도록 설계돼요. 각 test는 자신이 실제 사용하는 endpoint만 override하고 입력을 고정해요.
+
+거대한 공통 dependency fixture는 어떤 test가 무엇에 의존하는지 감춰요. 공통 생성 helper를 만들더라도 override 값이 test call site에서 보이도록 유지해요.
+
+random UUID, current date와 locale도 외부 입력이에요. expected state에 이 값이 들어가면 `.incrementing`, fixed date와 고정 locale을 제공해 deterministic하게 만들어요.
+
+## app target에서 실행할 때 host app 부작용을 조심해요
+
+application target의 unit test는 simulator에서 host app entry point도 실행할 수 있어요. app 시작 code가 analytics, network나 database를 바로 실행하면 TestStore와 무관한 live dependency가 test 중 동작할 수 있어요.
+
+TCA 공식 testing 문서는 다음 대응을 설명해요.
+
+- feature logic을 framework나 Swift package로 분리해 host app 없이 test해요.
+- app entry에서 test context를 확인해 실제 root와 startup side effect를 실행하지 않게 해요.
+- dependency를 app 시작과 동시에 전역에서 사용하지 말고 feature action 뒤 실행해요.
+
+이는 test를 통과시키기 위한 임시 분기보다 module boundary와 app lifecycle을 정리하라는 신호예요.
+
+SwiftPM test target에서 `ComposableArchitecture`를 중복 static link하면 app module에 연결된 implementation과 충돌할 수 있다는 공식 gotcha도 있어요. test target dependency graph는 TCA의 현재 Testing 문서와 project module 구조를 기준으로 확인해요.
+
+## TestStore와 일반 unit·UI test는 목적이 달라요
+
+| 도구                 | 직접 검증하는 경계                         | 강점                                              | 놓칠 수 있는 것                                                  |
+| -------------------- | ------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------- |
+| XCTest·Swift Testing | function과 object behavior                 | architecture와 무관한 logic을 빠르게 검증해요.    | TCA effect sequence를 자동으로 exhaustive 검사하지 않아요.       |
+| TCA TestStore        | reducer action, state, effect와 dependency | feature state machine을 단계별로 강하게 검증해요. | 실제 SwiftUI rendering과 accessibility wiring은 보장하지 않아요. |
+| XCUITest             | 실행 중인 app의 UI workflow                | store와 View가 연결된 사용자 결과를 검증해요.     | 느리고 reducer의 모든 branch를 확인하기 어려워요.                |
+
+TestStore가 있다고 pure formatter와 parser까지 모두 reducer action으로 감싸지 않아도 돼요. architecture와 무관한 function은 일반 unit test가 더 단순해요. 반대로 effect와 presentation이 feature behavior의 핵심이면 TestStore가 더 정확한 failure를 제공해요.
+
+## 흔한 실패와 원인을 정리해요
+
+### “Received unexpected action”이 발생해요
+
+effect가 action을 보냈지만 test에 `receive`가 없거나 순서가 달라요. production effect sequence를 확인하고 필요한 action과 state를 빠짐없이 assertion해요. 단지 통과시키려고 exhaustivity를 끄지 않아요.
+
+### “Effect is still running”이 발생해요
+
+timer, observation이나 request가 test 끝에도 실행 중이에요. clock을 전진시키고 결과를 receive하거나 stop action으로 cancellation을 검증해요.
+
+### 실제 timeout을 늘려야 통과해요
+
+uncontrolled network와 `Task.sleep`을 사용하고 있을 가능성이 커요. dependency와 `TestClock`으로 입력을 제어하고 실제 시간을 기다리지 않아요.
+
+### state assertion을 고치면 계속 다른 field가 실패해요
+
+leaf feature의 새 behavior라면 expected contract를 갱신해야 해요. app-level integration test가 child 내부 변화에 과도하게 묶인 상황이라면 그 test의 목적을 좁히고 non-exhaustive mode를 검토해요.
+
+### test끼리 dependency와 state가 섞여요
+
+TestStore를 suite property나 global로 공유했을 수 있어요. 각 test 안에서 initial state와 dependencies를 새로 만들어요.
+
+## 언제 TestStore를 사용해야 하나요
+
+다음 조건에서 중심 도구로 사용해요.
+
+- production feature가 TCA Reducer로 구현되어 있어요.
+- action에 따른 state transition을 정확히 보호해야 해요.
+- effect output action과 cancellation까지 검증해야 해요.
+- network, date, UUID와 clock을 dependency로 제어할 수 있어요.
+- child presentation과 parent delegate contract를 확인해야 해요.
+
+pure function 하나나 architecture 밖의 model은 Swift Testing이나 XCTest로 직접 검증해요. 실제 화면의 tap과 navigation wiring은 XCUITest를 추가해요. TestStore를 사용하기 위해 단순 logic을 억지로 reducer로 옮기지 마세요.
+
+## 적용 순서를 정리해요
+
+1. feature의 State, Action과 Reducer가 관찰할 behavior를 명확히 표현하는지 확인해요.
+2. network, clock, date와 UUID를 TCA Dependency로 분리해요.
+3. test마다 initial state와 TestStore를 지역 값으로 만들어요.
+4. user action을 `send`하고 hard-coded final state mutation을 assertion해요.
+5. effect가 보낸 action을 순서대로 `receive`하고 state를 확인해요.
+6. success, failure와 cancellation마다 dependency output을 고정해요.
+7. 실제 시간은 `TestClock`으로 필요한 시점만 advance해요.
+8. leaf feature는 exhaustive하게, 큰 integration은 목적이 분명할 때 non-exhaustive를 검토해요.
+9. presentation은 표시 state, child action과 dismissal sequence를 나눠 검증해요.
+10. UI wiring의 핵심 흐름은 별도 XCUITest로 보완해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `send`와 `receive`는 어떻게 다른가요?
+
+`send`는 사용자나 parent가 feature에 넣는 action과 그 즉시 state 변화를 검증해요. `receive`는 effect가 store로 되돌려 보낸 action과 그 action의 state 변화를 검증해요.
+
+### TestStore가 exhaustive하다는 것은 무엇인가요?
+
+모든 state mutation, effect가 보낸 action과 실행 중 effect의 완료를 빠짐없이 assertion해야 한다는 뜻이에요. 누락하면 test가 실패해서 feature의 숨은 behavior를 드러내요.
+
+### non-exhaustive test는 언제 사용하나요?
+
+여러 child feature를 조합한 integration에서 내부 구현보다 특정 delegate와 최종 parent state에 집중할 때 사용해요. 작은 leaf feature에서는 기본 exhaustive mode가 더 강한 보장을 줘요.
+
+### `TestClock`이 필요한 이유는 무엇인가요?
+
+실제 sleep을 기다리지 않고 debounce, timeout과 timer의 시간을 test가 직접 전진시키기 위해서예요. test가 빠르고 deterministic해지며 특정 시각 전후 action도 정확히 확인할 수 있어요.
+
+### TestStore만 있으면 UI test가 필요 없나요?
+
+아니요. TestStore는 reducer state machine을 검증하지만 SwiftUI View가 올바른 action을 보내고 state를 실제 accessibility UI로 표현하는지는 보장하지 않아요. 핵심 사용자 흐름은 XCUITest로 보완해요.
+
+## 참고 자료
+
+- [Point-Free — The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture)
+- [Point-Free — TCA 1.26.1 release](https://github.com/pointfreeco/swift-composable-architecture/releases/tag/1.26.1)
+- [TCA Documentation — Testing](https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/testingtca)
+- [TCA Documentation — TestStore](https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/teststore)
+- [TCA Documentation — Dependencies](https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/documentation/composablearchitecture/dependencymanagement)
+- [TCA Tutorial — Meet the Composable Architecture](https://swiftpackageindex.com/pointfreeco/swift-composable-architecture/main/tutorials/meetcomposablearchitecture)
+- [Swift Dependencies — Official Documentation](https://swiftpackageindex.com/pointfreeco/swift-dependencies/main/documentation/dependencies/)
+- [Swift Clocks — Official GitHub repository](https://github.com/pointfreeco/swift-clocks)
+- [Swift-KR — Swift로 이해하는 XCTest 단위 테스트](./xctest-unit-testing)
+- [Swift-KR — Swift로 이해하는 Swift Testing](./swift-testing)
+- [Swift-KR — Swift로 이해하는 XCUITest](./xcuitest)

--- a/docs/guide/testing/xctest-unit-testing.md
+++ b/docs/guide/testing/xctest-unit-testing.md
@@ -1,0 +1,487 @@
+---
+title: Swift로 이해하는 XCTest 단위 테스트
+description: XCTestCase, assertion, setup·teardown, async expectation, 테스트 대역, 성능 측정과 test plan을 독서 기록 예제로 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 XCTest 단위 테스트
+
+> **면접 답변 한 줄 요약:** XCTest 단위 테스트는 작은 코드 경계를 실제 앱 UI와 외부 환경에서 분리한 뒤 입력에 대한 결과나 상태 변화를 assertion으로 검증해서, 빠르고 재현 가능한 회귀 피드백을 만드는 테스트예요.
+
+테스트를 처음 만들면 “함수마다 테스트 하나를 작성하면 되나요?”라는 질문부터 생겨요. 단위 테스트의 **단위(unit)**는 반드시 함수 하나나 타입 하나를 뜻하지 않아요. 테스트에서 빠르고 결정적으로 실행할 수 있도록 선택한 **행동의 경계**를 뜻해요.
+
+예를 들어 독서 목표의 진행률을 계산하는 함수는 작은 단위예요. repository를 stub으로 바꾼 ViewModel의 로딩 행동도 하나의 단위로 검증할 수 있어요. 반면 실제 서버, 실제 날짜와 여러 화면을 한 테스트에 함께 넣으면 실패 원인이 넓어지고 실행 결과도 환경에 따라 달라져요.
+
+이 문서에서는 Apple의 XCTest로 다음 내용을 배워요.
+
+- unit, system under test와 assertion의 의미
+- Xcode unit test target과 `@testable import`
+- Arrange–Act–Assert로 첫 테스트를 만드는 방법
+- `XCTestCase`의 setup과 teardown 생명주기
+- `async throws`와 callback expectation을 구분하는 기준
+- stub, fake, spy 같은 테스트 대역과 의존성 제어
+- 성능 테스트, code coverage와 test plan의 역할
+- XCTest, Swift Testing, XCUITest와 TCA `TestStore`의 경계
+
+## 먼저 알아둘 테스트 용어
+
+| 용어                   | 쉬운 뜻                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| production code        | 실제 앱이나 framework에 포함되어 사용자 환경에서 실행되는 코드예요.                                                 |
+| test target            | production target을 불러와 테스트 코드와 test runner를 빌드하는 별도 target이에요. 보통 이름이 `AppTests`로 끝나요. |
+| system under test(SUT) | 현재 테스트가 직접 검증하는 대상이에요. 함수, 타입 또는 작은 기능 경계가 될 수 있어요.                              |
+| test case              | 하나의 입력과 상황에서 기대 행동을 확인하는 실행 단위예요. XCTest에서는 `test`로 시작하는 instance method가 돼요.   |
+| fixture                | 테스트를 실행하는 데 필요한 입력, 객체와 초기 상태의 묶음이에요.                                                    |
+| assertion              | 실제 결과가 기대값과 같은지 확인하고 다르면 테스트 실패를 기록하는 명령이에요.                                      |
+| deterministic          | 같은 코드와 입력으로 실행하면 시간, 순서나 외부 환경에 상관없이 같은 결과를 내는 성질이에요.                        |
+| test double            | network, database, clock 같은 실제 의존성을 테스트에서 대신하는 구현이에요. stub, fake와 spy가 대표적이에요.        |
+| regression             | 이미 동작하던 기능이 변경 뒤 다시 깨지는 문제예요. 테스트는 과거 버그와 약속을 자동으로 다시 확인해요.              |
+
+## 단위 테스트는 구현 줄 수보다 관찰할 행동을 검증해요
+
+독서 목표 진행률을 계산하는 가장 작은 타입부터 시작할게요.
+
+```swift
+struct ReadingGoal {
+  let dailyMinutes: Int
+
+  func progress(completedMinutes: Int) -> Double {
+    guard dailyMinutes > 0 else { return 0 }
+
+    return min(
+      Double(max(completedMinutes, 0)) / Double(dailyMinutes),
+      1
+    )
+  }
+}
+```
+
+이 타입이 외부에서 관찰할 수 있는 약속은 다음과 같아요.
+
+1. 목표의 절반을 읽으면 `0.5`를 반환해요.
+2. 목표보다 많이 읽어도 진행률은 `1`을 넘지 않아요.
+3. 음수 입력과 잘못된 목표는 안전한 값으로 처리해요.
+
+내부에서 `min`을 호출했는지 검증할 필요는 없어요. 구현을 같은 의미의 다른 코드로 바꿔도 외부 행동이 유지되면 테스트는 통과해야 해요. private method 호출 순서처럼 구현 세부 사항에 묶인 테스트는 안전한 refactoring까지 방해할 수 있어요.
+
+## Xcode에 unit test target을 연결해요
+
+Xcode 16 이상에서 새 프로젝트를 만들 때 Testing System을 선택하면 unit test와 UI test target을 함께 만들 수 있어요. 기존 프로젝트에는 다음 순서로 추가해요.
+
+1. **File > New > Target**을 선택해요.
+2. **Unit Testing Bundle**을 선택해요.
+3. testing system으로 XCTest를 선택해 test target을 만들어요.
+4. app scheme의 Test action에 새 target이 포함됐는지 확인해요.
+5. 테스트 파일에서 `import XCTest`와 `@testable import AppModule`을 작성해요.
+
+```swift
+import XCTest
+
+@testable import ReadingApp
+```
+
+Swift access control에서 다른 module은 `internal` 선언에 접근할 수 없어요. `@testable import`는 **Enable Testability**로 빌드한 module의 `internal` API를 test target에서 볼 수 있게 해요. `private`까지 공개하거나 production API를 테스트 때문에 모두 `public`으로 바꾸는 기능은 아니에요.
+
+Apple의 [Adding tests to your Xcode project](https://developer.apple.com/documentation/xcode/adding-tests-to-your-xcode-project)는 unit test가 작은 app logic을, integration test가 여러 component의 결합을 검증한다고 구분해요. 둘 다 같은 XCTest API를 사용할 수 있고 차이는 framework가 아니라 실제 code boundary의 크기예요.
+
+## Arrange–Act–Assert로 첫 테스트를 작성해요
+
+`XCTestCase`를 상속하고 이름이 `test`로 시작하는 instance method를 만들어요.
+
+```swift
+import XCTest
+
+final class ReadingGoalTests: XCTestCase {
+  func testHalfOfGoalReturnsHalfProgress() {
+    // Arrange: 입력과 SUT를 준비해요.
+    let goal = ReadingGoal(dailyMinutes: 30)
+
+    // Act: 검증할 행동을 한 번 실행해요.
+    let progress = goal.progress(completedMinutes: 15)
+
+    // Assert: 관찰된 결과를 기대값과 비교해요.
+    XCTAssertEqual(progress, 0.5, accuracy: 0.001)
+  }
+}
+```
+
+Arrange–Act–Assert(AAA)는 문법이 아니라 테스트의 읽기 순서예요.
+
+| 단계    | 답하는 질문                               | 예제                           |
+| ------- | ----------------------------------------- | ------------------------------ |
+| Arrange | 어떤 상황과 입력인가요?                   | 30분 목표를 만들어요.          |
+| Act     | 사용자가 기대하는 어떤 행동을 실행하나요? | 15분 완료의 진행률을 계산해요. |
+| Assert  | 외부에서 어떤 결과가 보여야 하나요?       | 결과가 0.5인지 확인해요.       |
+
+부동소수점 값은 계산 과정에서 아주 작은 오차가 생길 수 있으므로 `accuracy`를 함께 지정했어요. 모든 값을 무조건 정확한 `==`로 비교하는 대신 도메인이 허용하는 오차를 명시해요.
+
+## 경계값은 서로 다른 행동으로 나눠 검증해요
+
+happy path 하나만 확인하면 분기와 경계에서 생기는 버그를 놓치기 쉬워요.
+
+```swift
+final class ReadingGoalBoundaryTests: XCTestCase {
+  func testProgressDoesNotExceedOne() {
+    let goal = ReadingGoal(dailyMinutes: 30)
+
+    let progress = goal.progress(completedMinutes: 50)
+
+    XCTAssertEqual(progress, 1)
+  }
+
+  func testNegativeCompletedMinutesReturnsZero() {
+    let goal = ReadingGoal(dailyMinutes: 30)
+
+    let progress = goal.progress(completedMinutes: -10)
+
+    XCTAssertEqual(progress, 0)
+  }
+
+  func testInvalidGoalReturnsZero() {
+    let goal = ReadingGoal(dailyMinutes: 0)
+
+    let progress = goal.progress(completedMinutes: 10)
+
+    XCTAssertEqual(progress, 0)
+  }
+}
+```
+
+하나의 긴 테스트에서 세 상황을 연속으로 확인할 수도 있지만, 분리하면 어떤 계약이 깨졌는지 test name만 보고 알 수 있어요. 같은 계산을 많은 입력에 반복해야 한다면 [Swift Testing](./swift-testing)의 parameterized test가 중복을 줄이는 데 더 적합할 수 있어요.
+
+## assertion은 실패 뒤 테스트를 계속할지 결정해요
+
+XCTest는 값의 성격에 맞는 assertion을 제공해요.
+
+| 목적           | 대표 API                                       |
+| -------------- | ---------------------------------------------- |
+| 두 값 비교     | `XCTAssertEqual`, `XCTAssertNotEqual`          |
+| Boolean 조건   | `XCTAssertTrue`, `XCTAssertFalse`              |
+| optional 검사  | `XCTAssertNil`, `XCTAssertNotNil`, `XCTUnwrap` |
+| 오류 발생 여부 | `XCTAssertThrowsError`, `XCTAssertNoThrow`     |
+| 즉시 실패      | `XCTFail`                                      |
+
+optional 값이 없으면 뒤 검증을 실행할 수 없을 때는 `XCTUnwrap`이 유용해요.
+
+```swift
+func testFirstFinishedBook() throws {
+  let titles = ["The Swift Programming Language"]
+
+  let firstTitle = try XCTUnwrap(titles.first)
+
+  XCTAssertEqual(firstTitle, "The Swift Programming Language")
+}
+```
+
+`XCTAssertNotNil(titles.first)` 뒤에 force unwrap을 쓰면 실패를 이미 기록하고도 crash할 수 있어요. `XCTUnwrap`은 값이 없을 때 오류를 던져 현재 테스트 흐름을 중단하고, 값이 있으면 optional을 벗긴 타입으로 반환해요.
+
+여러 assertion을 넣을 수 있지만 하나의 테스트가 하나의 **행동과 결과 묶음**을 설명하도록 유지해요. 저장 버튼을 눌렀을 때 loading이 끝나고 message가 바뀌는 것처럼 한 행동의 여러 관찰값은 함께 확인해도 괜찮아요.
+
+## setup과 teardown은 각 테스트의 격리를 지켜야 해요
+
+공통 객체를 매 test method 전에 새로 만들어야 할 때 setup을 사용할 수 있어요.
+
+```swift
+final class ReadingGoalSetupTests: XCTestCase {
+  private var goal: ReadingGoal!
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    goal = ReadingGoal(dailyMinutes: 30)
+  }
+
+  override func tearDownWithError() throws {
+    goal = nil
+    try super.tearDownWithError()
+  }
+
+  func testHalfProgress() {
+    XCTAssertEqual(
+      goal.progress(completedMinutes: 15),
+      0.5,
+      accuracy: 0.001
+    )
+  }
+}
+```
+
+XCTest는 instance setup을 각 test method 전에, teardown을 각 test method 뒤에 실행해요. 현재 XCTest에는 `async throws` setup, `setUpWithError()`, `setUp()`이 있고 Apple의 [Set Up and Tear Down State in Your Tests](https://developer.apple.com/documentation/xctest/set-up-and-tear-down-state-in-your-tests)는 실행 순서와 cleanup 보장을 설명해요.
+
+공통 setup이 항상 좋은 것은 아니에요. 위 예제처럼 한 줄짜리 값은 각 테스트 안에서 지역 상수로 만드는 편이 입력을 바로 볼 수 있고 implicit unwrapped optional도 없애요. setup은 다음 조건일 때 사용해요.
+
+- 생성 비용과 준비 코드가 여러 테스트에서 의미 있게 반복돼요.
+- 각 테스트 전에 완전히 새 instance를 만들 수 있어요.
+- setup을 읽지 않아도 test method의 중요한 입력이 감춰지지 않아요.
+
+database file, notification observer처럼 반드시 정리해야 하는 resource는 `addTeardownBlock`으로 생성 지점 가까이에 cleanup을 등록할 수 있어요. teardown은 테스트 성공과 실패 모두에서 실행되지만 process crash까지 복구하는 장치는 아니에요.
+
+## 외부 의존성을 직접 사용하면 결과가 흔들려요
+
+다음 service는 현재 시각의 network 상태에 따라 다른 결과를 만들 수 있어요.
+
+```swift
+struct LiveReadingRepository {
+  func fetchCompletedMinutes() async throws -> Int {
+    // 실제 앱에서는 server와 통신해요.
+    20
+  }
+}
+
+struct ReadingStatusService {
+  private let repository = LiveReadingRepository()
+
+  func status(goal: Int) async throws -> String {
+    let minutes = try await repository.fetchCompletedMinutes()
+    return minutes >= goal ? "목표 달성" : "독서 중"
+  }
+}
+```
+
+이 코드를 그대로 테스트하면 offline, server data와 인증 상태가 결과에 개입해요. 원하는 실패도 만들기 어렵고 test suite가 느려져요. repository의 필요한 동작을 protocol로 표현하고 외부에서 전달해요.
+
+```swift
+protocol ReadingRepository: Sendable {
+  func fetchCompletedMinutes() async throws -> Int
+}
+
+struct ReadingStatusService {
+  let repository: any ReadingRepository
+
+  func status(goal: Int) async throws -> String {
+    let minutes = try await repository.fetchCompletedMinutes()
+    return minutes >= goal ? "목표 달성" : "독서 중"
+  }
+}
+```
+
+이 구조는 [의존성 주입](../design-patterns/dependency-injection)이에요. production에서는 live repository를, 테스트에서는 제어 가능한 대역을 전달해요.
+
+## stub으로 async 결과와 오류를 고정해요
+
+```swift
+enum ReadingRepositoryError: Error, Equatable {
+  case offline
+}
+
+private struct StubReadingRepository: ReadingRepository {
+  let result: Result<Int, ReadingRepositoryError>
+
+  func fetchCompletedMinutes() async throws -> Int {
+    try result.get()
+  }
+}
+```
+
+성공과 실패를 실제 network 없이 만들 수 있어요.
+
+```swift
+final class ReadingStatusServiceTests: XCTestCase {
+  func testCompletedGoalReturnsCompletedStatus() async throws {
+    let repository = StubReadingRepository(
+      result: .success(30)
+    )
+    let service = ReadingStatusService(repository: repository)
+
+    let status = try await service.status(goal: 30)
+
+    XCTAssertEqual(status, "목표 달성")
+  }
+
+  func testRepositoryErrorIsPropagated() async {
+    let repository = StubReadingRepository(
+      result: .failure(.offline)
+    )
+    let service = ReadingStatusService(repository: repository)
+
+    do {
+      _ = try await service.status(goal: 30)
+      XCTFail("offline 오류가 발생해야 해요.")
+    } catch {
+      XCTAssertEqual(error as? ReadingRepositoryError, .offline)
+    }
+  }
+}
+```
+
+Swift concurrency 함수를 검증할 때 test method를 `async` 또는 `async throws`로 만들고 production 호출을 직접 `await`해요. 예상하지 않은 오류라면 test method 밖으로 던져도 XCTest가 실패로 기록해요. `do-catch`는 특정 오류를 직접 비교해야 할 때 사용해요.
+
+UI-bound object를 검증하면 test method나 test class에 `@MainActor`를 붙여 격리 위치를 명시해요. Apple의 [Asynchronous Tests and Expectations](https://developer.apple.com/documentation/xctest/asynchronous-tests-and-expectations)도 main actor가 필요하면 annotation을 추가하라고 안내해요.
+
+## callback API는 expectation으로 완료를 알려요
+
+`async` API가 아닌 delegate나 completion handler를 테스트할 때 `XCTestExpectation`을 사용해요.
+
+```swift
+func testLegacyLoadCallsCompletion() async {
+  let completionCalled = expectation(
+    description: "독서 시간을 전달해요."
+  )
+  let loader = LegacyReadingLoader()
+
+  loader.load { minutes in
+    XCTAssertEqual(minutes, 20)
+    completionCalled.fulfill()
+  }
+
+  await fulfillment(
+    of: [completionCalled],
+    timeout: 1
+  )
+}
+```
+
+expectation은 “언젠가 되겠지”라고 일정 시간을 멈추는 sleep과 달라요. callback이 오면 즉시 테스트를 계속하고, 오지 않으면 명확한 timeout failure를 만들어요.
+
+다음 기준으로 선택해요.
+
+- 호출 API가 `async`이면 test method도 `async`로 만들고 직접 `await`해요.
+- delegate, notification, callback처럼 직접 await할 수 없으면 expectation을 사용해요.
+- callback 횟수나 순서가 계약이면 `expectedFulfillmentCount` 또는 `enforceOrder`를 명시해요.
+- `Thread.sleep`과 임의 delay로 비동기를 기다리지 않아요.
+
+## 테스트 대역은 검증 목적에 맞게 골라요
+
+| 대역  | 하는 일                                           | 독서 앱 예                                           |
+| ----- | ------------------------------------------------- | ---------------------------------------------------- |
+| dummy | signature를 채우지만 실제로 사용되지 않아요.      | 현재 테스트가 읽지 않는 analytics를 전달해요.        |
+| stub  | 준비된 값이나 오류를 반환해요.                    | 완료 시간이 항상 30분이라고 반환해요.                |
+| fake  | 단순하지만 실제 규칙으로 동작해요.                | memory dictionary에 독서 기록을 저장해요.            |
+| spy   | 호출된 값과 횟수를 기록해 나중에 확인해요.        | `save(minutes:)`가 30으로 한 번 호출됐는지 기록해요. |
+| mock  | 기대 호출과 순서를 미리 정의하고 스스로 검증해요. | sync 뒤 analytics 호출 순서를 엄격하게 확인해요.     |
+
+모든 대역을 mock이라고 부르면 테스트가 무엇을 확인하는지 읽기 어려워요. 반환값만 필요하면 stub, 저장 동작이 필요하면 fake, interaction을 확인해야 하면 spy처럼 목적을 이름에 드러내요.
+
+interaction 검증도 최소화해요. 최종 state나 반환값으로 행동을 확인할 수 있다면 private collaboration 호출 횟수보다 결과를 검증하는 편이 refactoring에 강해요.
+
+## 실제 시간을 기다리지 말고 clock을 주입해요
+
+debounce나 timeout 코드가 `Task.sleep`을 직접 호출하면 테스트도 실제 시간을 기다려야 해요. sleep 동작을 protocol이나 `Clock` dependency로 주입하면 즉시 완료하거나 수동으로 시간을 전진시키는 구현을 사용할 수 있어요.
+
+```swift
+struct ReminderScheduler<C: Clock> where C.Duration == Duration {
+  let clock: C
+
+  func waitBeforeReminder() async throws {
+    try await clock.sleep(for: .seconds(30))
+  }
+}
+```
+
+production에는 `ContinuousClock`, 테스트에는 제어 가능한 clock을 전달해요. 중요한 점은 timeout을 크게 늘리는 것이 아니라 **시간 자체를 테스트 입력으로 바꾸는 것**이에요.
+
+## performance test는 회귀를 측정해요
+
+동작의 정답이 아니라 실행 시간이나 resource 사용량의 회귀를 확인하려면 XCTest의 measurement API를 사용해요.
+
+```swift
+final class ReadingSummaryPerformanceTests: XCTestCase {
+  func testSummaryPerformance() {
+    let sessions = (0..<10_000).map { _ in 10 }
+
+    measure {
+      _ = sessions.reduce(0, +)
+    }
+  }
+}
+```
+
+`measure`는 block을 반복 실행하고 기본적으로 wall-clock time을 기록해요. CPU, memory, storage, app launch 같은 다른 지표는 `XCTMetric` 계열을 사용해요. Apple의 [Writing and running performance tests](https://developer.apple.com/documentation/xcode/writing-and-running-performance-tests)는 release build, 고정된 device 조건과 baseline을 함께 관리하도록 안내해요.
+
+performance test에서 code coverage와 sanitizer를 켜면 측정 자체의 overhead가 결과에 들어갈 수 있어요. 기능 테스트 설정과 성능 측정용 test plan을 분리해요.
+
+## test plan은 실행 조합을 코드 밖에서 관리해요
+
+test plan은 scheme의 Test action에서 어떤 test와 설정 조합을 실행할지 정의하는 `.xctestplan` 문서예요.
+
+- 빠른 unit test만 실행하는 개발용 plan
+- integration과 UI test까지 포함하는 pull request plan
+- locale, appearance와 device 설정을 바꾸는 UI plan
+- code coverage와 sanitizer를 켠 진단 plan
+- release configuration으로 실행하는 performance plan
+
+하나의 거대한 plan에 모든 설정을 섞기보다 피드백 목적에 따라 나눠요. `xcodebuild test -scheme ... -testPlan ...`으로 CI에서도 같은 구성을 재사용할 수 있어요.
+
+code coverage는 실행된 code path의 비율이지 테스트 품질 점수가 아니에요. 높은 숫자를 만들기 위해 의미 없는 assertion을 추가하지 말고, 빠진 boundary와 중요한 실패 경로를 찾는 지도처럼 사용해요.
+
+## flaky test는 production bug와 다르게 다뤄야 해요
+
+같은 commit에서 통과와 실패를 반복하는 테스트를 flaky test라고 해요. 대표 원인은 다음과 같아요.
+
+- 실제 network, 현재 날짜, locale와 random 값에 의존해요.
+- 다른 테스트가 남긴 global state와 file을 읽어요.
+- parallel test가 같은 singleton이나 database를 동시에 바꿔요.
+- `sleep` 뒤 작업이 끝났다고 가정해요.
+- callback이 오기 전에 테스트가 종료돼요.
+
+timeout을 늘리거나 실패 시 무조건 재실행하면 증상을 숨길 수 있어요. 외부 입력을 dependency로 만들고, 각 테스트에 고유한 fixture와 저장 공간을 주고, 완료 조건을 직접 기다려요. 병렬 실행이 불가능한 shared resource가 있다면 먼저 격리 구조를 개선하고 정말 필요한 범위만 직렬화해요.
+
+## 네 가지 테스트 도구는 검증 경계가 달라요
+
+| 도구                              | 직접 조작하는 대상                   | 잘 찾는 문제                         | 비용                                                           |
+| --------------------------------- | ------------------------------------ | ------------------------------------ | -------------------------------------------------------------- |
+| XCTest 단위 테스트                | 함수, 객체와 dependency              | 계산, 상태 전이, 오류 처리           | 빠르지만 UI 연결은 보장하지 않아요.                            |
+| [Swift Testing](./swift-testing)  | 함수와 module logic                  | 많은 입력, async logic, 표현식 실패  | UI automation과 XCTest 성능 metric은 대체하지 않아요.          |
+| [XCUITest](./xcuitest)            | 실행 중인 앱의 accessibility element | 핵심 사용자 흐름, 화면 연결, 접근성  | 느리고 system state에 민감해요.                                |
+| [TCA TestStore](./tca-test-store) | reducer의 action, state와 effect     | TCA feature의 모든 state·effect 단계 | TCA를 사용해야 하며 exhaustive test는 변화에 민감할 수 있어요. |
+
+XCTest는 assertion framework 이름이고 unit test는 검증 범위예요. XCTest로 integration, UI와 performance test도 쓸 수 있고 Swift Testing으로 unit과 integration test를 작성할 수도 있어요.
+
+## 언제 XCTest 단위 테스트를 사용해야 하나요
+
+다음 조건에서 먼저 작성해요.
+
+- 계산, validation과 state transition처럼 UI 없이 호출할 수 있는 행동이 있어요.
+- 오류, 빈 값과 boundary를 빠르게 반복 검증해야 해요.
+- dependency를 stub이나 fake로 바꿀 수 있어요.
+- Objective-C와 XCTest helper가 많은 기존 codebase를 점진적으로 보호해야 해요.
+- XCTest performance metric이나 UI testing과 같은 ecosystem을 사용해요.
+
+반대로 실제 화면 연결과 accessibility element를 검증하려면 XCUITest가 필요하고, 여러 component의 실제 조합을 확인하려면 integration test로 경계를 넓혀요. 작은 private method마다 test를 만들기보다 사용자에게 중요한 public behavior부터 보호해요.
+
+## 적용 순서를 정리해요
+
+1. 변경되면 사용자에게 문제가 되는 행동을 한 문장으로 적어요.
+2. 그 행동을 가장 작은 code boundary에서 직접 호출할 수 있는지 확인해요.
+3. network, clock, database와 random 값을 dependency로 분리해요.
+4. Arrange–Act–Assert로 happy path 하나를 작성해요.
+5. 오류와 0, 빈 값, 최대값 같은 boundary를 별도 case로 추가해요.
+6. async API는 직접 `await`하고 callback만 expectation으로 기다려요.
+7. 각 테스트가 독립된 fixture를 만들고 순서 없이 실행되는지 확인해요.
+8. 빠른 suite와 느린 integration·UI·performance suite를 test plan으로 나눠요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 단위 테스트의 단위는 함수 하나인가요?
+
+반드시 그렇지 않아요. 외부 환경을 제어한 상태에서 하나의 행동을 빠르고 결정적으로 검증할 수 있는 경계예요. 함수 하나일 수도 있고 dependency를 주입한 객체의 작은 use case일 수도 있어요.
+
+### `setUp`에 모든 fixture를 만들면 좋은가요?
+
+아니요. 중요한 입력이 test method 밖으로 숨고 공유 mutable state가 늘 수 있어요. 반복되는 준비 비용이 의미 있을 때만 사용하고 단순한 값은 각 테스트의 지역 상수로 만드는 편이 읽기 쉽고 격리하기 좋아요.
+
+### async test에서 expectation과 `async/await` 중 무엇을 사용하나요?
+
+production API가 `async`이면 test method도 `async`로 만들고 직접 `await`해요. callback, delegate와 notification처럼 직접 await할 수 없는 event에만 expectation을 사용해요.
+
+### mock 호출 횟수보다 결과를 검증하라는 이유는 무엇인가요?
+
+호출 순서와 private collaboration은 구현을 바꾸면 쉽게 달라져요. 반환값과 final state 같은 observable behavior를 검증하면 구현을 refactoring해도 같은 계약을 유지하는 한 테스트가 통과해요.
+
+### code coverage가 100%면 테스트가 충분한가요?
+
+아니요. coverage는 code가 실행됐다는 뜻이지 결과를 올바르게 검증했다는 뜻은 아니에요. 중요한 boundary, 오류와 사용자 흐름을 assertion했는지 별도로 판단해야 해요.
+
+## 참고 자료
+
+- [Apple Developer — XCTest](https://developer.apple.com/documentation/xctest)
+- [Apple Developer — XCTestCase](https://developer.apple.com/documentation/xctest/xctestcase)
+- [Apple Developer — Adding tests to your Xcode project](https://developer.apple.com/documentation/xcode/adding-tests-to-your-xcode-project)
+- [Apple Developer — Asynchronous Tests and Expectations](https://developer.apple.com/documentation/xctest/asynchronous-tests-and-expectations)
+- [Apple Developer — Set Up and Tear Down State in Your Tests](https://developer.apple.com/documentation/xctest/set-up-and-tear-down-state-in-your-tests)
+- [Apple Developer — Improving code assessment by organizing tests into test plans](https://developer.apple.com/documentation/xcode/organizing-tests-to-improve-feedback)
+- [Apple Developer — Writing and running performance tests](https://developer.apple.com/documentation/xcode/writing-and-running-performance-tests)
+- [Swift-KR — Swift로 이해하는 의존성 주입](../design-patterns/dependency-injection)
+- [Swift-KR — Swift로 이해하는 Swift Testing](./swift-testing)
+- [Swift-KR — Swift로 이해하는 XCUITest](./xcuitest)
+- [Swift-KR — Swift로 이해하는 TCA TestStore](./tca-test-store)

--- a/docs/guide/testing/xcuitest.md
+++ b/docs/guide/testing/xcuitest.md
@@ -1,0 +1,535 @@
+---
+title: Swift로 이해하는 XCUITest
+description: XCUITest의 별도 process와 accessibility tree, XCUIApplication·query·wait, launch 환경, Page Object와 안정적인 UI 테스트 전략을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 XCUITest
+
+> **면접 답변 한 줄 요약:** XCUITest는 test runner process가 실행 중인 앱을 accessibility element로 조회하고 실제 tap·typing·swipe를 보내 핵심 사용자 흐름을 검증해서, 화면과 기능이 함께 연결된 결과를 사용자 관점에서 확인하는 UI automation 도구예요.
+
+unit test는 `ReadingGoal.progress`를 직접 호출할 수 있어요. XCUITest는 앱의 ViewModel이나 repository를 직접 호출하지 않아요. 실제 앱을 별도 process로 실행하고 사용자가 보는 UI element를 찾아 tap하고 text를 입력해요.
+
+이 차이 때문에 XCUITest는 화면, navigation, storage와 여러 framework가 실제로 연결됐는지 확인할 수 있어요. 대신 app launch와 rendering을 기다려야 하므로 unit test보다 느리고 system alert, animation과 device 상태에도 영향을 받아요. 모든 분기를 UI test로 덮기보다 깨졌을 때 사용자 영향이 큰 흐름을 선택해야 해요.
+
+이 문서에서는 독서 시간 기록 화면을 예로 들어 다음 내용을 배워요.
+
+- app process와 UI test runner process의 관계
+- accessibility tree와 identifier의 역할
+- `XCUIApplication`, `XCUIElementQuery`, `XCUIElement`로 화면을 조작하는 방법
+- launch argument와 environment로 초기 상태를 고정하는 방법
+- `exists`, `isHittable`과 explicit wait의 차이
+- system alert와 interruption을 처리하는 방법
+- Page Object, screenshot, test plan과 accessibility audit
+- flaky UI test를 줄이고 적절한 사용자 흐름을 고르는 기준
+
+## 먼저 알아둘 UI testing 용어
+
+| 용어                        | 쉬운 뜻                                                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| UI automation               | 사람이 화면을 조작하는 행동을 code가 대신 실행하고 결과를 확인하는 테스트 방식이에요.                                    |
+| test runner process         | UI test code를 실행하는 별도 process예요. 앱의 memory와 model object에 직접 접근하지 않아요.                             |
+| application under test(AUT) | `XCUIApplication`으로 실행하고 조작하는 실제 대상 앱이에요.                                                              |
+| accessibility tree          | 화면을 보조 기술과 automation이 이해할 수 있도록 element의 role, label, value, identifier와 hierarchy를 표현한 구조예요. |
+| query                       | accessibility tree에서 조건에 맞는 element 후보를 찾는 표현이에요. `app.buttons`와 `matching`이 대표적이에요.            |
+| `XCUIElement`               | query가 가리키는 하나의 UI element proxy예요. tap, typeText와 상태 조회 API를 제공해요.                                  |
+| synchronization             | app의 animation과 비동기 작업이 원하는 상태에 도달할 때까지 조건을 기준으로 기다리는 일이에요.                           |
+| interruption                | 권한 alert처럼 앱의 원래 흐름을 가리고 test interaction을 막는 system 또는 예상 밖 modal UI예요.                         |
+| Page Object                 | 화면의 query와 interaction을 의미 있는 method로 감싸 test scenario에서 세부 selector를 분리하는 구조예요.                |
+
+## UI test는 앱 code가 아니라 화면 경계를 조작해요
+
+XCUITest의 실행 구조를 먼저 보면 왜 production object를 직접 읽을 수 없는지 이해하기 쉬워요.
+
+```text
+UI test runner process
+├─ XCTestCase
+├─ XCUIApplication proxy
+├─ XCUIElement query와 gesture 요청
+└─ assertion
+          │ operating system automation channel
+          ▼
+Application under test process
+├─ 실제 app lifecycle
+├─ SwiftUI 또는 UIKit 화면
+├─ model, network와 storage
+└─ accessibility tree를 system에 노출
+```
+
+Apple의 [Record, replay, and review: UI automation with Xcode](https://developer.apple.com/videos/play/wwdc2025/344/)는 automation이 앱과 독립적으로 실행되며 accessibility가 element type, label, value와 frame을 제공한다고 설명해요.
+
+분리된 process는 중요한 테스트 경계예요.
+
+- UI test는 app target의 `internal` property를 `@testable import`로 읽지 않아요.
+- 두 process의 global variable과 singleton은 공유되지 않아요.
+- app에 전달할 초기 상태는 launch argument, launch environment, URL 또는 test용 seed 경로로 준비해요.
+- assertion은 화면에 노출된 text, value, enabled와 navigation 결과를 기준으로 작성해요.
+
+## UI Testing Bundle을 추가해요
+
+Xcode project에 UI test target이 없다면 다음 순서로 만들어요.
+
+1. **File > New > Target**을 선택해요.
+2. **UI Testing Bundle**을 선택해요.
+3. Target to be Tested에 실제 앱 target을 지정해요.
+4. app scheme의 Test action과 test plan에 UI test target을 포함해요.
+5. UI test file에서 `import XCTest`를 작성해요.
+
+Xcode의 새 UI test template은 현재도 XCTest와 XCUIAutomation을 사용해요. Swift Testing은 unit·integration test와 함께 사용할 수 있지만 UI automation test는 `XCTestCase` subclass에 작성해요.
+
+## 앱 화면에 안정적인 accessibility identifier를 제공해요
+
+독서 시간을 입력하고 저장하는 SwiftUI 화면을 준비해요.
+
+```swift
+import SwiftUI
+
+struct ReadingRecordView: View {
+  @State private var minutes = ""
+  @State private var message = ""
+
+  var body: some View {
+    Form {
+      TextField("독서 시간", text: $minutes)
+        .keyboardType(.numberPad)
+        .accessibilityIdentifier("reading.minutesField")
+
+      Button("기록") {
+        message = "오늘 \(minutes)분을 기록했어요"
+      }
+      .accessibilityIdentifier("reading.saveButton")
+
+      Text(message)
+        .accessibilityIdentifier("reading.resultLabel")
+    }
+  }
+}
+```
+
+accessibility label인 화면 text로도 query할 수 있지만 localization이나 copy 변경에 따라 test가 깨져요. identifier는 사용자에게 읽히는 label과 분리된 automation용 identity예요.
+
+좋은 identifier는 다음 성질을 가져요.
+
+- app 전체 또는 해당 화면의 query scope 안에서 유일해요.
+- localized text를 사용하지 않아요.
+- row index처럼 순서가 바뀌면 의미가 달라지는 값보다 domain identity를 사용해요.
+- `button1`보다 `reading.saveButton`처럼 역할을 드러내요.
+- production과 test가 공유하는 contract이므로 오타를 줄이도록 상수 또는 convention을 관리해요.
+
+identifier를 추가했다고 접근성이 자동으로 좋아지는 것은 아니에요. VoiceOver가 읽을 label, value, trait와 hierarchy도 실제 사용자 의미에 맞아야 해요. 반대로 좋은 accessibility 구조는 UI automation query도 안정적으로 만들어요.
+
+## `XCUIApplication`을 실행하고 첫 사용자 흐름을 검증해요
+
+```swift
+import XCTest
+
+final class ReadingFlowUITests: XCTestCase {
+  @MainActor
+  func testRecordsReadingMinutes() {
+    continueAfterFailure = false
+
+    let app = XCUIApplication()
+    app.launchArguments += [
+      "--uitesting",
+      "--reset-reading-data",
+    ]
+    app.launch()
+
+    let minutesField = app.textFields[
+      "reading.minutesField"
+    ]
+    minutesField.tap()
+    minutesField.typeText("20")
+
+    app.buttons["reading.saveButton"].tap()
+
+    let result = app.staticTexts[
+      "reading.resultLabel"
+    ]
+    XCTAssertTrue(
+      result.waitForExistence(timeout: 2)
+    )
+    XCTAssertEqual(
+      result.label,
+      "오늘 20분을 기록했어요"
+    )
+  }
+}
+```
+
+Swift 6의 현재 XCUIAutomation API는 UI element type을 main actor에 격리해요. 예제는 test method에 `@MainActor`를 붙여 `XCUIApplication`과 element interaction이 실행될 actor를 명시했어요.
+
+`app.launch()`는 이미 실행 중인 대상 app을 종료한 뒤 새 instance를 실행하고 user event를 받을 준비가 될 때 반환해요. 하지만 app launch 뒤 시작한 network request나 animation까지 모두 끝났다는 뜻은 아니므로 최종 element 조건을 따로 기다려요.
+
+## Query는 후보를 좁히고 Element는 행동해요
+
+다음 표현은 역할이 달라요.
+
+```swift
+let allButtons = app.buttons
+let saveButton = app.buttons["reading.saveButton"]
+let enabledButtons = app.buttons.matching(
+  NSPredicate(format: "enabled == true")
+)
+let firstEnabledButton = enabledButtons.firstMatch
+```
+
+| 표현                  | 의미                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `app.buttons`         | 현재 accessibility tree의 button 후보를 나타내는 query예요.                           |
+| `query[identifier]`   | identifier가 맞는 element proxy를 만들어요.                                           |
+| `matching(predicate)` | attribute 조건으로 후보를 더 좁혀요.                                                  |
+| `firstMatch`          | query 결과 중 첫 element를 가리켜 성능을 줄일 수 있지만 uniqueness를 보장하지 않아요. |
+| `element(boundBy:)`   | 결과 순서의 index로 고르므로 UI 순서 변경에 민감해요.                                 |
+
+`firstMatch`를 붙여 test가 통과했다고 element identity가 명확해지는 것은 아니에요. 같은 identifier가 여러 개라면 app의 accessibility 구조를 고쳐요. 동적인 list row는 `reading.session.<stable-id>`처럼 domain ID를 포함할 수 있어요.
+
+실패할 때는 `app.debugDescription`이나 query의 debug output으로 현재 tree에 어떤 element가 노출됐는지 확인해요. 화면에 눈으로 보이는 View와 accessibility element가 일대일로 같지 않을 수 있어요.
+
+## `exists`와 `isHittable`은 답하는 질문이 달라요
+
+| property         | 답하는 질문                                                             |
+| ---------------- | ----------------------------------------------------------------------- |
+| `exists`         | 현재 accessibility hierarchy에 이 element가 있나요?                     |
+| `isHittable`     | 현재 system이 계산한 interaction point로 실제 gesture를 보낼 수 있나요? |
+| `enabled`        | control이 disabled가 아닌가요?                                          |
+| `value`, `label` | accessibility가 현재 어떤 값과 text를 노출하나요?                       |
+
+element가 `exists == true`여도 다른 modal에 가려지거나 화면 밖에 있어 `isHittable == false`일 수 있어요. 반대로 최종 결과 text처럼 tap하지 않을 element는 existence와 label만 확인하면 돼요.
+
+tap 직전에 무조건 `isHittable` assertion을 추가하기보다 test의 의미에 맞춰요. 사용자가 실제로 누를 수 있어야 하는 button이라면 hittable이 중요한 계약이고, scroll 뒤 나타나는 cell은 먼저 scroll action이 필요해요.
+
+## 고정 sleep 대신 원하는 UI 조건을 기다려요
+
+다음 코드는 기기와 CI 속도에 따라 실패해요.
+
+```swift
+app.buttons["reading.saveButton"].tap()
+sleep(2)
+XCTAssertTrue(
+  app.staticTexts["reading.resultLabel"].exists
+)
+```
+
+결과가 0.1초에 나타나도 항상 2초를 낭비하고, 느린 device에서 2.1초가 걸리면 실패해요. element의 조건을 직접 기다려요.
+
+```swift
+let result = app.staticTexts[
+  "reading.resultLabel"
+]
+
+XCTAssertTrue(
+  result.waitForExistence(timeout: 2),
+  "기록 결과가 표시되어야 해요."
+)
+```
+
+현재 API에는 `waitForNonExistence(timeout:)`와 특정 key path 값이 바뀔 때까지 기다리는 `wait(for:toEqual:timeout:)`도 있어요. deployment와 Xcode version을 확인해 사용해요.
+
+timeout은 실제 기다릴 최대 시간이지 항상 소비되는 시간이 아니에요. 모든 timeout을 크게 늘리기보다 app이 완료 상태를 accessibility로 명확하게 노출하고 그 조건을 기다리세요.
+
+## launch argument와 environment로 초기 상태를 고정해요
+
+UI test가 이전 실행의 UserDefaults나 database에 영향을 받으면 순서 의존성이 생겨요. `launchArguments`와 `launchEnvironment`를 `launch()` 전에 설정해 app이 test용 시작 상태를 만들게 해요.
+
+```swift
+let app = XCUIApplication()
+app.launchArguments = [
+  "--uitesting",
+  "--reset-reading-data",
+]
+app.launchEnvironment = [
+  "READING_SEED": "empty",
+  "ANIMATIONS_DISABLED": "1",
+]
+app.launch()
+```
+
+앱 시작 지점에서는 전달된 값을 읽어 dependency와 seed를 선택해요.
+
+```swift
+struct LaunchConfiguration {
+  let isUITesting: Bool
+  let shouldResetReadingData: Bool
+
+  init(processInfo: ProcessInfo = .processInfo) {
+    let arguments = processInfo.arguments
+    isUITesting = arguments.contains("--uitesting")
+    shouldResetReadingData = arguments.contains(
+      "--reset-reading-data"
+    )
+  }
+}
+```
+
+test code가 app process의 store를 직접 바꾸는 것이 아니에요. app이 launch contract를 받아 test 가능한 dependency graph를 구성하는 방식이에요.
+
+주의할 점도 있어요.
+
+- 인증 우회와 개인정보 seed 같은 test hook이 release에서 악용되지 않도록 build configuration과 입력 범위를 제한해요.
+- production behavior를 과도하게 바꿔 UI test만 통과하는 별도 앱을 만들지 않아요.
+- network를 stub한다면 화면 아래의 navigation과 rendering은 실제 경로로 유지해요.
+- 각 test가 필요한 state를 명시하고 이전 test의 결과에 기대지 않아요.
+
+## 한 test는 하나의 완결된 사용자 목표를 검증해요
+
+좋은 UI test 이름은 tap sequence보다 사용자 목표를 설명해요.
+
+```text
+testTapFieldThenTypeThenTapButton        // 구현 단계만 보여요.
+testUserCanRecordReadingMinutes          // 사용자 목표를 보여요.
+```
+
+독서 앱의 핵심 흐름을 예로 들면 다음 정도를 선택할 수 있어요.
+
+1. 처음 실행한 사용자가 독서 시간을 기록할 수 있어요.
+2. 잘못된 시간을 입력하면 validation message를 보고 수정할 수 있어요.
+3. 저장한 기록이 목록에 나타나고 상세 화면을 열 수 있어요.
+4. offline 오류 뒤 retry해서 저장할 수 있어요.
+
+계산 경계값 20개는 unit test나 parameterized test로 검증하고, UI test에서는 대표적인 성공과 중요한 오류 흐름을 확인해요. UI test가 많아질수록 전체 feedback이 느려지고 실패 원인 분석 비용도 커져요.
+
+## Page Object로 selector와 scenario를 분리해요
+
+여러 test가 같은 query와 입력 순서를 반복하면 화면 변경 때 모든 파일을 고쳐야 해요. 작은 Page Object로 element와 action을 모아요.
+
+```swift
+import XCTest
+
+@MainActor
+struct ReadingRecordPage {
+  let app: XCUIApplication
+
+  var minutesField: XCUIElement {
+    app.textFields["reading.minutesField"]
+  }
+
+  var saveButton: XCUIElement {
+    app.buttons["reading.saveButton"]
+  }
+
+  var resultLabel: XCUIElement {
+    app.staticTexts["reading.resultLabel"]
+  }
+
+  func record(minutes: Int) {
+    minutesField.tap()
+    minutesField.typeText(String(minutes))
+    saveButton.tap()
+  }
+}
+```
+
+test scenario는 사용자 행동과 결과에 집중해요.
+
+```swift
+@MainActor
+func testUserCanRecordReadingMinutes() {
+  let app = XCUIApplication()
+  app.launchArguments = ["--uitesting"]
+  app.launch()
+
+  let page = ReadingRecordPage(app: app)
+  page.record(minutes: 20)
+
+  XCTAssertTrue(
+    page.resultLabel.waitForExistence(timeout: 2)
+  )
+  XCTAssertEqual(
+    page.resultLabel.label,
+    "오늘 20분을 기록했어요"
+  )
+}
+```
+
+Page Object가 production app의 business logic을 다시 구현하면 안 돼요. query와 gesture를 감싸되 결과 assertion은 test에 남겨 어떤 계약을 검증하는지 보여 주세요. 화면 이동을 반환값으로 표현하면 flow도 읽기 쉬워져요.
+
+## 예상한 alert와 예상 밖 interruption을 구분해요
+
+삭제 확인 alert가 검증할 사용자 흐름의 일부라면 직접 query하고 assertion해요.
+
+```swift
+let deleteAlert = app.alerts["기록 삭제"]
+XCTAssertTrue(deleteAlert.waitForExistence(timeout: 2))
+deleteAlert.buttons["삭제"].tap()
+```
+
+사진 권한처럼 현재 검증 흐름과 무관하지만 interaction을 막을 수 있는 system UI에는 interruption monitor를 사용해요.
+
+```swift
+addUIInterruptionMonitor(
+  withDescription: "사진 접근 권한"
+) { alert in
+  let allowButton = alert.buttons["허용"]
+  guard allowButton.exists else { return false }
+
+  allowButton.tap()
+  return true
+}
+
+app.buttons["프로필 사진 선택"].tap()
+app.tap()
+```
+
+monitor는 interruption이 다음 UI interaction을 막을 때 시도되고, 최근 등록한 handler부터 역순으로 실행돼요. 정상 흐름의 alert를 interruption monitor로 숨기면 실제 alert 내용과 action을 검증하지 못해요. Apple의 [Handling UI Interruptions](https://developer.apple.com/documentation/xctest/handling-ui-interruptions)는 두 경우를 분리하도록 안내해요.
+
+system button title은 locale에 따라 달라질 수 있어요. 가능하면 test plan에서 권한 상태를 미리 구성하고, 꼭 처리해야 한다면 실행 locale과 system UI를 함께 관리해요.
+
+## 실패 진단에는 activity와 attachment를 남겨요
+
+긴 흐름은 `XCTContext.runActivity`로 단계 이름을 report에 남길 수 있어요.
+
+```swift
+XCTContext.runActivity(
+  named: "20분을 입력하고 저장해요"
+) { _ in
+  page.record(minutes: 20)
+}
+```
+
+실패 시 screenshot을 attachment로 추가하면 당시 화면을 확인할 수 있어요.
+
+```swift
+let screenshot = XCUIScreen.main.screenshot()
+let attachment = XCTAttachment(screenshot: screenshot)
+attachment.name = "reading-record-result"
+attachment.lifetime = .keepAlways
+add(attachment)
+```
+
+모든 성공 test의 대용량 artifact를 항상 보존하면 저장 비용이 커져요. test plan의 screenshot·video 정책과 함께 실패 진단에 필요한 범위를 정해요. Xcode test report는 failure 시점의 hierarchy, screenshot과 video를 확인하는 중심 도구예요.
+
+## accessibility audit도 UI test에서 자동화할 수 있어요
+
+iOS 17 이상에서는 현재 화면의 accessibility 문제를 audit할 수 있어요.
+
+```swift
+@MainActor
+func testReadingScreenAccessibility() throws {
+  let app = XCUIApplication()
+  app.launchArguments = ["--uitesting"]
+  app.launch()
+
+  try app.performAccessibilityAudit()
+}
+```
+
+audit은 element description, hit region, contrast, text clipping과 Dynamic Type 같은 일반 문제를 찾고 issue가 있으면 test를 실패시켜요. 특정 확인된 예외를 filter할 수 있지만 이유 없이 모든 issue를 무시하지 않아요.
+
+자동 audit이 VoiceOver 사용자의 전체 경험을 보장하지는 않아요. 핵심 흐름을 실제 assistive technology로 탐색하는 수동 검증과 함께 사용해요.
+
+## test plan으로 locale과 화면 조건을 반복해요
+
+UI test 하나를 여러 test plan configuration에서 실행하면 다음 차이를 확인할 수 있어요.
+
+- 한국어, 독일어처럼 text 길이가 다른 locale
+- 아랍어처럼 right-to-left layout
+- light와 dark appearance
+- Dynamic Type 크기
+- iPhone과 iPad destination
+- screen orientation
+- screenshot과 video 보존 정책
+
+같은 scenario를 모든 device와 locale 조합에 무작정 실행하면 CI 시간이 폭증해요. 매 pull request에는 대표 조합, nightly에는 넓은 matrix처럼 feedback 속도와 coverage를 나눠요.
+
+## launch performance는 별도 measurement로 관리해요
+
+UI test target에서 app launch metric을 측정할 수 있어요.
+
+```swift
+@MainActor
+func testLaunchPerformance() {
+  measure(metrics: [XCTApplicationLaunchMetric()]) {
+    XCUIApplication().launch()
+  }
+}
+```
+
+기능 UI test와 performance baseline은 실패 의미가 달라요. release configuration과 고정 device 조건을 사용하는 performance test plan을 따로 두고, 일반 UI test에 모든 metric을 섞지 않아요.
+
+## 흔한 flaky UI test를 원인별로 고쳐요
+
+| 증상                                          | 흔한 원인                                            | 개선                                                       |
+| --------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
+| element를 찾지 못해요.                        | localized label, 중복 identifier, 아직 나타나지 않음 | stable identifier와 `waitForExistence`를 사용해요.         |
+| tap이 실패해요.                               | element가 가려졌거나 화면 밖이에요.                  | navigation·scroll 조건을 명시하고 `isHittable`을 확인해요. |
+| 단독 실행은 통과하고 전체 suite에서 실패해요. | 이전 test의 storage와 login state가 남아요.          | launch seed와 test별 계정을 사용해요.                      |
+| CI에서만 timeout이 나요.                      | fixed sleep, 실제 network와 animation에 의존해요.    | 완료 상태를 노출하고 controlled dependency를 사용해요.     |
+| 다른 언어에서 query가 실패해요.               | 화면 text를 identity로 사용해요.                     | identifier로 찾고 localized text는 별도 assertion해요.     |
+| keyboard 때문에 button이 가려져요.            | device size와 focus 상태를 가정해요.                 | keyboard dismissal이나 scroll action을 scenario에 넣어요.  |
+
+실패를 재실행해서 green으로 만드는 것만으로 해결하지 않아요. result bundle의 screenshot, video와 accessibility hierarchy에서 어떤 조건이 달랐는지 먼저 확인해요.
+
+## XCUITest와 다른 테스트의 경계를 비교해요
+
+| 질문                               | XCTest·Swift Testing unit test                 | XCUITest                                                |
+| ---------------------------------- | ---------------------------------------------- | ------------------------------------------------------- |
+| production code를 직접 호출하나요? | 네. 함수와 object를 test process에서 호출해요. | 아니요. 별도 app process의 UI를 조작해요.               |
+| dependency를 어떻게 제어하나요?    | initializer와 test value를 직접 전달해요.      | app launch contract가 test용 graph와 seed를 선택해요.   |
+| 무엇을 assertion하나요?            | 반환값, state와 interaction이에요.             | accessibility element의 존재, 값과 사용자 workflow예요. |
+| 속도와 실패 원인은 어떤가요?       | 빠르고 좁아요.                                 | 느리고 app·OS 통합 범위가 넓어요.                       |
+| 적절한 개수는 어떤가요?            | 다양한 branch와 boundary를 많이 검증해요.      | 중요한 end-to-end 흐름을 적게 유지해요.                 |
+
+UI test가 통과해도 모든 domain branch가 검증되는 것은 아니고 unit test가 통과해도 화면 wiring이 맞다는 보장은 없어요. 두 층이 서로 다른 위험을 보호해요.
+
+## 언제 XCUITest를 사용해야 하나요
+
+다음 조건에서 높은 가치가 있어요.
+
+- 로그인, 결제, 기록 저장처럼 깨지면 사용자가 목표를 완료할 수 없는 핵심 흐름이에요.
+- navigation, focus, keyboard와 여러 화면의 실제 연결을 확인해야 해요.
+- 과거 UI regression을 실제 사용자 행동으로 재현할 수 있어요.
+- locale, Dynamic Type와 device 차이에서 layout과 접근성을 확인해야 해요.
+- launch performance와 accessibility audit을 자동화해야 해요.
+
+단순 계산, validation branch와 network error mapping은 unit test가 더 빠르고 정확해요. 화면의 모든 button마다 UI test를 만들기보다 핵심 workflow와 integration risk에 집중해요.
+
+## 적용 순서를 정리해요
+
+1. 실패하면 사용자 목표가 막히는 workflow를 하나 고르세요.
+2. UI Testing Bundle과 test plan에 대상 app을 연결하세요.
+3. 핵심 element에 stable accessibility identifier를 제공하세요.
+4. launch argument와 environment로 독립적인 seed 상태를 만드세요.
+5. `XCUIApplication`을 새로 launch하고 사용자 gesture로만 흐름을 진행하세요.
+6. fixed sleep 대신 최종 element 조건을 explicit wait로 기다리세요.
+7. 반복 query는 작은 Page Object로 모으고 assertion은 scenario에 남기세요.
+8. 예상한 alert는 직접 검증하고 무관한 interruption만 monitor로 처리하세요.
+9. CI의 locale·device matrix와 screenshot·video 보존 범위를 정하세요.
+10. flaky failure는 재실행 전에 hierarchy와 result bundle로 원인을 분류하세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### XCUITest에서 app의 ViewModel을 직접 읽을 수 있나요?
+
+아니요. UI test runner와 대상 app은 별도 process라 memory object를 공유하지 않아요. accessibility element를 통해 결과를 관찰하고 launch argument, environment나 deep link로 초기 상태를 전달해요.
+
+### accessibility identifier와 label은 어떻게 다른가요?
+
+identifier는 automation에서 element identity를 안정적으로 찾기 위한 값이고 보통 사용자에게 읽히지 않아요. label은 VoiceOver 등 보조 기술이 사용자에게 element 의미를 설명하는 localized text예요.
+
+### UI test에서 `sleep`을 피하는 이유는 무엇인가요?
+
+고정 시간보다 작업이 빠르면 시간을 낭비하고 느리면 실패하기 때문이에요. `waitForExistence`처럼 실제 완료 조건을 기다리면 필요한 만큼만 기다리고 실패 원인도 명확해져요.
+
+### Page Object에 assertion을 넣어도 되나요?
+
+공통 invariant라면 일부 넣을 수 있지만 사용자 scenario의 핵심 기대는 test에 남기는 편이 좋아요. Page Object는 selector와 gesture 세부 사항을 숨기고 test는 어떤 행동을 보장하는지 표현해야 해요.
+
+### 모든 기능을 UI test로 검증하지 않는 이유는 무엇인가요?
+
+app launch와 OS interaction 때문에 느리고 실패 원인이 넓어요. 계산과 branch는 빠른 unit test로 많이 검증하고 UI test는 실제 연결을 보장할 핵심 workflow에 집중해야 feedback 속도와 신뢰성을 함께 유지할 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer — Testing](https://developer.apple.com/documentation/xcode/testing)
+- [Apple Developer — Adding tests to your Xcode project](https://developer.apple.com/documentation/xcode/adding-tests-to-your-xcode-project)
+- [Apple Developer — XCUIApplication](https://developer.apple.com/documentation/xcuiautomation/xcuiapplication)
+- [Apple Developer — XCUIElement](https://developer.apple.com/documentation/xcuiautomation/xcuielement)
+- [Apple Developer — XCUIElementAttributes](https://developer.apple.com/documentation/xcuiautomation/xcuielementattributes)
+- [Apple Developer — Handling UI Interruptions](https://developer.apple.com/documentation/xctest/handling-ui-interruptions)
+- [Apple Developer — Performing accessibility audits for your app](https://developer.apple.com/documentation/accessibility/performing-accessibility-audits-for-your-app)
+- [Apple Developer — Record, replay, and review: UI automation with Xcode](https://developer.apple.com/videos/play/wwdc2025/344/)
+- [Apple Developer — Improving code assessment by organizing tests into test plans](https://developer.apple.com/documentation/xcode/organizing-tests-to-improve-feedback)
+- [Swift-KR — Swift로 이해하는 XCTest 단위 테스트](./xctest-unit-testing)
+- [Swift-KR — Swift로 이해하는 Swift Testing](./swift-testing)

--- a/docs/guide/uikit/collection-views/_meta.json
+++ b/docs/guide/uikit/collection-views/_meta.json
@@ -23,6 +23,11 @@
       },
       {
         "type": "custom-link",
+        "label": "DifferenceKit",
+        "link": "/guide/uikit/collection-views/differencekit"
+      },
+      {
+        "type": "custom-link",
         "label": "셀과 재사용 뷰",
         "link": "/guide/uikit/collection-views/cells-and-reusable-views"
       },

--- a/docs/guide/uikit/collection-views/data.md
+++ b/docs/guide/uikit/collection-views/data.md
@@ -286,6 +286,8 @@ section snapshot은 다음 정보를 관리해요.
 
 diffable data source를 사용한다고 모델 계층이 자동으로 설계되지는 않아요. 앱이 데이터 변경을 감지하고 backing store와 snapshot을 만드는 책임은 여전히 가져요.
 
+기존 `UICollectionViewDataSource`를 유지하면서 모델의 정체성과 내용 변경을 나눠 계산하고 싶다면 외부 diff 라이브러리도 선택지가 될 수 있어요. [DifferenceKit 학습 문서](./differencekit)에서 `Differentiable`, `StagedChangeset`, Swift `CollectionDifference`, UIKit diffable data source의 차이를 비교해요.
+
 ## prefetching은 곧 보일 데이터를 미리 준비해요
 
 이미지 디코딩이나 네트워크 요청이 셀이 나타난 뒤 시작되면 빠르게 스크롤할 때 빈 이미지가 보일 수 있어요. `UICollectionViewDataSourcePrefetching`은 곧 필요할 가능성이 있는 index path를 미리 알려 줘요.

--- a/docs/guide/uikit/collection-views/differencekit.md
+++ b/docs/guide/uikit/collection-views/differencekit.md
@@ -1,0 +1,580 @@
+---
+title: Swift로 이해하는 DifferenceKit
+description: DifferenceKit의 Differentiable과 StagedChangeset을 이해하고 Swift 핵심 프로토콜, CollectionDifference, UIKit diffable data source와 비교합니다.
+---
+
+# Swift로 이해하는 DifferenceKit
+
+> **면접 답변 한 줄 요약:** DifferenceKit은 모델의 안정적인 식별자와 표시 내용의 동등성을 분리해 선형·section 컬렉션의 삽입, 삭제, 이동, 갱신을 계산하고, 위험한 UIKit batch update를 여러 안전한 단계로 나누는 Swift 오픈소스 라이브러리예요.
+
+`UICollectionView`의 데이터가 바뀌면 새 배열을 화면에 반영해야 해요. `reloadData()`는 간단하지만 어떤 item이 이동하거나 내용만 바뀌었는지 표현하지 못해요. 반대로 `deleteItems`, `insertItems`, `moveItem`, `reloadItems`를 직접 호출하면 모델과 화면의 개수 및 순서를 정확히 맞춰야 해요.
+
+[DifferenceKit](https://github.com/ra1028/DifferenceKit)은 두 컬렉션의 차이를 계산하고 UIKit의 batch update에 적용하는 과정을 도와줘요. 이 문서는 2026년 8월에 확인한 최신 공개 릴리스 `1.3.0`을 기준으로 해요. 이 릴리스는 2022년 6월에 게시되었으므로 새 프로젝트에서는 아래의 대안과 유지보수 상태도 함께 판단해야 해요.
+
+이 문서에서는 다음 내용을 살펴봐요.
+
+- DifferenceKit이 해결하는 Collection View 갱신 문제
+- `Differentiable`, `ContentIdentifiable`, `ContentEquatable`의 관계
+- `Equatable`, `Hashable`, `Identifiable`과 다른 점
+- `StagedChangeset`을 `UICollectionView`에 적용하는 방법
+- Swift `CollectionDifference`, UIKit diffable data source와의 차이
+- 오래된 배포 대상과 새 프로젝트에서 선택하는 기준
+
+## 먼저 알아둘 diff 용어
+
+| 용어                          | 쉬운 뜻                                                                                                                                         |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| diff                          | 이전 상태와 새 상태 사이에서 무엇이 삽입, 삭제, 이동 또는 변경되었는지 나타내는 차이예요.                                                       |
+| identity, 정체성              | 순서나 내용이 바뀌어도 같은 item인지 판단하는 기준이에요. 서버 ID나 UUID처럼 안정적인 값을 사용해요.                                            |
+| content equality, 내용 동등성 | 정체성이 같은 두 item의 화면에 표시할 내용도 같은지 판단하는 기준이에요.                                                                        |
+| changeset                     | 한 상태에서 다음 상태로 가기 위한 삽입, 삭제, 이동, 갱신 작업과 그 단계의 데이터를 묶은 값이에요.                                               |
+| batch update                  | 여러 Collection View 변경을 한 번에 적용해 일관된 애니메이션으로 보여 주는 갱신 방식이에요.                                                     |
+| stage                         | 동시에 적용하면 충돌할 수 있는 변경을 나누어 순서대로 실행하는 한 단계예요.                                                                     |
+| sectioned collection          | section과 그 안의 item으로 이루어진 2차원 컬렉션이에요.                                                                                         |
+| Heckel algorithm              | 값의 등장 정보를 이용해 두 시퀀스의 차이를 찾는 알고리즘 계열이에요. DifferenceKit은 Paul Heckel의 알고리즘을 Swift 컬렉션에 맞게 최적화했어요. |
+| diffable data source          | section과 item 식별자로 만든 snapshot을 적용하면 UIKit이 화면 차이를 처리하는 iOS 13 이후의 data source예요.                                    |
+
+## 수동 batch update는 모델과 화면을 직접 맞춰야 해요
+
+사진 목록에서 첫 item을 지우고, 새 item을 추가하며, 기존 item의 즐겨찾기 표시까지 바꾼다고 해 볼게요. 가장 단순한 방법은 배열을 교체하고 전체를 다시 불러오는 거예요.
+
+```swift
+photos = newPhotos
+collectionView.reloadData()
+```
+
+결과는 맞지만 삭제와 삽입 애니메이션이 사라지고 보이는 셀을 전부 다시 구성할 수 있어요. 세부 변경을 직접 표현하려면 다음처럼 모델 변경과 UI 명령을 맞춰야 해요.
+
+```swift
+collectionView.performBatchUpdates {
+  photos.remove(at: 0)
+  collectionView.deleteItems(
+    at: [IndexPath(item: 0, section: 0)]
+  )
+
+  photos.append(newPhoto)
+  collectionView.insertItems(
+    at: [IndexPath(item: photos.count - 1, section: 0)]
+  )
+}
+```
+
+실제 화면에서는 section 삽입과 삭제, item 이동과 갱신이 함께 일어날 수 있어요. 배열의 개수와 Collection View가 예상하는 개수가 한 순간이라도 다르거나 각 작업이 참조하는 이전·이후 위치를 혼동하면 내부 일관성 오류가 발생할 수 있어요.
+
+DifferenceKit은 호출자가 각 `IndexPath`를 직접 계산하는 대신 **이전 컬렉션과 목표 컬렉션**을 전달하게 해요.
+
+```text
+이전 모델 + 목표 모델
+        │
+        ▼
+DifferenceKit이 diff 계산
+        │
+        ▼
+StagedChangeset
+        │
+        ▼
+각 단계의 모델을 동기적으로 교체하며 UICollectionView 갱신
+```
+
+## DifferenceKit은 식별과 내용 비교를 분리해요
+
+DifferenceKit `1.3.0`의 소스에서 `Differentiable`은 독립적인 protocol 선언이 아니라 두 protocol을 합친 typealias예요. 개념만 남겨 단순화하면 다음과 같은 관계예요.
+
+```swift
+typealias Differentiable =
+  ContentIdentifiable & ContentEquatable
+
+protocol ContentIdentifiable {
+  associatedtype DifferenceIdentifier: Hashable
+  var differenceIdentifier: DifferenceIdentifier { get }
+}
+
+protocol ContentEquatable {
+  func isContentEqual(to source: Self) -> Bool
+}
+```
+
+두 요구사항은 서로 다른 질문에 답해요.
+
+1. `differenceIdentifier`는 “이전과 이후의 값이 같은 item인가요?”에 답해요.
+2. `isContentEqual(to:)`는 “같은 item의 표시 내용도 그대로인가요?”에 답해요.
+
+사진 모델에 적용해 볼게요.
+
+```swift
+import DifferenceKit
+import Foundation
+
+struct Photo: Identifiable, Equatable, Differentiable {
+  let id: UUID
+  var title: String
+  var isFavorite: Bool
+
+  var differenceIdentifier: UUID {
+    id
+  }
+
+  func isContentEqual(to source: Photo) -> Bool {
+    title == source.title &&
+      isFavorite == source.isFavorite
+  }
+}
+```
+
+`id`가 같다면 순서가 달라져도 같은 사진이에요. 같은 사진의 `title`이나 `isFavorite`가 달라지면 삭제 후 삽입이 아니라 내용 갱신 후보가 돼요.
+
+`isContentEqual`에서 `id`를 다시 비교할 필요는 없어요. 이 메서드는 diff 알고리즘이 이미 같은 `differenceIdentifier`로 연결한 두 값의 내용을 비교할 때 사용하기 때문이에요. 화면에 영향을 주는 프로퍼티를 빠뜨리면 모델은 바뀌었는데 셀이 갱신되지 않을 수 있어요.
+
+### 전체 모델을 식별자로 사용하지 않아요
+
+`Hashable` 타입에는 `differenceIdentifier`의 기본 구현이 제공되므로 아래 코드도 가능해요.
+
+```swift
+struct Photo: Hashable, Differentiable {
+  let id: UUID
+  var title: String
+  var isFavorite: Bool
+}
+```
+
+하지만 합성된 `Hashable`은 세 프로퍼티를 모두 사용해요. 즐겨찾기만 바뀌어도 이전 값과 새 값의 식별자가 달라져 같은 사진의 내용 갱신이 아니라 삭제와 삽입으로 해석될 수 있어요.
+
+바뀔 수 있는 모델에는 안정적인 식별자를 명시하는 편이 안전해요.
+
+```swift
+var differenceIdentifier: UUID { id }
+```
+
+문자열 상수처럼 값 자체가 곧 정체성이고 내용도 변하지 않는 타입에는 기본 구현이 편리해요.
+
+```swift
+extension String: Differentiable {}
+```
+
+## Swift 핵심 프로토콜과 역할이 달라요
+
+DifferenceKit의 이름은 Swift 표준 프로토콜과 비슷하지만 계약의 범위가 달라요.
+
+| 계약                                                  | 답하는 질문                                             | DifferenceKit에서의 관계                                                                                    |
+| ----------------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [`Equatable`](/guide/swift/protocols/equatable)       | 두 값 전체를 `==`로 같다고 볼 수 있나요?                | `ContentEquatable` 타입이 `Equatable`도 따르면 `==`를 사용하는 `isContentEqual` 기본 구현을 받을 수 있어요. |
+| [`Hashable`](/guide/swift/protocols/hashable)         | 같은 값을 같은 hash 입력으로 표현할 수 있나요?          | 전체 모델이 아니라 `DifferenceIdentifier`가 반드시 `Hashable`이어야 해요.                                   |
+| [`Identifiable`](/guide/swift/protocols/identifiable) | 한 값의 정체성을 `id`로 표현할 수 있나요?               | `ContentIdentifiable`과 목적이 비슷하지만 프로퍼티 이름이 `differenceIdentifier`이고 diff 계산에 사용돼요.  |
+| `ContentEquatable`                                    | 정체성이 같은 두 값의 표시 내용도 같은가요?             | 다르면 `elementUpdated` 또는 `sectionUpdated`를 만들 수 있어요.                                             |
+| `ContentIdentifiable`                                 | diff 계산에서 같은 item으로 연결할 식별자는 무엇인가요? | `DifferenceIdentifier: Hashable`과 `differenceIdentifier`를 요구해요.                                       |
+| `Differentiable`                                      | 식별과 내용 비교를 모두 제공하나요?                     | 앞의 두 DifferenceKit protocol을 합친 conformance 계약이에요.                                               |
+
+`Identifiable`을 이미 따르는 모델이라면 같은 `id`를 DifferenceKit에 연결할 수 있어요.
+
+```swift
+struct Photo: Identifiable, Differentiable {
+  let id: UUID
+  let title: String
+
+  var differenceIdentifier: ID { id }
+
+  func isContentEqual(to source: Photo) -> Bool {
+    title == source.title
+  }
+}
+```
+
+두 프로토콜의 식별자가 우연히 같은 값을 쓰는 것이지, `Identifiable` conformance만으로 `Differentiable`이 자동 충족되지는 않아요. DifferenceKit은 내용 비교까지 필요하기 때문이에요.
+
+## StagedChangeset은 이전 상태에서 목표 상태로 가는 과정을 만들어요
+
+모델을 준비했으면 두 배열로 `StagedChangeset`을 만들어요.
+
+```swift
+let before = [
+  Photo(id: firstID, title: "서울", isFavorite: false),
+  Photo(id: secondID, title: "부산", isFavorite: false),
+]
+
+let after = [
+  Photo(id: secondID, title: "부산", isFavorite: true),
+  Photo(id: thirdID, title: "제주", isFavorite: false),
+]
+
+let stagedChangeset = StagedChangeset(
+  source: before,
+  target: after
+)
+```
+
+이 예제에는 세 종류의 변화가 있어요.
+
+| 변화           | DifferenceKit의 해석                                                   |
+| -------------- | ---------------------------------------------------------------------- |
+| 서울 사진 제거 | 첫 번째 item의 `differenceIdentifier`가 목표 배열에 없으므로 삭제예요. |
+| 부산 즐겨찾기  | 식별자는 같고 `isContentEqual`이 `false`이므로 내용 갱신이에요.        |
+| 제주 사진 추가 | 새 `differenceIdentifier`가 생겼으므로 삽입이에요.                     |
+
+`StagedChangeset`은 `Changeset`의 순서 있는 컬렉션이에요. 각 `Changeset`에는 다음 단계의 `data`와 변경 위치가 함께 들어 있어요.
+
+```swift
+for changeset in stagedChangeset {
+  print(changeset.data)
+  print(changeset.elementDeleted)
+  print(changeset.elementInserted)
+  print(changeset.elementUpdated)
+  print(changeset.elementMoved)
+}
+```
+
+주요 값은 다음과 같아요.
+
+| 프로퍼티            | 의미                                                                  |
+| ------------------- | --------------------------------------------------------------------- |
+| `data`              | 해당 stage의 변경을 적용한 직후 data source가 가져야 할 컬렉션이에요. |
+| `elementDeleted`    | 삭제할 item의 `ElementPath` 목록이에요.                               |
+| `elementInserted`   | 삽입할 item의 `ElementPath` 목록이에요.                               |
+| `elementUpdated`    | 내용이 달라 다시 구성할 item의 `ElementPath` 목록이에요.              |
+| `elementMoved`      | 이전 경로와 목표 경로를 묶은 이동 목록이에요.                         |
+| `sectionDeleted` 등 | section의 삭제, 삽입, 갱신, 이동을 같은 방식으로 표현해요.            |
+
+DifferenceKit은 UIKit batch update에서 동시에 처리하기 어려운 변경 조합을 최소 stage로 나눠요. 따라서 중간 `data`는 최종 목표 배열과 다를 수 있어요. 모든 stage가 끝난 마지막 `data`가 목표 상태예요.
+
+## UICollectionView에 각 stage를 적용해요
+
+DifferenceKit은 `UICollectionView` extension으로 `reload(using:interrupt:setData:)`를 제공해요. 기존 `UICollectionViewDataSource`를 유지한 채 사용할 수 있어요.
+
+```swift
+import DifferenceKit
+import UIKit
+
+@MainActor
+final class PhotoGridViewController: UICollectionViewController {
+  private var photos: [Photo] = []
+
+  func apply(_ newPhotos: [Photo]) {
+    let changeset = StagedChangeset(
+      source: photos,
+      target: newPhotos
+    )
+
+    collectionView.reload(
+      using: changeset,
+      interrupt: { $0.changeCount > 100 }
+    ) { [weak self] data in
+      self?.photos = data
+    }
+  }
+}
+```
+
+`setData` closure에서 받은 `data`를 data source가 읽는 저장소에 **동기적으로** 대입해야 해요. extension은 각 stage마다 대략 다음 순서로 동작해요.
+
+1. `setData(changeset.data)`를 호출해 모델을 해당 stage에 맞춰요.
+2. `deleteSections`, `insertSections`, `reloadSections`, `moveSection`을 호출해요.
+3. `deleteItems`, `insertItems`, `reloadItems`, `moveItem`을 호출해요.
+4. 다음 stage로 넘어가 같은 과정을 반복해요.
+
+아래처럼 최종 배열만 나중에 대입하면 안 돼요.
+
+```swift
+// 잘못된 예: stage마다 data source가 참조하는 데이터가 바뀌지 않아요.
+collectionView.reload(using: changeset) { _ in }
+photos = newPhotos
+```
+
+Collection View는 batch update 중에도 data source에 section과 item 개수를 물어볼 수 있어요. 화면 명령은 첫 stage를 반영하는데 data source가 이전 상태나 최종 상태를 반환하면 개수가 일치하지 않아 충돌할 수 있어요.
+
+### 변경이 너무 많으면 reloadData로 전환해요
+
+수백 개의 변경을 모두 애니메이션하면 diff 계산보다 layout, 셀 구성, 애니메이션 비용이 더 커질 수 있어요. `interrupt`가 `true`를 반환하면 DifferenceKit extension은 마지막 데이터를 대입하고 `reloadData()`로 전환해요.
+
+```swift
+collectionView.reload(
+  using: changeset,
+  interrupt: { stage in
+    stage.changeCount > 100
+  }
+) { [weak self] data in
+  self?.photos = data
+}
+```
+
+`100`은 라이브러리가 정한 정답이 아니에요. 셀 복잡도, 기기 성능, layout 비용을 측정해 화면별 기준을 정해야 해요. Collection View가 window에 올라가 있지 않을 때도 extension은 마지막 데이터와 `reloadData()`를 사용하는 경로를 제공해요.
+
+## section과 item의 diff를 함께 계산해요
+
+여러 section을 사용하려면 section도 식별하고 내용을 비교할 수 있어야 해요. 직접 `DifferentiableSection`을 구현할 수도 있지만, 보통은 `ArraySection`으로 section 모델과 item 배열을 묶으면 간단해요.
+
+```swift
+struct PhotoSectionModel: Differentiable {
+  enum ID: Hashable {
+    case favorites
+    case all
+  }
+
+  let id: ID
+  let title: String
+
+  var differenceIdentifier: ID { id }
+
+  func isContentEqual(
+    to source: PhotoSectionModel
+  ) -> Bool {
+    title == source.title
+  }
+}
+
+typealias PhotoSection =
+  ArraySection<PhotoSectionModel, Photo>
+```
+
+section 배열은 다음처럼 만들어요.
+
+```swift
+let sections: [PhotoSection] = [
+  PhotoSection(
+    model: PhotoSectionModel(
+      id: .favorites,
+      title: "즐겨찾기"
+    ),
+    elements: favoritePhotos
+  ),
+  PhotoSection(
+    model: PhotoSectionModel(
+      id: .all,
+      title: "모든 사진"
+    ),
+    elements: allPhotos
+  ),
+]
+```
+
+이전 section과 새 section으로 같은 API를 사용해요.
+
+```swift
+let changeset = StagedChangeset(
+  source: currentSections,
+  target: newSections
+)
+
+collectionView.reload(using: changeset) {
+  [weak self] sections in
+  self?.currentSections = sections
+}
+```
+
+section의 `differenceIdentifier`가 같고 제목이 달라지면 `sectionUpdated`, item의 식별자는 같고 내용이 달라지면 `elementUpdated`가 될 수 있어요. `ArraySection`은 section 모델과 item 배열을 연결하지만 계층형 부모·자식 트리를 표현하는 UIKit `NSDiffableDataSourceSectionSnapshot`과는 목적이 달라요.
+
+## Swift CollectionDifference와 비교해요
+
+Swift 표준 라이브러리에는 `CollectionDifference`가 있어요. `BidirectionalCollection.difference(from:)`으로 두 컬렉션의 삽입과 삭제를 계산하고 `applying(_:)`으로 다른 컬렉션에 적용할 수 있어요.
+
+```swift
+let before = ["서울", "부산"]
+let after = ["부산", "제주"]
+
+let difference = after
+  .difference(from: before)
+  .inferringMoves()
+
+let result = before.applying(difference)
+```
+
+두 도구는 “컬렉션 차이”를 다루지만 결과의 목적이 달라요.
+
+| 기준               | Swift `CollectionDifference`                                                      | DifferenceKit `StagedChangeset`                                             |
+| ------------------ | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 소속               | Swift 표준 라이브러리                                                             | 외부 오픈소스 package                                                       |
+| 기본 입력 계약     | `Equatable` 또는 비교 closure                                                     | `Differentiable`, 즉 식별자와 내용 비교                                     |
+| 기본 변경 표현     | 삽입과 삭제                                                                       | 삽입, 삭제, 이동, 내용 갱신                                                 |
+| 이동               | `inferringMoves()`가 삭제·삽입의 연관 관계를 추론해요.                            | 식별자를 이용해 이동 정보를 계산해요.                                       |
+| section-aware diff | 한 번의 diff는 1차원 컬렉션을 다루며 중첩 section/item 의미를 별도로 알지 못해요. | `DifferentiableSection`으로 section과 item 변경을 함께 표현해요.            |
+| 중간 상태          | 하나의 완전한 차이를 표현해요.                                                    | UIKit에 적용할 수 있도록 여러 안전한 stage와 각 stage의 데이터를 제공해요.  |
+| UI 적용            | UIKit 적용 API가 없어요.                                                          | `UITableView`와 `UICollectionView` extension을 제공해요.                    |
+| diff 적용 결과     | 호환되지 않는 기반 컬렉션이면 `applying`이 `nil`을 반환해요.                      | `setData`와 UIKit batch update를 stage별로 실행해요.                        |
+| 공식 복잡도 설명   | 최악의 경우 `O(n × m)`이며 공통 원소나 `Hashable` 여부에 따라 빨라질 수 있어요.   | Heckel 기반 `O(n)`을 내세우지만 항상 가장 짧은 변경 집합을 만들지는 않아요. |
+
+`CollectionDifference`에는 “같은 ID인데 제목이 달라졌다”는 별도 내용 갱신 개념이 없어요. `Photo` 전체의 `Equatable` 결과를 사용하면 내용 변경을 삭제와 삽입으로 표현할 수 있고, ID만 비교하는 closure를 사용하면 내용 변경은 diff에 나타나지 않아요. UI의 reload 의미까지 필요하면 호출자가 별도로 계산해야 해요.
+
+undo/redo, 텍스트 줄 변경, 서버에 전달할 patch처럼 UIKit과 무관한 일반 컬렉션 차이가 필요하면 표준 `CollectionDifference`가 더 작은 선택이에요. section과 item의 내용 변경을 계산해 기존 Collection View data source에 적용하려면 DifferenceKit이 더 직접적일 수 있어요.
+
+## UIKit Diffable Data Source와 비교해요
+
+[`UICollectionViewDiffableDataSource`](./data)는 iOS 13부터 제공되는 UIKit의 기본 해법이에요. 앱은 목표 상태를 `NSDiffableDataSourceSnapshot`으로 만들고 data source에 적용해요.
+
+| 기준           | DifferenceKit                                                        | UIKit diffable data source                                                                    |
+| -------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 최소 iOS       | 공식 README 기준 iOS 9                                               | iOS 13                                                                                        |
+| data source    | 기존 `UICollectionViewDataSource`와 모델 배열을 유지해요.            | `UICollectionViewDiffableDataSource`가 data source 역할을 맡아요.                             |
+| 목표 상태 표현 | 이전·목표 모델 컬렉션으로 `StagedChangeset`을 만들어요.              | section과 item 식별자를 `NSDiffableDataSourceSnapshot`에 넣어요.                              |
+| 모델 계약      | `differenceIdentifier`와 `isContentEqual`을 제공해요.                | section과 item 식별자가 `Hashable`이어야 하고 현재 SDK에서는 `Sendable` 제약도 가져요.        |
+| 내용 갱신      | `isContentEqual`이 다르면 `elementUpdated`를 자동 계산해요.          | backing store를 바꾼 뒤 `reconfigureItems` 또는 `reloadItems`로 의도를 표시해요.              |
+| batch 적용     | 공개된 `Changeset`을 stage별 `performBatchUpdates`로 적용해요.       | snapshot을 적용하면 UIKit이 변경을 처리해요.                                                  |
+| 계층형 목록    | section과 평평한 item 컬렉션의 차이를 계산해요.                      | `NSDiffableDataSourceSectionSnapshot`으로 부모·자식 계층과 펼침 상태도 표현할 수 있어요.      |
+| 의존성         | 외부 package와 라이브러리 유지보수 상태를 관리해야 해요.             | UIKit에 포함돼 별도 의존성이 없어요.                                                          |
+| 변경 결과 검사 | 삭제, 삽입, 이동, 갱신 경로를 `Changeset`에서 직접 검사할 수 있어요. | 일반적으로 현재와 목표 snapshot을 중심으로 사용하고 UIKit 내부 diff 구현에는 의존하지 않아요. |
+
+새 화면이 iOS 13 이상만 지원하고 기존 data source 구조를 유지할 이유가 없다면 UIKit diffable data source를 먼저 검토하는 편이 자연스러워요. DifferenceKit은 다음과 같은 조건에서 여전히 의미가 있어요.
+
+- iOS 9~12를 지원해야 해요.
+- 기존 `UICollectionViewDataSource` 구조를 크게 바꾸기 어려워요.
+- UI에 적용하기 전에 명시적인 삽입, 삭제, 이동, 갱신 결과를 검사해야 해요.
+- section과 item의 내용 변경을 모델 protocol에서 일관되게 정의하고 싶어요.
+- 이미 DifferenceKit 기반 프레임워크나 사내 목록 구조를 사용하고 있어요.
+
+## 알고리즘 특성과 성능을 과장하지 않아요
+
+DifferenceKit은 Paul Heckel의 알고리즘을 바탕으로 `O(n)` diff 계산을 제공한다고 설명해요. 다만 공식 API 문서에는 두 가지 중요한 제한도 적혀 있어요.
+
+- 계산된 변경 집합이 항상 가장 짧지는 않아요.
+- 같은 식별자가 중복되면 이동은 최선 노력으로 계산하고 나머지는 삽입 또는 삭제로 처리할 수 있어요.
+
+가능하면 section과 item 식별자를 고유하게 유지하세요. 중복을 기술적으로 처리할 수 있다는 설명을 중복 식별자를 권장한다는 뜻으로 해석하면 안 돼요.
+
+공식 README의 성능 비교는 Xcode 11.1과 Swift 5.1 환경에서 측정된 오래된 결과예요. 현재 앱의 기기, Swift 버전, 데이터 크기, 셀과 layout 비용을 대표하지 않으므로 “항상 다른 도구보다 빠르다”는 근거로 사용하면 안 돼요.
+
+실제 성능은 다음 항목을 함께 측정해요.
+
+- source와 target의 item 수
+- 한 번에 발생하는 변경 수
+- section 이동과 item 이동의 비율
+- 셀 구성과 이미지 디코딩 비용
+- layout invalidation과 애니메이션 비용
+- `interrupt`로 `reloadData()`에 전환할 기준
+
+## diff 계약을 작은 테스트로 고정해요
+
+UI 없이도 모델의 식별과 내용 비교가 원하는 changeset을 만드는지 테스트할 수 있어요.
+
+```swift
+import DifferenceKit
+import Foundation
+import Testing
+
+@Test
+func samePhotoWithChangedContentBecomesUpdate() {
+  let id = UUID()
+  let before = [
+    Photo(id: id, title: "서울", isFavorite: false),
+  ]
+  let after = [
+    Photo(id: id, title: "서울", isFavorite: true),
+  ]
+
+  let staged = StagedChangeset(
+    source: before,
+    target: after
+  )
+
+  let updates = staged.flatMap(\.elementUpdated)
+
+  #expect(
+    updates.contains(
+      ElementPath(element: 0, section: 0)
+    )
+  )
+  #expect(staged.last?.data == after)
+}
+```
+
+이 테스트가 실패한다면 다음을 확인해요.
+
+1. `differenceIdentifier`가 내용과 함께 바뀌지 않았나요?
+2. `isContentEqual`이 화면에 표시하는 모든 값을 비교하나요?
+3. 서로 다른 item이 같은 식별자를 공유하지 않나요?
+4. section 모델에도 같은 문제가 있지 않나요?
+
+UIKit 통합 테스트에서는 변경 후 item 수와 보이는 셀뿐 아니라 `setData`가 각 stage에서 동기적으로 호출되는 구조인지도 확인해야 해요.
+
+## 언제 사용해야 하나요
+
+DifferenceKit을 사용하기 좋은 경우는 다음과 같아요.
+
+- 오래된 iOS를 지원하면서 Collection View의 세부 애니메이션이 필요해요.
+- 수동 `performBatchUpdates`의 위치 계산과 일관성 오류를 줄이고 싶어요.
+- 정체성과 내용 변경을 분리한 모델 계약이 필요해요.
+- section과 item의 diff 결과를 UIKit 밖에서도 검사하거나 테스트하고 싶어요.
+- 기존 data source와 셀 제공 구조는 유지하고 diff 계층만 교체하고 싶어요.
+
+다음 조건에서는 도입하지 않아도 돼요.
+
+- item이 거의 바뀌지 않는 작은 목록이라 `reloadData()`로 충분해요.
+- iOS 13 이상만 지원하며 UIKit diffable data source가 요구사항을 충족해요.
+- 단순한 컬렉션 patch만 필요해 표준 `CollectionDifference`로 충분해요.
+- 외부 의존성의 릴리스 주기와 Swift 버전 호환성을 관리하기 어려워요.
+- 계층형 outline을 UIKit section snapshot으로 직접 표현해야 해요.
+
+최신 공개 릴리스가 오래되었다는 사실만으로 기존 사용처를 즉시 제거할 필요는 없어요. 반대로 과거 성능 수치만 보고 새 프로젝트에 자동 채택해서도 안 돼요. 현재 배포 대상, 필요한 변경 의미, 유지보수 비용을 함께 비교하세요.
+
+## Swift Package Manager로 설치해요
+
+재현 가능한 예제를 위해 현재 최신 릴리스 `1.3.0`을 고정하면 다음과 같아요.
+
+```swift
+dependencies: [
+  .package(
+    url: "https://github.com/ra1028/DifferenceKit.git",
+    exact: "1.3.0"
+  ),
+]
+```
+
+앱 target에는 product를 연결해요.
+
+```swift
+.target(
+  name: "PhotoApp",
+  dependencies: [
+    .product(
+      name: "DifferenceKit",
+      package: "DifferenceKit"
+    ),
+  ]
+)
+```
+
+Xcode의 Package Dependencies 화면에서 저장소 URL을 추가할 수도 있어요. 실제 프로젝트에서는 새 버전이나 fork를 선택하기 전에 release, commit, issue, Swift toolchain 호환성을 다시 확인하세요.
+
+## 적용 순서를 정리해요
+
+1. 기존 data source가 참조하는 section과 item 저장소를 찾아요.
+2. 각 모델에서 위치나 표시 내용과 무관한 안정적인 식별자를 정해요.
+3. `differenceIdentifier`와 `isContentEqual`을 각각 구현해요.
+4. 식별자 중복과 빠진 내용 프로퍼티를 단위 테스트로 확인해요.
+5. 이전·목표 컬렉션으로 `StagedChangeset`을 만들어요.
+6. `reload(using:)`의 `setData`에서 stage 데이터를 동기적으로 저장해요.
+7. 삽입, 삭제, 이동, 내용 갱신, section 변경을 각각 검증해요.
+8. 대량 변경을 측정하고 필요하면 `interrupt` 기준을 정해요.
+9. 배포 대상이 올라가면 UIKit diffable data source로 단순화할 이점도 다시 검토해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### DifferenceKit의 `Differentiable`과 Swift `Identifiable`은 무엇이 다른가요?
+
+`Identifiable`은 값의 정체성을 `id`로 표현하는 표준 protocol이에요. DifferenceKit의 `Differentiable`은 diff에 사용할 식별자뿐 아니라 정체성이 같은 두 값의 내용이 같은지 비교하는 계약까지 합쳐, 이동과 내용 갱신을 구분해요.
+
+### 왜 `setData`에서 stage 데이터를 즉시 저장해야 하나요?
+
+Collection View는 각 batch update 중 data source의 section과 item 개수를 다시 조회할 수 있기 때문이에요. 화면에 적용하는 변경과 모델이 서로 다른 stage를 가리키면 내부 일관성 오류가 발생할 수 있으므로, 각 `Changeset.data`를 동기적으로 반영해야 해요.
+
+### `CollectionDifference` 대신 DifferenceKit이 필요한 경우는 언제인가요?
+
+표준 `CollectionDifference`는 일반 컬렉션의 삽입과 삭제를 표현하고 적용하는 데 적합해요. section과 item의 내용 갱신, 명시적인 이동, UIKit에서 안전하게 실행할 중간 stage와 적용 extension까지 필요하면 DifferenceKit이 더 직접적인 도구가 될 수 있어요.
+
+### 새 Collection View에도 DifferenceKit을 먼저 선택해야 하나요?
+
+그렇지는 않아요. iOS 13 이상이라면 별도 의존성이 없고 snapshot과 계층형 section을 지원하는 UIKit diffable data source를 먼저 검토하고, 오래된 배포 대상, 기존 data source 유지, 명시적인 changeset 같은 요구가 있을 때 DifferenceKit을 선택해요.
+
+### `O(n)`이면 항상 `CollectionDifference`보다 빠른가요?
+
+아니요. 점근적 복잡도는 입력이 커질 때 연산량이 증가하는 모양을 설명할 뿐 실제 앱의 상수 비용, 변경 분포, 셀 구성, layout과 애니메이션 비용까지 보장하지 않아요. DifferenceKit의 공개 benchmark도 오래된 도구 환경에서 측정되었으므로 현재 앱 데이터로 다시 측정해야 해요.
+
+## 참고 자료
+
+- [DifferenceKit 공식 저장소](https://github.com/ra1028/DifferenceKit)
+- [DifferenceKit 1.3.0 릴리스](https://github.com/ra1028/DifferenceKit/releases/tag/1.3.0)
+- [DifferenceKit — ContentIdentifiable.swift](https://github.com/ra1028/DifferenceKit/blob/1.3.0/Sources/ContentIdentifiable.swift)
+- [DifferenceKit — ContentEquatable.swift](https://github.com/ra1028/DifferenceKit/blob/1.3.0/Sources/ContentEquatable.swift)
+- [DifferenceKit — Differentiable.swift](https://github.com/ra1028/DifferenceKit/blob/1.3.0/Sources/Differentiable.swift)
+- [DifferenceKit — StagedChangeset](https://ra1028.github.io/DifferenceKit/Structs/StagedChangeset.html)
+- [DifferenceKit — UICollectionView extension](https://ra1028.github.io/DifferenceKit/Extensions/UICollectionView.html)
+- [Apple Developer — CollectionDifference](https://developer.apple.com/documentation/swift/collectiondifference)
+- [Swift Evolution SE-0240 — Ordered Collection Diffing](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0240-ordered-collection-diffing.md)
+- [Apple Developer — NSDiffableDataSourceSnapshot](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot-swift.struct)
+- [Apple Developer — Updating collection views using diffable data sources](https://developer.apple.com/documentation/uikit/updating-collection-views-using-diffable-data-sources)

--- a/docs/guide/uikit/collection-views/differencekit.md
+++ b/docs/guide/uikit/collection-views/differencekit.md
@@ -1,6 +1,6 @@
 ---
 title: Swift로 이해하는 DifferenceKit
-description: DifferenceKit의 Differentiable과 StagedChangeset을 이해하고 Swift 핵심 프로토콜, CollectionDifference, UIKit diffable data source와 비교합니다.
+description: DifferenceKit의 Differentiable과 StagedChangeset을 이해하고 CollectionDifference·difference(from:)의 기능과 시간 복잡도, UIKit 갱신 방식을 비교합니다.
 ---
 
 # Swift로 이해하는 DifferenceKit
@@ -17,7 +17,9 @@ description: DifferenceKit의 Differentiable과 StagedChangeset을 이해하고 
 - `Differentiable`, `ContentIdentifiable`, `ContentEquatable`의 관계
 - `Equatable`, `Hashable`, `Identifiable`과 다른 점
 - `StagedChangeset`을 `UICollectionView`에 적용하는 방법
-- Swift `CollectionDifference`, UIKit diffable data source와의 차이
+- Swift `difference(from:)`, DifferenceKit diff의 시간 복잡도와 차이
+- `reloadData()`와 부분 batch update를 선택하는 기준
+- UIKit diffable data source와의 차이
 - 오래된 배포 대상과 새 프로젝트에서 선택하는 기준
 
 ## 먼저 알아둘 diff 용어
@@ -365,30 +367,162 @@ section의 `differenceIdentifier`가 같고 제목이 달라지면 `sectionUpdat
 
 Swift 표준 라이브러리에는 `CollectionDifference`가 있어요. `BidirectionalCollection.difference(from:)`으로 두 컬렉션의 삽입과 삭제를 계산하고 `applying(_:)`으로 다른 컬렉션에 적용할 수 있어요.
 
+### difference(from:)은 이전 상태를 목표 상태로 바꾸는 차이를 만들어요
+
+호출 방향을 먼저 읽어야 해요. `after.difference(from: before)`는 `before`가 `after`가 되기 위해 필요한 차이를 반환해요.
+
 ```swift
-let before = ["서울", "부산"]
-let after = ["부산", "제주"]
+let before = [1, 2, 3, 4]
+let after = [1, 3, 4, 5]
+
+let difference = after.difference(from: before)
+```
+
+결과에는 이전 배열의 offset `1`에 있는 `2`를 제거하고, 최종 배열의 offset `3`에 `5`를 삽입하라는 정보가 들어 있어요.
+
+```swift
+for change in difference {
+  switch change {
+  case let .remove(offset, element, _):
+    print("\(offset)의 \(element)를 제거해요")
+
+  case let .insert(offset, element, _):
+    print("\(offset)에 \(element)를 삽입해요")
+  }
+}
+```
+
+`CollectionDifference.Change`는 기본적으로 `insert`와 `remove` 두 case를 가져요. `remove`의 offset은 이전 상태를 기준으로 하고 `insert`의 offset은 모든 변경이 끝난 최종 상태를 기준으로 해요.
+
+계산한 차이는 원래 컬렉션에 적용할 수도 있어요.
+
+```swift
+let result = before.applying(difference)
+
+print(result == after) // true
+```
+
+`applying(_:)`의 결과가 optional인 이유는 diff를 만든 기반 상태와 적용할 컬렉션이 호환되지 않을 수 있기 때문이에요.
+
+[difference(from:)와 applying(_:)을 설명한 글](https://jeong9216.tistory.com/716)도 이전 배열이 새 배열로 바뀌기 위해 필요한 삽입과 삭제를 읽고, 그 차이를 원본에 적용하는 흐름을 작은 정수 배열로 보여 줘요. 이 아이디어는 목록 전체를 무조건 다시 적재하지 않고 바뀐 위치만 갱신하는 출발점이 돼요.
+
+### 이동은 별도로 추론해요
+
+`difference(from:)`은 기본적으로 이동을 추론하지 않아요. 같은 값이 한 번 삭제되고 다른 위치에 한 번 삽입되었다면 `inferringMoves()`로 두 변경의 연관 관계를 만들 수 있어요.
+
+```swift
+let before = ["서울", "부산", "제주"]
+let after = ["제주", "서울", "부산"]
 
 let difference = after
   .difference(from: before)
   .inferringMoves()
-
-let result = before.applying(difference)
 ```
+
+이동이 독립적인 `move` case로 바뀌는 것은 아니에요. 연결된 `remove`와 `insert`의 `associatedWith` offset이 서로를 가리켜요. UI에서 이동 애니메이션을 사용하려면 호출자가 이 연결을 읽어 `moveItem`이나 `moveRow`로 변환해야 해요.
+
+### difference(from:)의 시간 복잡도를 나눠 봐요
+
+기호를 먼저 정할게요.
+
+- `N`은 목표 컬렉션인 `after.count`예요.
+- `M`은 이전 컬렉션인 `before.count`예요.
+- `C`는 계산된 삽입과 삭제의 전체 개수예요.
+
+Swift 공식 문서와 SE-0240에 공개된 복잡도는 다음과 같아요.
+
+| 작업                          | 공개된 시간 복잡도 | 의미                                                                               |
+| ----------------------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| `difference(from:by:)`        | 최악 `O(N × M)`    | 두 컬렉션에 공통 원소가 많으면 더 빠른 실행을 기대할 수 있어요.                    |
+| `difference(from:)`           | 최악 `O(N × M)`    | 공통 원소가 많거나 `Element`가 `Hashable`이면 더 빠를 수 있어요.                   |
+| `inferringMoves()`            | `O(C)`             | `Element: Hashable`일 때 이미 계산한 diff의 변경 수에 선형으로 이동 관계를 찾아요. |
+| `before.applying(difference)` | `O(M + C)`         | 기반 컬렉션 크기와 적용할 변경 수에 비례해 새 컬렉션을 만들어요.                   |
+
+최악 `O(N × M)`은 두 입력을 곱한 만큼의 작업이 항상 발생한다는 뜻이 아니에요. 공통 값이 많은 일반적인 입력에서는 더 빨라질 수 있지만, 공개 API가 보장하는 최악의 상한은 이차 시간이에요. Swift 표준 API 문서는 구체 구현 알고리즘의 이름보다 이 복잡도와 결과 계약을 공개하므로, 특정 내부 알고리즘이 영원히 유지된다고 가정하지 않는 편이 안전해요.
+
+### DifferenceKit은 입력 크기에 선형인 diff를 제공해요
+
+DifferenceKit의 `StagedChangeset(source:target:)` 공식 문서는 Paul Heckel의 diff 알고리즘을 바탕으로 `O(n)`에 변경을 계산한다고 설명해요. 이 문서에서는 전체 입력 크기를 `L`이라고 부를게요. 선형 컬렉션에서는 `L = N + M`이고, section 컬렉션에서는 이전·목표 상태의 모든 section과 item을 합친 크기예요.
+
+| 작업                                  | 공개된 시간 복잡도 | 함께 알아둘 점                                                                                |
+| ------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------- |
+| 선형 컬렉션 `StagedChangeset` 생성    | `O(L)`             | 식별자로 item을 연결하고 삽입, 삭제, 이동, 내용 갱신을 계산해요.                              |
+| section 컬렉션 `StagedChangeset` 생성 | `O(L)`             | section과 그 안의 item 변경을 계산하고 UIKit에 적용할 stage도 만들어요.                       |
+| `collectionView.reload(using:)` 적용  | 별도 Big-O 미공개  | 각 stage의 변경 경로를 실행하며 셀 구성, layout, animation 비용은 Collection View가 부담해요. |
+
+선형 시간의 대가도 있어요. DifferenceKit 공식 문서는 결과가 항상 가장 짧은 변경 집합은 아니며, 같은 식별자가 중복되면 이동을 최선 노력으로 처리한다고 밝혀요. 따라서 `O(L)`만 보고 결과 품질과 실제 화면 비용까지 우월하다고 결론 내리면 안 돼요.
+
+### 두 diff pipeline의 계산 비용을 비교해요
+
+복잡도 차이를 한 흐름으로 보면 다음과 같아요.
+
+```text
+Swift 표준 방식
+difference(from:) 최악 O(N × M)
+  + 선택적인 move 추론 O(C)
+  + 앱이 UIKit 변경 명령으로 변환하고 적용하는 비용
+
+DifferenceKit 방식
+StagedChangeset 생성 O(L)
+  + 안전한 stage별 UIKit batch update 비용
+```
+
+두 Big-O는 **diff를 계산하는 시간**을 비교해요. 실제 사용자가 느끼는 전체 시간에는 셀 구성, Auto Layout, 이미지 처리, layout invalidation, animation까지 들어가므로 `O(L)`이라는 이유만으로 화면이 언제나 더 빠르다고 보장할 수는 없어요.
+
+### 변경이 적으면 부분 갱신이 reloadData보다 효율적일 수 있어요
+
+제시한 글의 실전 요점처럼, 계산한 diff로 `UITableView`나 `UICollectionView`의 바뀐 위치만 갱신하면 매번 `reloadData()`로 전체 목록을 다시 적재하도록 알리는 것보다 효율적일 수 있어요. 특히 전체 item 수에 비해 변경 수 `C`가 작고 셀 구성이 비쌀 때 이점이 커져요.
+
+아래 코드는 **단일 section의 삽입과 삭제만 있는 경우** `CollectionDifference`를 batch update로 옮기는 최소 예제예요.
+
+```swift
+let difference = after.difference(from: before)
+
+let deletedPaths = difference.removals.compactMap {
+  change -> IndexPath? in
+  guard case let .remove(offset, _, _) = change else {
+    return nil
+  }
+  return IndexPath(item: offset, section: 0)
+}
+
+let insertedPaths = difference.insertions.compactMap {
+  change -> IndexPath? in
+  guard case let .insert(offset, _, _) = change else {
+    return nil
+  }
+  return IndexPath(item: offset, section: 0)
+}
+
+items = after
+
+collectionView.performBatchUpdates {
+  collectionView.deleteItems(at: deletedPaths)
+  collectionView.insertItems(at: insertedPaths)
+}
+```
+
+`difference(from:)`만 호출한다고 Table View나 Collection View가 자동으로 갱신되지는 않아요. 앱이 결과를 UIKit 명령으로 변환하고 data source 상태를 정확히 맞춰야 해요. section 변경, 이동, 내용 갱신이 섞이면 이 코드는 충분하지 않으며, 잘못된 조합은 batch update 충돌을 만들 수 있어요.
+
+DifferenceKit은 이 빈 공간을 채워요. `Changeset`에 item·section의 삽입, 삭제, 이동, 갱신을 담고 `StagedChangeset`으로 위험한 조합을 나눈 뒤 `reload(using:)` extension으로 적용해요.
+
+반대로 대부분의 item이 한꺼번에 바뀌면 diff 계산과 많은 애니메이션을 추가하는 것이 `reloadData()`보다 비쌀 수 있어요. DifferenceKit이 `interrupt` closure로 변경 수가 큰 stage를 전체 reload로 전환할 수 있게 한 이유예요.
+
+### 기능과 목적을 한눈에 비교해요
 
 두 도구는 “컬렉션 차이”를 다루지만 결과의 목적이 달라요.
 
-| 기준               | Swift `CollectionDifference`                                                      | DifferenceKit `StagedChangeset`                                             |
-| ------------------ | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| 소속               | Swift 표준 라이브러리                                                             | 외부 오픈소스 package                                                       |
-| 기본 입력 계약     | `Equatable` 또는 비교 closure                                                     | `Differentiable`, 즉 식별자와 내용 비교                                     |
-| 기본 변경 표현     | 삽입과 삭제                                                                       | 삽입, 삭제, 이동, 내용 갱신                                                 |
-| 이동               | `inferringMoves()`가 삭제·삽입의 연관 관계를 추론해요.                            | 식별자를 이용해 이동 정보를 계산해요.                                       |
-| section-aware diff | 한 번의 diff는 1차원 컬렉션을 다루며 중첩 section/item 의미를 별도로 알지 못해요. | `DifferentiableSection`으로 section과 item 변경을 함께 표현해요.            |
-| 중간 상태          | 하나의 완전한 차이를 표현해요.                                                    | UIKit에 적용할 수 있도록 여러 안전한 stage와 각 stage의 데이터를 제공해요.  |
-| UI 적용            | UIKit 적용 API가 없어요.                                                          | `UITableView`와 `UICollectionView` extension을 제공해요.                    |
-| diff 적용 결과     | 호환되지 않는 기반 컬렉션이면 `applying`이 `nil`을 반환해요.                      | `setData`와 UIKit batch update를 stage별로 실행해요.                        |
-| 공식 복잡도 설명   | 최악의 경우 `O(n × m)`이며 공통 원소나 `Hashable` 여부에 따라 빨라질 수 있어요.   | Heckel 기반 `O(n)`을 내세우지만 항상 가장 짧은 변경 집합을 만들지는 않아요. |
+| 기준               | Swift `CollectionDifference`                                                      | DifferenceKit `StagedChangeset`                                            |
+| ------------------ | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 소속               | Swift 표준 라이브러리                                                             | 외부 오픈소스 package                                                      |
+| 기본 입력 계약     | `Equatable` 또는 비교 closure                                                     | `Differentiable`, 즉 식별자와 내용 비교                                    |
+| 기본 변경 표현     | 삽입과 삭제                                                                       | 삽입, 삭제, 이동, 내용 갱신                                                |
+| 이동               | `inferringMoves()`가 삭제·삽입의 연관 관계를 추론해요.                            | 식별자를 이용해 이동 정보를 계산해요.                                      |
+| section-aware diff | 한 번의 diff는 1차원 컬렉션을 다루며 중첩 section/item 의미를 별도로 알지 못해요. | `DifferentiableSection`으로 section과 item 변경을 함께 표현해요.           |
+| 중간 상태          | 하나의 완전한 차이를 표현해요.                                                    | UIKit에 적용할 수 있도록 여러 안전한 stage와 각 stage의 데이터를 제공해요. |
+| UI 적용            | UIKit 적용 API가 없어요.                                                          | `UITableView`와 `UICollectionView` extension을 제공해요.                   |
+| diff 적용 결과     | 호환되지 않는 기반 컬렉션이면 `applying`이 `nil`을 반환해요.                      | `setData`와 UIKit batch update를 stage별로 실행해요.                       |
+| diff 계산 복잡도   | 최악 `O(N × M)`, 공통 값이 많거나 `Hashable`이면 더 빠를 수 있어요.               | Heckel 기반 `O(L)`, 항상 가장 짧은 변경 집합을 보장하지는 않아요.          |
 
 `CollectionDifference`에는 “같은 ID인데 제목이 달라졌다”는 별도 내용 갱신 개념이 없어요. `Photo` 전체의 `Equatable` 결과를 사용하면 내용 변경을 삭제와 삽입으로 표현할 수 있고, ID만 비교하는 closure를 사용하면 내용 변경은 diff에 나타나지 않아요. UI의 reload 의미까지 필요하면 호출자가 별도로 계산해야 해요.
 
@@ -418,7 +552,7 @@ undo/redo, 텍스트 줄 변경, 서버에 전달할 patch처럼 UIKit과 무관
 - section과 item의 내용 변경을 모델 protocol에서 일관되게 정의하고 싶어요.
 - 이미 DifferenceKit 기반 프레임워크나 사내 목록 구조를 사용하고 있어요.
 
-## 알고리즘 특성과 성능을 과장하지 않아요
+## 실제 화면 성능은 diff 복잡도만으로 결정되지 않아요
 
 DifferenceKit은 Paul Heckel의 알고리즘을 바탕으로 `O(n)` diff 계산을 제공한다고 설명해요. 다만 공식 API 문서에는 두 가지 중요한 제한도 적혀 있어요.
 
@@ -428,6 +562,8 @@ DifferenceKit은 Paul Heckel의 알고리즘을 바탕으로 `O(n)` diff 계산�
 가능하면 section과 item 식별자를 고유하게 유지하세요. 중복을 기술적으로 처리할 수 있다는 설명을 중복 식별자를 권장한다는 뜻으로 해석하면 안 돼요.
 
 공식 README의 성능 비교는 Xcode 11.1과 Swift 5.1 환경에서 측정된 오래된 결과예요. 현재 앱의 기기, Swift 버전, 데이터 크기, 셀과 layout 비용을 대표하지 않으므로 “항상 다른 도구보다 빠르다”는 근거로 사용하면 안 돼요.
+
+같은 이유로 `difference(from:)`의 최악 `O(N × M)`만 보고 표준 API가 실제 화면에서 항상 느리다고 단정할 수도 없어요. 공통 값이 많은 입력은 더 빠를 수 있고, 작은 목록에서는 외부 package와 모델 conformance를 추가하는 비용이 더 클 수 있어요.
 
 실제 성능은 다음 항목을 함께 측정해요.
 
@@ -561,9 +697,9 @@ Collection View는 각 batch update 중 data source의 section과 item 개수를
 
 그렇지는 않아요. iOS 13 이상이라면 별도 의존성이 없고 snapshot과 계층형 section을 지원하는 UIKit diffable data source를 먼저 검토하고, 오래된 배포 대상, 기존 data source 유지, 명시적인 changeset 같은 요구가 있을 때 DifferenceKit을 선택해요.
 
-### `O(n)`이면 항상 `CollectionDifference`보다 빠른가요?
+### `difference(from:)`과 DifferenceKit의 시간 복잡도는 어떻게 다른가요?
 
-아니요. 점근적 복잡도는 입력이 커질 때 연산량이 증가하는 모양을 설명할 뿐 실제 앱의 상수 비용, 변경 분포, 셀 구성, layout과 애니메이션 비용까지 보장하지 않아요. DifferenceKit의 공개 benchmark도 오래된 도구 환경에서 측정되었으므로 현재 앱 데이터로 다시 측정해야 해요.
+Swift `difference(from:)`의 공개된 최악 시간 복잡도는 `O(N × M)`이고, 공통 값이 많거나 원소가 `Hashable`이면 더 빨라질 수 있어요. DifferenceKit은 전체 입력 크기 `L`에 대해 `O(L)`인 Heckel 기반 diff를 제공하지만 항상 가장 짧은 변경 집합을 만들지는 않아요. 어느 쪽도 실제 UI가 더 빠르다고 보장하지 않으므로 셀 구성, layout, animation을 포함해 앱 데이터로 측정해야 해요.
 
 ## 참고 자료
 
@@ -575,6 +711,10 @@ Collection View는 각 batch update 중 data source의 section과 item 개수를
 - [DifferenceKit — StagedChangeset](https://ra1028.github.io/DifferenceKit/Structs/StagedChangeset.html)
 - [DifferenceKit — UICollectionView extension](https://ra1028.github.io/DifferenceKit/Extensions/UICollectionView.html)
 - [Apple Developer — CollectionDifference](https://developer.apple.com/documentation/swift/collectiondifference)
+- [Apple Developer — difference(from:)](https://developer.apple.com/documentation/swift/array/difference%28from%3A%29)
+- [Apple Developer — inferringMoves()](https://developer.apple.com/documentation/swift/collectiondifference/inferringmoves%28%29)
+- [Apple Developer — applying(_:)](https://developer.apple.com/documentation/swift/array/applying%28_%3A%29)
 - [Swift Evolution SE-0240 — Ordered Collection Diffing](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0240-ordered-collection-diffing.md)
+- [정주는 개발 중 — difference(from:)와 applying(_:)](https://jeong9216.tistory.com/716)
 - [Apple Developer — NSDiffableDataSourceSnapshot](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot-swift.struct)
 - [Apple Developer — Updating collection views using diffable data sources](https://developer.apple.com/documentation/uikit/updating-collection-views-using-diffable-data-sources)


### PR DESCRIPTION
## Summary

테스트 도구마다 검증하는 경계와 실행 방식이 다르다는 점, Swift 핵심 프로토콜마다 표현하는 의미와 지켜야 할 계약이 다르다는 점, Collection View의 diff 도구마다 모델 계약과 적용 방식이 다르다는 점을 입문자가 단계적으로 이해할 수 있도록 학습 문서를 추가합니다.

## Changes

### 테스트

- XCTest 단위 테스트 문서에 테스트 경계, assertion, setup·teardown, async expectation, 테스트 대역, 성능 측정과 test plan을 정리했습니다.
- Swift Testing 문서에 `@Test`, `@Suite`, `#expect`, `#require`, parameterized test, trait·tag, 병렬 실행과 XCTest 전환 기준을 정리했습니다.
- XCUITest 문서에 별도 process, accessibility tree와 identifier, query·wait, launch 환경, Page Object, interruption, accessibility audit와 flaky test 대응을 정리했습니다.
- TCA 1.26.1 기준 TestStore 문서에 `send`·`receive`, dependency override, `TestClock`, exhaustivity와 presentation dismissal 테스트를 정리했습니다.

### Swift 핵심 프로토콜

- `Equatable`, `Hashable`, `Identifiable` 문서에 값의 동등성, 해시 기반 컬렉션, 안정적인 식별자의 차이와 계약을 정리했습니다.
- `Codable` 문서에 `Encodable`·`Decodable`, 합성, `CodingKeys`, 중첩 컨테이너, 기본값과 버전 호환 전략을 정리했습니다.
- 함께 알아야 할 `Comparable`, `Sequence`·`Collection`, `Sendable` 문서를 추가해 정렬 규칙, 순회·인덱스 보장, 동시성 경계의 안전성을 정리했습니다.

### DifferenceKit

- DifferenceKit 1.3.0 기준 `ContentIdentifiable`, `ContentEquatable`, `Differentiable`, `Changeset`, `StagedChangeset`의 역할을 정리했습니다.
- `Equatable`, `Hashable`, `Identifiable`, Swift `CollectionDifference`, UIKit diffable data source와 모델 계약·변경 표현·적용 방식·배포 대상을 비교했습니다.
- `difference(from:)`의 삽입·삭제 offset, `applying(_:)`, `inferringMoves()` 동작과 UIKit 부분 갱신 변환 예제를 추가했습니다.
- Swift 표준 diff의 최악 `O(N × M)`과 DifferenceKit의 입력 크기 기준 `O(L)`을 비교하고, 이동 추론·적용 및 실제 UIKit 렌더링 비용을 분리해 설명했습니다.
- `reloadData()`와 부분 batch update의 장단점, 변경량이 많을 때 DifferenceKit `interrupt`로 전체 갱신을 선택하는 기준을 정리했습니다.
- 선형 및 section 컬렉션 모델링, `UICollectionView.reload(using:)`, stage별 동기적 data source 갱신과 테스트 예제를 추가했습니다.
- DifferenceKit 문서를 Collection View 학습 가이드와 기존 Diffable Data Source 문서에 연결했습니다.
- 테스트 및 핵심 프로토콜 상위 내비게이션과 사이드바 메타데이터를 연결했습니다.

## Testing

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run build`
- [x] XCTest와 Swift Testing 예제를 임시 Swift package에서 컴파일하고 실행했습니다.
- [x] XCUITest 전용 API를 iOS 17 simulator SDK로 타입 검사했습니다.
- [x] TCA 1.26.1을 고정한 임시 Swift package에서 TestStore 예제 6개를 컴파일하고 실행했습니다.
- [x] 핵심 프로토콜 예제를 Swift 6.3 strict concurrency와 warnings-as-errors 조건에서 컴파일하고 실행했습니다.
- [x] `Identifiable`의 SwiftUI `List` 예제를 타입 검사했습니다.
- [x] DifferenceKit 1.3.0을 고정한 임시 Swift package에서 선형·section changeset 예제를 컴파일하고 Swift Testing 테스트 2개를 실행했습니다.
- [x] DifferenceKit의 UIKit 적용 예제와 `CollectionDifference` 부분 갱신 예제를 iOS 17 simulator SDK, Swift 6 strict concurrency와 warnings-as-errors 조건에서 타입 검사했습니다.
- [x] 개발 서버에서 새 테스트 문서 4개, 핵심 프로토콜 문서 7개와 DifferenceKit 문서의 HTTP 200 응답을 확인했습니다.
- [x] `git diff --check`

## Related Issues

Closes #35
