### PR TITLE
[#37] Swift Concurrency와 Actor 학습 문서 섹션을 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -24,6 +24,12 @@
     "position": "left"
   },
   {
+    "text": "Instruments",
+    "link": "/guide/instruments/index",
+    "activeMatch": "/guide/instruments/",
+    "position": "left"
+  },
+  {
     "text": "UIKit",
     "link": "/guide/uikit/collection-views/index",
     "activeMatch": "/guide/uikit/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -21,6 +21,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "instruments",
+    "label": "Instruments"
+  },
+  {
+    "type": "dir-section-header",
     "name": "uikit",
     "label": "UIKit"
   },

--- a/docs/guide/instruments/_meta.json
+++ b/docs/guide/instruments/_meta.json
@@ -1,0 +1,51 @@
+[
+  {
+    "type": "custom-link",
+    "label": "Instruments 시작하기",
+    "link": "/guide/instruments/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "시간과 비동기 코드",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "비동기 메서드 시간 측정",
+        "link": "/guide/instruments/async-method-timing"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "CPU와 응답성",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "CPU Profiler와 Time Profiler",
+        "link": "/guide/instruments/cpu-profiling"
+      },
+      {
+        "type": "custom-link",
+        "label": "Hangs와 앱 응답성",
+        "link": "/guide/instruments/responsiveness-and-hangs"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "메모리",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "Allocations와 Leaks",
+        "link": "/guide/instruments/memory-profiling"
+      }
+    ]
+  }
+]

--- a/docs/guide/instruments/async-method-timing.md
+++ b/docs/guide/instruments/async-method-timing.md
@@ -1,0 +1,348 @@
+---
+title: Instruments로 비동기 메서드 시간 측정하기
+description: ContinuousClock과 OSSignposter로 await를 포함한 비동기 메서드의 전체 지연 시간을 측정하고 Swift Tasks에서 실행·중단·Main Actor 구간을 분석하는 방법을 설명합니다.
+---
+
+# Instruments로 비동기 메서드 시간 측정하기
+
+> **면접 답변 한 줄 요약:** 비동기 메서드의 전체 지연은 `OSSignposter` interval로 `await` 전후를 표시하고, 같은 구간의 Swift Tasks와 CPU profile을 함께 봐야 실행 시간, 대기 시간과 task scheduling 원인을 구분할 수 있어요.
+
+`async` 함수가 2초 걸렸다는 말에는 여러 시간이 섞여 있어요. CPU에서 코드를 실행한 시간일 수도 있고, network 응답을 기다린 시간일 수도 있으며, actor에 진입할 차례를 기다리거나 task가 scheduling되기 전의 시간일 수도 있어요.
+
+Time Profiler만 열어 함수 이름을 찾으면 CPU에서 sample된 구간은 볼 수 있지만, `await`에서 task가 중단된 시간은 함수의 CPU 비용으로 잡히지 않아요. 반대로 시작과 종료 시각만 빼면 사용자가 기다린 전체 시간은 알 수 있지만 왜 느렸는지는 알 수 없어요.
+
+이 문서에서는 다음 질문을 나누어 측정해요.
+
+- `async` 메서드 호출부터 반환까지 실제로 얼마나 걸렸나요?
+- 그중 CPU에서 코드를 실행한 시간은 얼마나 되나요?
+- task는 언제 생성되고 실행·중단·재개됐나요?
+- Main Actor나 다른 actor의 경합이 있었나요?
+- 여러 동시 호출과 throw·취소 상황에서도 interval이 정확히 닫히나요?
+
+## 먼저 알아둘 비동기 측정 용어
+
+| 용어                      | 쉬운 뜻                                                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| elapsed time, wall time   | 시작부터 종료까지 실제 시계로 흐른 시간이에요. CPU 실행뿐 아니라 `await`, network, file I/O와 scheduling 대기를 포함해요.                         |
+| CPU time                  | thread가 실제 CPU에서 명령을 실행한 시간이에요. 기다리느라 실행되지 않은 시간은 포함하지 않아요.                                                  |
+| suspension point          | `await`에서 task가 잠시 실행을 멈추고 thread를 양보할 수 있는 지점이에요. 나중에 같은 thread가 아닌 다른 thread에서 재개될 수도 있어요.           |
+| task lifetime             | task가 생성되어 완료되거나 취소될 때까지 살아 있는 구간이에요. 특정 메서드 한 번의 시작과 종료 범위와 반드시 같지는 않아요.                       |
+| signpost event와 interval | event는 한 시점을 표시하고, interval은 begin과 end 사이의 지속 시간을 표시해요. Instruments timeline에서 앱 의미가 있는 구간을 찾는 표지예요.     |
+| subsystem과 category      | 여러 log와 signpost를 앱과 기능 단위로 분류하는 문자열이에요. 같은 이름의 interval도 subsystem과 category로 필터링할 수 있어요.                   |
+| signpost ID               | 같은 이름의 interval 여러 개가 동시에 실행될 때 begin과 end를 올바르게 짝짓는 식별자예요.                                                         |
+| Points of Interest        | 중요한 앱 동작을 timeline에 표시하는 Instruments track이에요. `.pointsOfInterest` category의 signpost를 사용하면 관련 구간을 쉽게 찾을 수 있어요. |
+
+## 먼저 어떤 시간을 원하는지 정해요
+
+사진 목록을 불러오는 메서드를 예로 들어 볼게요.
+
+```swift
+func loadFeed() async throws -> [FeedItem] {
+  let response = try await client.fetchFeed()
+  return try decoder.decode(response.data)
+}
+```
+
+이 메서드에는 적어도 세 종류의 시간이 있어요.
+
+```text
+loadFeed 전체 elapsed time
+├─ request 생성과 response decode의 CPU time
+├─ network response를 기다린 suspension time
+└─ task가 executor에서 실행 차례를 기다린 scheduling time
+```
+
+사용자가 새로고침 indicator를 보는 시간은 전체 elapsed time에 가까워요. decode 알고리즘을 최적화하려면 CPU time이 중요하고, Main Actor에서 밀리는 문제를 찾으려면 task와 executor 상태가 중요해요. 하나의 숫자로 세 질문을 모두 답하려 하지 마세요.
+
+| 측정 질문                          | 사용할 도구                          | 결과의 의미                                           |
+| ---------------------------------- | ------------------------------------ | ----------------------------------------------------- |
+| 호출부터 반환까지 몇 초인가요?     | `ContinuousClock`, signpost interval | `await` 대기를 포함한 elapsed time이에요.             |
+| 어떤 함수가 CPU를 많이 사용하나요? | CPU Profiler, Time Profiler          | CPU에서 sample된 호출 경로와 비용 비중이에요.         |
+| task가 언제 중단되고 재개됐나요?   | Swift Tasks                          | task lifetime과 running·suspended 같은 상태 변화예요. |
+| actor 때문에 병렬성이 줄었나요?    | Swift Actors와 task 상세 정보        | actor별 task 실행과 경합 관계를 조사할 단서예요.      |
+| 같은 성능이 계속 유지되나요?       | performance test와 metric            | 반복 가능한 입력에서 회귀 여부를 확인하는 수치예요.   |
+
+## ContinuousClock으로 코드 안에서 elapsed time을 확인해요
+
+Instruments를 열기 전에 stopwatch 형태의 값만 빠르게 확인하고 싶다면 `ContinuousClock`을 사용할 수 있어요. `ContinuousClock`은 고해상도 실행 시간 측정에 적합한 단조 증가 clock이에요. 비동기 closure를 받는 `measure(_:)`도 제공해요.
+
+```swift
+let clock = ContinuousClock()
+
+let elapsed = try await clock.measure {
+  _ = try await repository.loadFeed()
+}
+
+print("loadFeed elapsed:", elapsed)
+```
+
+이 값은 `await`에서 중단된 시간도 포함해요. 따라서 “사용자가 결과를 받을 때까지 얼마나 기다렸는가”를 확인하는 데는 적합하지만 network, CPU, actor 대기 중 무엇이 원인인지는 알려 주지 않아요. 여러 도구와 같은 시간축에서 원인을 조사하려면 signpost를 사용하세요.
+
+`Date()` 두 값을 빼는 방식보다 성능 구간에는 단조 증가 clock을 사용하는 편이 좋아요. 달력 시각은 사용자나 system의 시각 보정 대상이지만 `ContinuousClock`은 stopwatch처럼 경과 시간을 측정하기 위한 타입이에요. API의 정확한 동작은 [ContinuousClock](https://developer.apple.com/documentation/swift/continuousclock)과 [비동기 measure(_:)](https://developer.apple.com/documentation/swift/clock/measure%28_%3A%29-7l47m)에서 확인할 수 있어요.
+
+## OSSignposter로 async 메서드 전체를 표시해요
+
+`OSSignposter`는 unified logging system에 interval과 event를 기록하고, Instruments의 signpost instrument가 이를 timeline에 표시하게 해요. begin에서 반환한 `OSSignpostIntervalState`를 같은 이름의 end에 전달해야 해요.
+
+다음 예제는 여러 `loadFeed()` 호출이 동시에 실행돼도 각각을 구분하고, 성공·throw·취소 경로 모두에서 interval을 끝내요.
+
+```swift
+import Foundation
+import OSLog
+
+struct FeedItem: Decodable, Sendable {
+  let id: Int
+  let title: String
+}
+
+protocol FeedClient: Sendable {
+  func fetchFeed() async throws -> Data
+}
+
+private enum PerformanceLog {
+  static let signposter = OSSignposter(
+    subsystem: Bundle.main.bundleIdentifier
+      ?? "com.example.PhotoApp",
+    category: .pointsOfInterest
+  )
+}
+
+struct FeedRepository: Sendable {
+  let client: any FeedClient
+
+  func loadFeed() async throws -> [FeedItem] {
+    let signposter = PerformanceLog.signposter
+    let signpostID = signposter.makeSignpostID()
+    let state = signposter.beginInterval(
+      "LoadFeed",
+      id: signpostID
+    )
+
+    defer {
+      signposter.endInterval("LoadFeed", state)
+    }
+
+    let data = try await client.fetchFeed()
+    return try JSONDecoder().decode(
+      [FeedItem].self,
+      from: data
+    )
+  }
+}
+```
+
+코드에서 중요한 부분을 하나씩 살펴볼게요.
+
+1. subsystem은 앱을, category는 성능 측정 목적을 구분해요.
+2. `.pointsOfInterest` category를 사용해 Instruments에서 관심 구간으로 찾기 쉽게 만들어요.
+3. `makeSignpostID()`를 호출마다 새로 만들어 동시에 실행되는 `LoadFeed` interval을 구분해요.
+4. `beginInterval`을 첫 `await` 전에 호출해 network 대기를 포함해요.
+5. `defer`에서 같은 이름과 state로 `endInterval`을 호출해 정상 반환, throw와 task 취소 경로 모두 닫아요.
+
+Apple의 [`OSSignposter`](https://developer.apple.com/documentation/os/ossignposter) 문서도 동시에 존재하는 같은 이름의 interval을 signpost ID로 구분하고, begin에서 받은 state를 end에 전달하도록 설명해요. interval state는 begin과 end의 이름, signposter와 중복 종료가 일치하는지도 검사해요.
+
+### withIntervalSignpost는 async closure용이 아니에요
+
+`OSSignposter.withIntervalSignpost`는 동기 closure를 감싸는 편의 API예요. 현재 공개된 signature의 closure에는 `async`가 없으므로 내부에서 `await`해야 하는 메서드를 직접 감쌀 수 없어요.
+
+동기 작업이라면 다음처럼 사용할 수 있어요.
+
+```swift
+let decoded = try signposter.withIntervalSignpost(
+  "DecodeFeed"
+) {
+  try decoder.decode([FeedItem].self, from: data)
+}
+```
+
+비동기 작업은 앞 예제처럼 `beginInterval`과 `defer`의 `endInterval`을 직접 사용하세요. 정확한 signature는 [withIntervalSignpost(_:id:around:)](https://developer.apple.com/documentation/os/ossignposter/withintervalsignpost%28_%3Aid%3Aaround%3A%29)에서 확인할 수 있어요.
+
+## Instruments에서 signpost duration을 읽어요
+
+코드를 추가했으면 다음 순서로 기록해요.
+
+1. 물리 기기를 선택하고 Xcode에서 `Product > Profile`을 실행해요.
+2. 전체 CPU 흐름도 함께 볼 때는 Time Profiler template을 선택해요.
+3. Points of Interest track이 없다면 `+ Instrument`에서 추가해요.
+4. Record를 누르고 `loadFeed()`가 실행되는 새로고침 동작을 여러 번 반복해요.
+5. Stop을 누르고 Points of Interest에서 subsystem, category와 `LoadFeed` 이름을 찾아요.
+6. interval summary에서 각 duration과 반복 결과를 확인해요.
+7. 느린 interval을 선택해 inspection range로 설정해요.
+8. 같은 구간의 CPU profile과 Swift Tasks를 확인해요.
+
+signpost interval은 timeline에서 앱의 의미를 붙여 주는 기준점이에요. Apple의 [Analyzing CPU profiles with call tree views](https://developer.apple.com/documentation/xcode/analyzing-cpu-profiles-with-call-tree-views)도 interval span을 선택해 해당 구간으로 call tree를 제한하는 흐름을 안내해요.
+
+### metadata에는 민감한 값을 넣지 않아요
+
+signpost message에 page 번호, item 개수처럼 분석에 필요한 값을 추가할 수 있어요.
+
+```swift
+let state = signposter.beginInterval(
+  "LoadFeed",
+  id: signpostID,
+  "page: \(page, privacy: .public)"
+)
+```
+
+token, 전체 URL query, 사용자 ID, 검색어와 개인 데이터는 trace에 남기지 마세요. 꼭 구분값이 필요하면 privacy option을 명시하고 원문 대신 안전한 범주나 hash를 사용하세요. `.trace` 파일을 공유할 때는 앱 log와 signpost metadata가 포함될 수 있다고 가정해야 해요.
+
+## 전체 interval을 단계별로 나눠요
+
+`LoadFeed`가 느리다는 사실을 확인했다면 큰 interval 안의 단계를 따로 표시해요. 처음부터 모든 작은 함수에 signpost를 넣으면 기록이 복잡해지므로 원인 후보가 되는 경계만 선택하세요.
+
+```swift
+func loadFeed() async throws -> [FeedItem] {
+  let signposter = PerformanceLog.signposter
+  let loadState = signposter.beginInterval("LoadFeed")
+  defer {
+    signposter.endInterval("LoadFeed", loadState)
+  }
+
+  let requestState = signposter.beginInterval("FetchFeed")
+  let data = try await client.fetchFeed()
+  signposter.endInterval("FetchFeed", requestState)
+
+  return try signposter.withIntervalSignpost(
+    "DecodeFeed"
+  ) {
+    try JSONDecoder().decode([FeedItem].self, from: data)
+  }
+}
+```
+
+이 예제는 이해하기 쉽게 각 단계가 한 번만 실행된다고 가정해 기본 `.exclusive` ID를 사용해요. `FetchFeed`나 `DecodeFeed`가 같은 signposter 안에서 동시에 여러 번 실행될 수 있다면 단계별로 `makeSignpostID()`를 만들어 전달하세요.
+
+결과를 다음처럼 해석할 수 있어요.
+
+| 관찰 결과                                      | 다음 가설과 도구                                                                 |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| `FetchFeed`가 길고 CPU는 낮아요.               | network 또는 server 대기일 수 있어요. Network template과 URLSession 지표를 봐요. |
+| `DecodeFeed`가 길고 CPU sample이 많아요.       | decode가 CPU-bound일 수 있어요. CPU call tree와 allocation을 확인해요.           |
+| 두 하위 interval은 짧지만 `LoadFeed`가 길어요. | scheduling, actor hop 또는 빠진 단계를 의심하고 Swift Tasks를 확인해요.          |
+| 반복할수록 모든 interval이 길어져요.           | thermal, memory pressure, 누적 task와 cache 상태를 함께 확인해요.                |
+
+## Swift Tasks에서 중단과 재개를 확인해요
+
+signpost는 “얼마나 오래”를 잘 보여 주지만 task가 왜 그 시간을 보냈는지는 설명하지 않아요. Swift Concurrency template의 Swift Tasks와 Swift Actors instrument를 함께 사용하세요.
+
+1. `Product > Profile`에서 Swift Concurrency template을 선택하거나 현재 trace에 Swift Tasks를 추가해요.
+2. 같은 `LoadFeed` 동작을 기록해요.
+3. Running Tasks, Alive Tasks와 Total Tasks의 변화를 먼저 봐요.
+4. signpost interval과 겹치는 task를 선택해 lifetime과 상태 변화를 확인해요.
+5. Task Forest에서 부모·자식 task 관계를 확인해요.
+6. creation backtrace에서 task가 만들어진 호출 위치를 찾아요.
+7. Swift Actors에서 특정 actor가 긴 작업을 직렬로 처리하는지 조사해요.
+
+Apple은 [Visualize and optimize Swift concurrency](https://developer.apple.com/videos/play/wwdc2022/110350/)에서 Swift Tasks의 Running, Alive, Total 통계와 Task Forest를 사용해 Main Actor blocking, actor contention, thread pool exhaustion과 continuation 문제를 좁히는 방법을 보여 줘요.
+
+### task lifetime을 메서드 duration으로 읽지 않아요
+
+하나의 task는 `loadFeed()` 전후의 다른 비동기 작업도 실행할 수 있어요. 반대로 `loadFeed()` 안에서 child task 여러 개를 만들 수도 있어요. task lifetime의 길이와 특정 메서드의 interval은 서로 다른 경계예요.
+
+- 메서드 API 경계는 signpost interval로 표시해요.
+- task의 생성, 중단, 재개와 부모·자식 관계는 Swift Tasks로 봐요.
+- CPU에서 실행한 함수의 비용은 CPU profile로 봐요.
+
+세 데이터를 같은 inspection range에서 겹쳐 봐야 잘못된 결론을 피할 수 있어요.
+
+## Main Actor에서 실행됐다는 것과 CPU 병렬성을 구분해요
+
+`async`라는 이유만으로 작업이 Main Actor 밖에서 실행되는 것은 아니에요. Main Actor에 격리된 context에서 생성한 task가 CPU 계산을 이어받으면 UI event와 경쟁할 수 있어요. timeline에서 다음을 확인하세요.
+
+- `LoadFeed` interval 동안 Main Thread에 긴 Swift task 실행 구간이 있는지
+- Hangs track과 Main Thread의 높은 CPU가 같은 시간에 나타나는지
+- actor에 실행 대기 중인 task가 계속 쌓이는지
+- child task가 실제로 겹쳐 실행되는지, 직렬로 이어지는지
+
+Main Actor와 actor 격리의 언어 규칙은 [MainActor 문서](../swift/concurrency/main-actor.md)와 [Actor 문서](../swift/concurrency/actors.md)에서 이어서 볼 수 있어요. 성능 때문에 격리를 제거하기 전에 전달하는 값의 `Sendable` 안전성과 UI 갱신 경계를 먼저 확인하세요.
+
+## 여러 번 측정하고 분포를 비교해요
+
+network가 포함된 `async` 함수는 같은 코드라도 결과 변동이 커요. 평균 하나만 기록하지 말고 다음 값을 함께 봐요.
+
+- 첫 호출과 준비 후 호출을 분리한 duration
+- 최소, 중앙값, 상위 지연과 최대 duration
+- 성공, server 오류, 취소 경로의 duration
+- Wi-Fi, cellular과 network conditioning별 결과
+- 같은 구간의 CPU와 memory peak
+
+OSSignposter interval summary는 여러 interval의 duration을 비교하는 데 유용해요. 그러나 signpost는 회귀 test의 pass/fail 기준 자체가 아니에요. 안정된 입력을 만들 수 있는 decode나 local database 작업은 performance test로 옮기고, 실제 network가 포함된 end-to-end 지연은 별도 환경과 관측 지표로 관리하세요.
+
+## 도구별 역할을 정리해요
+
+| 방법                       | 장점                                                            | 한계                                                              |
+| -------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `ContinuousClock`          | 코드에서 async elapsed time을 간단히 얻어요.                    | 다른 Instruments track과 자동으로 연결되지 않아요.                |
+| `OSSignposter` interval    | 앱의 의미 있는 구간을 timeline에 표시하고 반복 duration을 봐요. | interval 경계는 개발자가 올바르게 정해야 해요.                    |
+| Swift Tasks                | task의 생성, 상태, lifetime과 구조를 보여 줘요.                 | 특정 메서드 API 경계와 항상 일치하지 않아요.                      |
+| CPU Profiler/Time Profiler | CPU에서 무거운 함수와 호출 경로를 찾아요.                       | `await`와 I/O 대기를 메서드 CPU 비용으로 보여 주지 않아요.        |
+| performance test           | 고정된 입력으로 성능 회귀를 자동 검증해요.                      | 실제 사용자 환경의 network와 scheduling 전체를 재현하기 어려워요. |
+
+## 흔한 실수를 피해야 해요
+
+### begin과 end에서 다른 이름을 쓰지 않아요
+
+interval state는 이름과 signposter의 일관성을 검사해요. 이름을 동적으로 만들지 말고 `StaticString` literal을 사용해 같은 경계를 유지하세요.
+
+### 동시에 실행되는 interval에 기본 exclusive ID를 공유하지 않아요
+
+같은 이름과 scope의 interval이 겹칠 수 있다면 호출마다 `makeSignpostID()`를 만들어요. 그렇지 않으면 begin과 end를 올바르게 구분할 수 없어요.
+
+### 성공 경로에서만 endInterval을 호출하지 않아요
+
+`try await`가 throw하거나 task가 취소돼도 interval은 닫혀야 해요. begin 직후 `defer`를 선언하면 모든 scope 종료 경로를 처리할 수 있어요.
+
+### elapsed time을 CPU 최적화 근거로 사용하지 않아요
+
+2초 interval의 대부분이 server response 대기라면 Swift decode 코드를 미세 최적화해도 사용자가 느끼는 시간은 거의 달라지지 않아요. 같은 범위의 CPU와 task 상태를 확인하세요.
+
+### 너무 작은 함수마다 signpost를 넣지 않아요
+
+측정 자체에도 비용이 있고 timeline이 읽기 어려워져요. 사용자 동작, request, decode, database transaction처럼 의미 있는 경계를 먼저 표시하고 필요한 곳만 세분화하세요.
+
+## 적용 순서를 정리해요
+
+1. 메서드의 시작과 종료 중 사용자가 기다리는 경계를 정해요.
+2. 빠른 숫자가 필요하면 `ContinuousClock`으로 elapsed time을 확인해요.
+3. 같은 시간축의 분석이 필요하면 `.pointsOfInterest` `OSSignposter`를 만들어요.
+4. 동시 호출에는 고유 signpost ID를 사용하고 `defer`에서 interval을 닫아요.
+5. Instruments에서 여러 번 기록해 duration 분포를 확인해요.
+6. 느린 interval을 inspection range로 설정해 CPU와 Swift Tasks를 함께 봐요.
+7. network, CPU, scheduling과 actor 경합 중 주된 원인을 분류해요.
+8. 수정 후 같은 조건으로 다시 측정하고 안정된 구간은 performance test로 보호해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 비동기 함수의 실행 시간은 Time Profiler만으로 잴 수 있나요?
+
+정확한 호출 시작부터 반환까지의 elapsed time은 Time Profiler sample만으로 재기 어려워요. Time Profiler는 CPU에서 실행 중인 call stack을 주기적으로 sample하므로 `await`에서 중단된 대기는 빠져요. 메서드 경계에는 signpost interval을 사용하고 원인은 CPU profile과 Swift Tasks로 나눠 봐야 해요.
+
+### `ContinuousClock`과 `OSSignposter`는 무엇이 다른가요?
+
+`ContinuousClock`은 코드에서 경과 시간 값을 바로 계산하는 stopwatch 역할을 해요. `OSSignposter`는 같은 구간을 Instruments timeline에 표시해 CPU, task, Hangs 같은 다른 데이터와 연결하고 반복 interval의 분포를 분석할 수 있게 해요.
+
+### 왜 `defer`에서 `endInterval`을 호출하나요?
+
+비동기 메서드는 정상 반환 외에도 throw와 취소로 scope를 빠져나갈 수 있어요. begin 직후 `defer`를 두면 모든 종료 경로에서 동일한 state로 interval을 한 번 닫을 수 있어요.
+
+### async 함수가 느리면 background thread로 옮기면 되나요?
+
+먼저 느린 시간이 CPU 실행인지 I/O와 actor 대기인지 측정해야 해요. network 대기가 원인이라면 thread를 바꿔도 latency가 줄지 않고, CPU 계산이 Main Actor를 막는 경우에만 격리와 실행 위치를 바꾸는 방향이 의미 있어요.
+
+### task lifetime과 signpost interval이 왜 다른가요?
+
+task는 여러 async 함수를 차례로 실행하거나 child task를 만들 수 있는 실행 단위예요. signpost interval은 개발자가 선택한 한 기능이나 메서드의 의미적 경계이므로 task 전체 수명보다 짧거나 여러 task에 걸칠 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer — OSSignposter](https://developer.apple.com/documentation/os/ossignposter)
+- [Apple Developer — Recording Performance Data](https://developer.apple.com/documentation/os/recording-performance-data)
+- [Apple Developer — beginInterval(_:id:)](https://developer.apple.com/documentation/os/ossignposter/begininterval%28_%3Aid%3A%29)
+- [Apple Developer — endInterval(_:_:)](https://developer.apple.com/documentation/os/ossignposter/endinterval%28_%3A_%3A%29)
+- [Apple Developer — withIntervalSignpost(_:id:around:)](https://developer.apple.com/documentation/os/ossignposter/withintervalsignpost%28_%3Aid%3Aaround%3A%29)
+- [Apple Developer — ContinuousClock](https://developer.apple.com/documentation/swift/continuousclock)
+- [Apple Developer — Clock.measure(_:)](https://developer.apple.com/documentation/swift/clock/measure%28_%3A%29-7l47m)
+- [Apple Developer — Analyzing CPU profiles with call tree views](https://developer.apple.com/documentation/xcode/analyzing-cpu-profiles-with-call-tree-views)
+- [WWDC22 — Visualize and optimize Swift concurrency](https://developer.apple.com/videos/play/wwdc2022/110350/)
+- [WWDC18 — Measuring Performance Using Logging](https://developer.apple.com/videos/play/wwdc2018/405/)
+- [SwiftLee — Using Xcode Instruments to optimize Swift Concurrency code](https://www.avanderlee.com/concurrency/using-xcode-instruments-to-optimize-swift-concurrency-code/)

--- a/docs/guide/instruments/cpu-profiling.md
+++ b/docs/guide/instruments/cpu-profiling.md
@@ -1,0 +1,279 @@
+---
+title: CPU Profiler와 Time Profiler로 병목 찾기
+description: Instruments의 CPU Profiler와 Time Profiler가 call stack을 sampling하는 방식을 이해하고 call tree, flame graph, Weight와 Self Weight로 Swift CPU 병목을 찾는 방법을 설명합니다.
+---
+
+# CPU Profiler와 Time Profiler로 병목 찾기
+
+> **면접 답변 한 줄 요약:** CPU profiling은 실행 중인 call stack을 반복해서 sample하고 자주 관측되는 함수와 호출 경로를 찾아, CPU 시간을 크게 차지하는 병목부터 측정 기반으로 최적화하는 과정이에요.
+
+느린 메서드 이름을 알고 있어도 그 메서드 자체가 비싼지, 내부에서 호출한 정렬이나 decode가 비싼지는 코드만 보고 확정하기 어려워요. 반대로 앱 전체에서 CPU를 많이 쓰는 함수만 찾으면 사용자가 기다리는 기능과 무관한 background 작업을 고칠 수 있어요.
+
+CPU profiling에서는 두 범위를 함께 정해야 해요.
+
+1. 사용자가 문제를 겪은 **시간 구간**을 signpost나 timeline으로 고정해요.
+2. 그 구간의 call tree에서 **CPU sample이 집중된 호출 경로**를 찾아요.
+
+이 문서에서는 현재 Instruments에서 널리 사용하는 Time Profiler와 Apple silicon의 CPU Profiler를 중심으로 설명해요. 특정 Xcode나 기기에서 CPU Profiler template이 보이지 않으면 Time Profiler로 같은 조사 흐름을 시작할 수 있어요.
+
+## 먼저 알아둘 CPU profiling 용어
+
+| 용어                | 쉬운 뜻                                                                                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CPU-bound           | 처리 속도가 network나 disk 대기보다 CPU 계산량에 주로 제한되는 상태예요.                                                                            |
+| sample              | profiler가 특정 순간에 CPU에서 실행 중인 thread의 call stack을 관측한 한 번의 기록이에요.                                                           |
+| call stack          | 현재 함수에 도달하기까지 겹쳐진 함수 호출 순서예요.                                                                                                 |
+| call tree           | 여러 call stack sample을 같은 호출 경로끼리 합쳐 계층으로 보여 주는 표예요.                                                                         |
+| Weight              | 한 함수와 그 아래에서 호출한 함수까지 포함해 부여된 CPU sample 비중이에요. 정확한 stopwatch duration이 아니라 profiler 방식에 따른 추정 비용이에요. |
+| Self Weight         | 하위 함수에 넘긴 sample을 제외하고 그 함수 본문 자체에 귀속된 비중이에요.                                                                           |
+| flame graph         | call stack을 막대 너비로 시각화한 그래프예요. 넓은 막대일수록 선택한 weight 기준에서 더 많은 sample이 포함돼요.                                     |
+| aliasing            | 일정 주기의 profiler sample과 앱의 반복 작업 주기가 우연히 맞아 특정 함수가 실제보다 과대·과소 표현되는 sampling 왜곡이에요.                        |
+| on-CPU와 off-CPU    | on-CPU는 실제 명령을 실행 중인 상태이고, off-CPU는 lock, I/O, sleep나 scheduling 때문에 실행되지 않는 상태예요.                                     |
+| hot path와 hot spot | hot path는 비용이 누적되는 무거운 호출 경로이고, hot spot은 sample이 집중된 함수나 코드 영역이에요.                                                 |
+
+## Time Profiler와 CPU Profiler의 sampling 기준이 달라요
+
+두 instrument 모두 call stack sample을 모아 call tree와 flame graph로 보여 주지만 sample을 발생시키는 기준이 달라요.
+
+| 비교 기준     | Time Profiler                                                         | CPU Profiler                                                        |
+| ------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| sampling 기준 | 일정한 시간 간격으로 실행 중인 thread stack을 관측해요.               | Apple silicon CPU별 cycle counter를 기반으로 독립적으로 sample해요. |
+| 강점          | 시간에 따른 thread 활동과 CPU 사용을 폭넓게 보기 좋아요.              | 순수 CPU 비용을 더 공정하게 가중해 최적화 대상을 찾는 데 유리해요.  |
+| 주의점        | 주기적인 작업과 sampler 주기가 겹치는 aliasing이 생길 수 있어요.      | 지원 Xcode와 Apple silicon 환경을 확인해야 해요.                    |
+| 공통 한계     | 모든 함수 호출을 기록하지 않으므로 짧거나 드문 호출을 놓칠 수 있어요. | 모든 함수 호출의 정확한 duration을 자동으로 제공하는 것은 아니에요. |
+
+Apple은 [Optimize CPU performance with Instruments](https://developer.apple.com/videos/play/wwdc2025/308/)에서 CPU 최적화가 목적이라면 Time Profiler의 timer sampling보다 CPU별로 sampling하는 CPU Profiler를 선호하도록 안내해요. 반면 UI 멈춤이 언제 발생했고 thread가 어떻게 움직였는지 넓게 볼 때는 Time Profiler template이 좋은 출발점이 될 수 있어요.
+
+### Processor Trace는 더 깊은 단계의 도구예요
+
+Processor Trace는 sampling 대신 지원 기기의 hardware branch trace로 user-space의 함수 실행 흐름을 재구성해요. 짧은 함수 한 번의 호출과 compiler가 생성한 ARC 코드까지 조사할 수 있지만 지원 hardware와 OS 조건이 있고 매우 많은 trace 데이터를 만들 수 있어요.
+
+처음부터 Processor Trace로 들어가기보다 다음 순서를 사용하세요.
+
+1. signpost와 CPU Profiler 또는 Time Profiler로 중요한 구간을 찾습니다.
+2. 불필요한 작업 제거, cache와 알고리즘 변경을 먼저 검토합니다.
+3. 여전히 CPU-bound인 짧은 핵심 구간의 instruction-level 비용이 필요할 때 Processor Trace와 CPU Counters를 검토합니다.
+
+지원 조건과 기록 방법은 [Analyzing CPU usage with the Processor Trace instrument](https://developer.apple.com/documentation/xcode/analyzing-cpu-usage-with-processor-trace)에서 확인하세요.
+
+## 최적화할 사용자 시나리오를 먼저 고정해요
+
+CPU graph 전체가 높다는 사실만으로 어떤 코드를 고칠지 결정할 수 없어요. 예를 들어 이미지 검색 결과가 나타나는 시간이 문제라면 다음처럼 경계를 정해요.
+
+```text
+검색 버튼 탭
+  → local index 검색
+  → 결과 정렬
+  → cell model 생성
+  → 첫 결과 화면 표시
+```
+
+이 구간을 `OSSignposter`의 “SearchPhotos” interval로 표시하면 profiling 결과를 같은 경계로 반복해서 볼 수 있어요. signpost 작성법은 [비동기 메서드 시간 측정](./async-method-timing.md)에서 설명해요.
+
+측정 전에는 다음 조건도 확인하세요.
+
+- Profile action이 최적화된 configuration을 사용하는지
+- 앱과 framework의 symbol을 읽을 수 있는지
+- 같은 입력 데이터와 검색어를 사용하는지
+- 물리 기기의 thermal 상태가 비슷한지
+- 첫 실행 준비 비용과 반복 실행 비용을 구분했는지
+
+## CPU trace를 기록해요
+
+Time Profiler를 기준으로 기본 순서를 따라가 볼게요. CPU Profiler에서도 inspection range와 call tree를 읽는 핵심 흐름은 같아요.
+
+1. Xcode에서 scheme과 물리 기기를 선택해요.
+2. `Product > Profile`을 실행해요.
+3. 넓은 조사는 Time Profiler, CPU 최적화는 지원되는 경우 CPU Profiler template을 선택해요.
+4. Record를 누르고 준비한 동작을 반복해 profiler가 충분한 sample을 모으게 해요.
+5. Stop을 누르고 signpost나 증상 구간을 찾습니다.
+6. 목표 구간만 inspection range로 설정하고 확대해요.
+7. app process나 관련 thread track을 선택해 call tree를 열어요.
+
+아주 짧은 코드는 sample 사이에 실행을 끝내 profiler가 놓칠 수 있어요. 이때는 production과 같은 코드를 일정 시간 반복하는 benchmark harness를 만들되, 반복문 자체나 test framework 비용이 결과를 지배하지 않는지 확인하세요. 실제 기능의 latency를 인위적인 반복 횟수로 대신하지 말고 CPU hotspot을 안정적으로 sample하기 위한 용도로만 사용해요.
+
+## call tree에서 Weight와 Self Weight를 나눠 봐요
+
+다음 호출 관계를 생각해 볼게요.
+
+```text
+SearchViewModel.search()
+└─ PhotoRepository.search()
+   ├─ Array.filter(_:)
+   └─ Array.sorted(by:)
+```
+
+`PhotoRepository.search()`의 Weight가 높지만 Self Weight가 낮다면 실제 CPU sample은 `filter`와 `sorted` 같은 하위 호출에 있을 가능성이 커요. 반대로 Self Weight도 높다면 repository 함수 본문의 loop, hash 계산이나 값 복사가 직접 비용을 만들 수 있어요.
+
+| 관찰 결과                           | 해석과 다음 행동                                                           |
+| ----------------------------------- | -------------------------------------------------------------------------- |
+| Weight와 Self Weight가 모두 높아요. | 함수 본문 자체의 알고리즘, copy와 ARC 비용을 source에서 확인해요.          |
+| Weight는 높고 Self Weight는 낮아요. | disclosure를 열어 무거운 callee를 따라가요.                                |
+| system library가 가장 무거워요.     | 호출자를 확인해 앱이 API를 너무 자주 또는 잘못된 방식으로 호출하는지 봐요. |
+| 앱 코드 sample이 거의 없어요.       | symbolication, inspection range와 target process가 맞는지 먼저 확인해요.   |
+| latency는 긴데 CPU sample은 적어요. | I/O, lock, task scheduling 같은 off-CPU 대기를 의심해요.                   |
+
+함수 이름만 보고 system framework 비용을 숨겨 버리면 앱 코드가 어떤 API를 호출했는지 놓칠 수 있어요. 처음에는 전체 경로를 읽고, 원인 범위를 이해한 뒤 `Hide System Libraries`를 사용해 앱 코드에 집중하세요.
+
+## Invert Call Tree로 무거운 leaf를 모아 봐요
+
+일반 call tree는 진입점에서 callee 방향으로 내려가요. 같은 낮은 수준 함수가 여러 경로에서 호출되면 sample이 여러 branch에 나뉘어 보여요. `Invert Call Tree`는 sample이 끝난 leaf 쪽을 위로 올려 같은 hotspot을 찾기 쉽게 해요.
+
+다음 순서가 실용적이에요.
+
+1. 목표 inspection range를 설정해요.
+2. app process의 call tree를 선택해요.
+3. `Hide System Libraries`로 앱 symbol을 우선 봐요.
+4. `Invert Call Tree`를 켜 leaf hotspot을 찾아요.
+5. 무거운 symbol을 선택해 callers와 callees를 번갈아 확인해요.
+6. `Focus on Subtree`로 관련 경로만 남겨요.
+7. Source Viewer에서 sample이 집중된 line을 확인해요.
+
+call tree, flame graph와 Top Functions가 같은 profile을 서로 다른 관점에서 보여 주는 방식은 [Analyzing CPU profiles with call tree views](https://developer.apple.com/documentation/xcode/analyzing-cpu-profiles-with-call-tree-views)에서 자세히 설명해요.
+
+## flame graph에서는 넓이와 호출 깊이를 읽어요
+
+flame graph의 가로 폭은 선택한 weight 기준의 sample 비중이고 세로 방향은 call stack 깊이예요. 시간 순서 그래프가 아니므로 왼쪽 함수 다음에 오른쪽 함수가 실행됐다고 해석하면 안 돼요.
+
+- 넓은 상위 막대는 여러 하위 호출을 포함한 비싼 경로일 수 있어요.
+- 넓은 leaf 막대는 특정 함수 자체가 hotspot일 가능성이 있어요.
+- 같은 symbol이 여러 위치에 나타나면 서로 다른 caller에서 호출된 것이에요.
+- bar가 좁거나 보이지 않는다고 호출이 전혀 없었다는 뜻은 아니에요. sampling 사이에 끝났을 수 있어요.
+
+세부 호출 순서와 정확한 단일 호출 시간을 알아야 한다면 signpost, 지원 기기의 Processor Trace나 별도 benchmark가 필요해요.
+
+## 예제로 반복 정렬 병목을 줄여요
+
+검색할 때마다 전체 사진을 filter하고 정렬하는 코드를 살펴볼게요.
+
+```swift
+struct PhotoSearch {
+  func search(
+    _ photos: [Photo],
+    query: String
+  ) -> [Photo] {
+    photos
+      .filter { $0.title.localizedCaseInsensitiveContains(query) }
+      .sorted { $0.createdAt > $1.createdAt }
+  }
+}
+```
+
+call tree에서 `sorted(by:)` 아래 비교 closure와 문자열 비교가 반복해서 넓게 보인다고 가정해 볼게요. 곧바로 비교 함수를 미세 최적화하기 전에 작업 자체를 줄일 수 있는지 확인해요.
+
+```swift
+struct PhotoIndex {
+  private let newestFirst: [Photo]
+
+  init(photos: [Photo]) {
+    newestFirst = photos.sorted {
+      $0.createdAt > $1.createdAt
+    }
+  }
+
+  func search(query: String) -> [Photo] {
+    newestFirst.filter {
+      $0.title.localizedCaseInsensitiveContains(query)
+    }
+  }
+}
+```
+
+정렬 결과를 입력이 바뀔 때만 만들면 검색마다 정렬하는 비용을 피할 수 있어요. 대신 index를 보관하는 memory와 데이터 변경 시 갱신 책임이 생겨요. 실제로 좋아졌는지는 같은 사진 수, 검색어와 기기에서 before/after trace를 기록해 검증해야 해요.
+
+### sample 결과만 보고 cache를 무한히 늘리지 않아요
+
+CPU를 줄이기 위한 cache가 memory pressure와 오래된 데이터 문제를 만들 수 있어요. cache hit 비율, 최대 크기, 무효화 시점과 memory trace를 함께 확인하세요. CPU 최적화는 다른 자원의 비용을 옮기는 결정일 수 있어요.
+
+## CPU가 낮은 느림은 다른 instrument로 넘겨요
+
+사용자 latency가 긴데 목표 구간의 CPU 사용이 낮다면 다음 상태를 의심해요.
+
+| 가능한 원인                  | 확인할 도구와 단서                                                 |
+| ---------------------------- | ------------------------------------------------------------------ |
+| network response 대기        | Network template, URLSession task metrics와 signpost 하위 interval |
+| synchronous file I/O         | System Trace의 thread state와 system call                          |
+| lock 또는 semaphore 대기     | System Trace에서 blocked thread와 이를 깨우는 thread               |
+| actor 또는 executor 대기     | Swift Tasks, Swift Actors와 최신 Instruments의 executor 관련 track |
+| Main Thread event 지연       | Hangs track과 Main Thread의 running·blocked 상태                   |
+| memory pressure와 page fault | Allocations, VM 관련 instrument와 memory warning                   |
+
+CPU profile은 on-CPU 코드에 답하는 도구예요. off-CPU 대기를 억지로 call tree 안에서 찾지 말고 같은 inspection range에 적합한 instrument를 추가하세요.
+
+## 최적화 순서를 크게 잡아요
+
+Apple의 CPU 성능 세션도 복잡한 micro-optimization보다 불필요한 작업 제거, 중요한 경로 밖으로 미루기, precomputation과 cache, 알고리즘·자료구조 변경을 먼저 검토하도록 권해요.
+
+1. 실행하지 않아도 되는 작업을 제거해요.
+2. 사용자 critical path 밖으로 미룰 수 있는지 봐요.
+3. 같은 결과를 반복 계산한다면 안전한 cache나 precomputation을 검토해요.
+4. 더 나은 알고리즘과 자료구조로 계산량을 줄여요.
+5. API 호출 횟수와 값 copy를 줄여요.
+6. 마지막에 compiler와 CPU 수준의 micro-optimization을 검토해요.
+
+각 단계에서 before/after를 다시 측정하세요. 더 복잡한 코드로 바꾸었는데 사용자가 느끼는 latency가 달라지지 않았다면 유지보수 비용만 늘어난 셈이에요.
+
+## 흔한 실수를 피해야 해요
+
+### sample 비율을 정확한 함수 duration으로 쓰지 않아요
+
+sampling profiler의 30% weight는 그 함수가 stopwatch로 전체 시간의 정확히 30% 실행됐다는 뜻이 아니에요. 선택 구간과 sampling 방식에서 해당 stack이 관측된 비중으로 읽으세요.
+
+### 호출 횟수가 많은 함수와 느린 함수를 혼동하지 않아요
+
+아주 짧은 함수가 수백만 번 호출되어 hotspot이 될 수 있고, 한 번 호출되지만 대부분 I/O를 기다리는 함수는 CPU sample이 적을 수 있어요. CPU 비용과 elapsed time을 나눠 봐야 해요.
+
+### Release symbol이 없다고 Debug build만 측정하지 않아요
+
+Debug build의 실행 특성은 최적화된 배포 build와 크게 다를 수 있어요. Profile configuration과 dSYM을 바로 구성해 최적화된 code를 symbolicate하세요.
+
+### 평균 기기 한 대만 보지 않아요
+
+성능 목표 기기와 문제가 보고된 기기 등급에서 측정하세요. 최신 기기에서 짧은 구간이 오래된 지원 기기에서는 user-visible hang이 될 수 있어요.
+
+### 가장 넓은 system symbol을 직접 고치려 하지 않아요
+
+system framework 구현은 바꿀 수 없지만 이를 호출하는 앱의 입력 크기, 호출 횟수와 API 선택은 바꿀 수 있어요. caller를 따라 앱 코드의 결정을 찾으세요.
+
+## 적용 순서를 정리해요
+
+1. 느린 사용자 동작을 재현하고 signpost로 경계를 표시해요.
+2. 최적화된 build, symbol과 물리 기기를 준비해요.
+3. CPU Profiler가 지원되면 CPU 최적화에 사용하고, 넓은 조사는 Time Profiler로 시작해요.
+4. 여러 번 실행해 충분한 sample을 수집해요.
+5. 목표 interval로 inspection range를 제한해요.
+6. Weight와 Self Weight를 나누고 Invert Call Tree로 hotspot을 찾아요.
+7. 불필요한 작업, cache, 알고리즘 순서로 큰 개선부터 적용해요.
+8. 같은 조건의 after run으로 latency와 CPU 감소를 함께 검증해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Time Profiler는 함수 실행 시간을 정확히 재나요?
+
+아니에요. Time Profiler는 일정한 시간 간격으로 실행 중인 thread의 call stack을 sample해 CPU 비용의 분포를 추정해요. 특정 함수 한 번의 elapsed time은 signpost나 clock으로 별도 측정해야 해요.
+
+### Weight와 Self Weight는 무엇이 다른가요?
+
+Weight는 함수와 그 함수가 호출한 하위 함수의 sample을 함께 포함해요. Self Weight는 하위 호출을 제외하고 함수 본문 자체에 귀속된 sample이므로, 높은 Weight의 실제 비용이 본문인지 callee인지 구분할 때 사용해요.
+
+### CPU 사용률이 낮은데 앱이 느리면 무엇을 봐야 하나요?
+
+thread나 task가 CPU 밖에서 network, file I/O, lock 또는 actor를 기다리는지 확인해야 해요. System Trace, Network, Swift Tasks와 Hangs를 같은 inspection range에 추가해 blocked 원인을 조사해요.
+
+### Invert Call Tree는 언제 사용하나요?
+
+같은 leaf 함수가 여러 caller 경로에서 호출되어 일반 call tree의 여러 branch에 흩어질 때 사용해요. 무거운 leaf를 위로 모은 뒤 caller를 따라가면 앱의 어떤 경로가 반복 비용을 만드는지 찾기 쉬워요.
+
+### Processor Trace를 언제 사용하나요?
+
+sampling으로 중요한 CPU 구간을 좁혔지만 짧은 함수의 정확한 호출 흐름이나 compiler·runtime 비용까지 확인해야 할 때 사용해요. 지원 hardware와 OS가 필요하고 데이터가 매우 커질 수 있으므로 짧은 핵심 구간에 적용해요.
+
+## 참고 자료
+
+- [WWDC25 — Optimize CPU performance with Instruments](https://developer.apple.com/videos/play/wwdc2025/308/)
+- [Apple Developer — Analyzing CPU profiles with call tree views](https://developer.apple.com/documentation/xcode/analyzing-cpu-profiles-with-call-tree-views)
+- [Apple Developer — Analyzing CPU usage with the Processor Trace instrument](https://developer.apple.com/documentation/xcode/analyzing-cpu-usage-with-processor-trace)
+- [Apple Developer — Addressing CPU bottlenecks](https://developer.apple.com/documentation/xcode/addressing-cpu-bottlenecks)
+- [Apple Developer — Improving your app’s performance](https://developer.apple.com/documentation/xcode/improving-your-app-s-performance/)
+- [WWDC26 — Profile, fix, and verify: Improve app responsiveness with Instruments](https://developer.apple.com/videos/play/wwdc2026/268/)
+- [WWDC25 — Improve memory usage and performance with Swift](https://developer.apple.com/videos/play/wwdc2025/312/)

--- a/docs/guide/instruments/index.md
+++ b/docs/guide/instruments/index.md
@@ -1,0 +1,211 @@
+---
+title: Xcode Instruments 시작하기
+description: Xcode의 Product > Profile에서 Instruments trace를 기록하고 timeline, inspection range, detail view를 읽어 성능 문제를 재현·분석·검증하는 기본 흐름을 설명합니다.
+---
+
+# Xcode Instruments 시작하기
+
+> **면접 답변 한 줄 요약:** Instruments는 실행 중인 앱의 CPU, 메모리, task, thread, 응답성 같은 데이터를 시간축에 기록하고, 느린 구간의 원인을 실제 측정값으로 좁혀 가는 Xcode 성능 분석 도구예요.
+
+앱이 “느린 것 같다”는 느낌만으로는 무엇을 고쳐야 할지 결정하기 어려워요. 같은 1초의 지연도 CPU 계산이 길어서 생길 수 있고, 파일이나 lock을 기다려 생길 수 있으며, 네트워크 응답이나 Main Actor 경합 때문일 수도 있어요.
+
+Instruments는 하나의 정답을 자동으로 알려 주는 도구가 아니에요. **증상을 재현하고, 관련 구간을 좁히고, 적절한 instrument의 상세 데이터를 읽어 가설을 검증하는 도구**예요. Apple도 성능 개선을 현재 상태 측정, 중요한 문제 선택, profiling, 변경, 재측정의 반복 과정으로 설명해요. 자세한 흐름은 [Improving your app’s performance](https://developer.apple.com/documentation/xcode/improving-your-app-s-performance/)에서 확인할 수 있어요.
+
+이 섹션에서는 다음 내용을 다뤄요.
+
+- Instruments를 열고 trace를 기록하는 기본 순서
+- timeline, track, inspection range, detail view를 읽는 방법
+- 질문에 맞는 template과 instrument를 고르는 기준
+- 비동기 메서드의 전체 지연 시간을 측정하는 방법
+- CPU 병목, 메모리 증가, UI 멈춤을 분석하는 방법
+- 수정 전후 trace를 비교해 개선을 검증하는 방법
+
+## 먼저 알아둘 Instruments 용어
+
+| 용어                    | 쉬운 뜻                                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| profiling               | 실행 중인 앱의 자원 사용과 호출 정보를 기록해 성능 특성을 조사하는 일이에요.                                                             |
+| instrument              | CPU sample, allocation, Swift task처럼 한 종류의 데이터를 수집하고 보여 주는 측정 도구예요.                                              |
+| template                | 목적에 맞는 여러 instrument와 기본 설정을 묶은 시작 구성이에요. Time Profiler, Allocations, Swift Concurrency 등이 있어요.               |
+| trace와 run             | trace는 Instruments 문서 전체이고, run은 Record부터 Stop까지 한 번 수집한 결과예요. 한 trace 안에 여러 run을 기록할 수 있어요.           |
+| timeline과 track        | timeline은 시간이 왼쪽에서 오른쪽으로 흐르는 영역이고, track은 CPU, Hangs, Points of Interest처럼 한 종류의 변화를 한 줄로 표시해요.     |
+| inspection range        | 현재 분석 대상으로 선택한 시간 구간이에요. detail view의 통계와 call tree는 이 범위를 기준으로 다시 계산돼요.                            |
+| detail view와 inspector | detail view는 선택한 track의 표, call tree, flame graph를 보여 주고, inspector는 선택한 event나 symbol의 추가 정보를 보여 줘요.          |
+| call tree               | 호출한 함수와 호출된 함수의 관계를 계층으로 묶은 표예요. CPU sample이나 task 생성 backtrace를 코드 경로로 읽을 때 사용해요.              |
+| symbolication           | 기계 주소를 `PhotoRepository.load()` 같은 함수 이름과 소스 위치로 바꾸는 과정이에요. 알맞은 debug symbol이 없으면 주소만 보일 수 있어요. |
+| baseline                | 최적화 전의 기준 측정값이에요. 같은 조건의 수정 후 결과와 비교해야 실제 개선인지 판단할 수 있어요.                                       |
+
+## 먼저 질문을 정하고 instrument를 골라요
+
+template 이름부터 고르면 눈앞의 그래프에 맞춰 문제를 해석하기 쉬워요. 먼저 사용자가 겪는 증상과 알고 싶은 값을 문장으로 적어 보세요.
+
+| 알고 싶은 것                                       | 먼저 선택할 도구                    | 이 도구가 답하는 질문                                                 |
+| -------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------------- |
+| 특정 `async` 메서드가 끝날 때까지 몇 초 걸리나요?  | `OSSignposter`와 Points of Interest | `await`로 중단된 시간을 포함한 시작부터 종료까지의 지연은 얼마인가요? |
+| task가 왜 늦게 실행되거나 어디서 중단되나요?       | Swift Concurrency의 Swift Tasks     | task의 수명, 상태 변화, 부모·자식 관계는 어떤가요?                    |
+| 실행 중 CPU를 가장 많이 쓰는 코드는 무엇인가요?    | CPU Profiler 또는 Time Profiler     | CPU가 코드를 실행할 때 자주 관측되는 호출 경로는 무엇인가요?          |
+| 화면이 터치에 늦게 반응하는 이유는 무엇인가요?     | Hangs, Time Profiler, System Trace  | Main Thread가 계산 중인가요, 다른 자원을 기다리나요?                  |
+| 기능을 반복할수록 메모리가 늘어나는 이유는 뭔가요? | Allocations의 Generations, Leaks    | 어떤 allocation이 살아남고, 도달할 수 없는 누수는 무엇인가요?         |
+| 네트워크 요청과 응답 구간이 느린가요?              | Network template와 URLSession 지표  | 연결, 전송, 응답 단계 중 어디서 시간이 걸리나요?                      |
+| 배터리를 많이 쓰는 원인은 무엇인가요?              | Power Profiler                      | CPU, GPU, network, wake-up 가운데 전력 영향이 큰 활동은 무엇인가요?   |
+
+한 trace 문서에 instrument를 더 추가할 수도 있어요. 예를 들어 Hangs가 표시된 구간에 Swift Tasks를 추가하면 Main Actor에서 실행된 비동기 작업을 함께 볼 수 있어요. 그러나 처음부터 모든 instrument를 넣으면 기록 비용과 화면 복잡도가 커지므로 현재 가설을 검증하는 도구부터 선택하세요.
+
+## 측정 전에 재현 절차를 고정해요
+
+좋은 trace는 Record 버튼을 누르기 전에 결정돼요. “앱을 둘러본다”보다 다음처럼 시작과 끝이 분명한 절차를 준비하세요.
+
+```text
+앱을 완전히 종료한다
+  → 사진 목록을 연다
+  → 첫 번째 사진을 선택한다
+  → 편집 화면이 나타날 때까지 기다린다
+  → Stop을 누른다
+```
+
+측정 조건도 함께 기록해요.
+
+- 앱 commit과 build configuration
+- Xcode, iOS와 기기 모델
+- 네트워크 종류와 cache가 비어 있는지 여부
+- 로그인 상태와 사용한 테스트 데이터
+- 발열 상태와 저전력 모드 여부
+- 첫 실행인지, 한 번 준비한 뒤의 반복 실행인지
+
+Simulator는 빠른 반복과 기능 확인에는 유용하지만 Mac의 CPU와 자원을 사용해요. Apple은 실제 성능을 판단할 때 물리 기기에서 더 높은 충실도의 측정을 얻을 수 있다고 안내해요. 특히 문제가 특정 저사양 기기에서 발생하면 그 기기에서 다시 측정하세요. 자세한 내용은 [Running your app on simulated or physical devices](https://developer.apple.com/documentation/xcode/running-your-app-on-simulated-or-physical-devices)와 [Improving your app’s performance](https://developer.apple.com/documentation/xcode/improving-your-app-s-performance/)에서 확인할 수 있어요.
+
+## Product > Profile로 trace를 기록해요
+
+Xcode 프로젝트에서 앱을 profiling하는 기본 흐름은 다음과 같아요.
+
+1. Xcode toolbar에서 scheme과 측정할 물리 기기를 선택해요.
+2. `Product > Scheme > Edit Scheme`의 Profile action이 의도한 build configuration을 사용하는지 확인해요.
+3. `Product > Profile`을 선택하거나 `Command-I`를 눌러요.
+4. template 선택 창에서 현재 질문에 맞는 template을 골라 `Choose`를 눌러요.
+5. Instruments toolbar의 target이 원하는 기기와 앱인지 확인해요.
+6. 왼쪽 위 Record 버튼을 누르고 준비한 절차만 재현해요.
+7. 문제가 나타나면 Stop을 눌러 기록을 끝내요.
+
+Instruments 앱을 `Xcode > Open Developer Tool > Instruments`로 직접 열고 target을 선택할 수도 있어요. 처음에는 Xcode의 `Product > Profile`이 scheme, build와 target을 자연스럽게 이어 주므로 더 단순해요. 전체 UI의 기본 사용법은 Apple의 [Getting Started with Instruments](https://developer.apple.com/videos/play/wwdc2019/411/)에서도 단계별로 볼 수 있어요.
+
+### Profile build와 symbol을 확인해요
+
+Debug build는 최적화되지 않은 코드, 진단 기능과 debugger의 영향 때문에 배포 코드와 다른 결과를 낼 수 있어요. Profile action은 보통 Release configuration을 사용하지만 프로젝트에서 바꿀 수 있으므로 Scheme Editor에서 직접 확인하세요.
+
+최적화된 build를 읽으려면 debug symbol도 필요해요. Release binary와 dSYM은 build UUID가 일치해야 하고, 앱과 포함된 framework마다 대응하는 dSYM이 있어요. 함수 이름 대신 주소만 보인다면 다음 항목을 확인하세요.
+
+- `Debug Information Format`이 `DWARF with dSYM File`인지
+- 분석 중인 binary와 dSYM이 같은 archive에서 나왔는지
+- Instruments의 `File > Symbols`에 올바른 dSYM이 연결됐는지
+
+자세한 symbol 생성과 보관 기준은 [Building your app to include debugging information](https://developer.apple.com/documentation/xcode/building-your-app-to-include-debugging-information)에서 확인할 수 있어요.
+
+## timeline에서 문제 구간을 먼저 좁혀요
+
+전체 recording의 call tree를 바로 펼치면 앱 시작, 화면 전환, background 작업이 모두 섞여요. 다음 순서로 관심 구간부터 제한하세요.
+
+1. timeline에서 증상이 발생한 track을 찾아요.
+2. 마우스로 시작과 끝을 드래그해 inspection range를 선택해요.
+3. `Option`을 누른 채 범위를 드래그하거나 관련 메뉴로 확대해요.
+4. 분석하려는 track을 선택해 아래 detail view를 바꿔요.
+5. table, call tree 또는 flame graph에서 무거운 항목을 찾고 source로 이동해요.
+
+`OSSignposter`로 “LoadFeed” 같은 interval을 남겨 두면 사용자 동작을 눈으로 추측하지 않아도 돼요. interval을 inspection range로 설정하면 같은 구간의 CPU, thread, task 데이터도 함께 걸러져요. 비동기 측정 코드는 [비동기 메서드 시간 측정](./async-method-timing.md) 문서에서 자세히 다뤄요.
+
+## timeline, detail view, inspector의 역할을 나눠 읽어요
+
+Instruments 화면은 다음 질문 순서로 읽으면 덜 복잡해요.
+
+```text
+Timeline
+  “언제 이상했나요?”
+        ↓ 범위를 선택
+Detail View
+  “그 구간에서 무엇이 많거나 무거웠나요?”
+        ↓ 항목을 선택
+Inspector / Source Viewer
+  “어떤 코드 경로와 상태가 이 결과를 만들었나요?”
+```
+
+timeline의 높이가 크다는 이유만으로 원인을 확정하지 마세요. CPU graph가 높다면 call tree로 앱 코드를 찾아야 하고, Hangs 표시가 있다면 Main Thread가 실행 중인지 blocked 상태인지 추가로 구분해야 해요. instrument마다 수집 방식과 weight의 의미도 달라요.
+
+## 한 번의 수치보다 반복 가능한 비교를 만들어요
+
+성능은 background process, cache, 네트워크와 발열에 따라 달라져요. 하나의 가장 빠른 결과만 골라 결론 내리지 말고 다음 과정을 사용하세요.
+
+1. 준비 실행으로 shader, cache와 lazy initialization 영향을 구분해요.
+2. 같은 입력과 조작으로 여러 번 기록해 분포와 이상치를 봐요.
+3. 개선 전 trace를 baseline으로 저장해요.
+4. 한 번에 하나의 중요한 변경만 적용해요.
+5. 같은 기기와 조건에서 다시 기록해요.
+6. 목표 구간뿐 아니라 메모리, 응답성, 전력의 부작용도 확인해요.
+
+Instruments의 run comparison을 사용할 수 있는 버전이라면 같은 trace의 이전 run과 새 run을 비교하세요. 자동 회귀 검사가 필요하면 Instruments에서 찾은 구간을 XCTest 또는 Swift Testing의 성능 test로 옮겨 지속적으로 측정하는 편이 좋아요.
+
+## 흔한 실수를 피해야 해요
+
+### recording 전체의 가장 무거운 함수를 바로 고치지 않아요
+
+앱이 오래 머문 idle loop나 시작 과정이 사용자 문제와 무관할 수 있어요. 먼저 증상 구간을 inspection range로 제한하세요.
+
+### sample 수를 메서드의 정확한 실행 시간으로 읽지 않아요
+
+Time Profiler와 CPU Profiler는 모든 함수 호출을 stopwatch처럼 재는 도구가 아니에요. call stack을 sample해 CPU 비용의 비중을 추정해요. 한 비동기 메서드의 시작부터 끝까지 걸린 시간은 signpost interval로 표시하세요.
+
+### CPU가 낮으면 코드가 빠르다고 단정하지 않아요
+
+thread가 file I/O, lock, network나 actor를 기다리면 사용자는 느리다고 느끼지만 CPU graph는 낮을 수 있어요. 이때는 System Trace, Network 또는 Swift Concurrency instrument가 더 적합해요.
+
+### Simulator 결과를 기기 시간으로 일반화하지 않아요
+
+Simulator와 실제 기기는 CPU, GPU, memory pressure와 thermal 조건이 달라요. Simulator는 가설을 빠르게 확인하는 도구로 사용하고 최종 판단은 목표 기기에서 검증하세요.
+
+### 개선 후 재측정을 생략하지 않아요
+
+코드가 단순해졌다는 이유만으로 성능이 좋아졌다고 단정할 수 없어요. 같은 절차의 after trace를 만들고 baseline과 비교하세요.
+
+## 문제별 다음 문서를 선택해요
+
+- `async` 함수의 전체 지연과 task 중단 구간을 알고 싶다면 [비동기 메서드 시간 측정](./async-method-timing.md)을 읽어요.
+- CPU를 실제로 많이 사용하는 함수와 call path를 찾고 싶다면 [CPU Profiler와 Time Profiler](./cpu-profiling.md)를 읽어요.
+- 반복 동작 뒤 살아남는 객체와 누수를 찾고 싶다면 [Allocations와 Leaks](./memory-profiling.md)를 읽어요.
+- 터치나 화면 전환이 멈추는 원인을 찾고 싶다면 [Hangs와 앱 응답성](./responsiveness-and-hangs.md)을 읽어요.
+
+## 적용 순서를 정리해요
+
+1. 사용자가 느끼는 증상을 한 문장으로 적어요.
+2. 시작과 끝이 분명한 재현 절차와 목표 기기를 정해요.
+3. 질문에 맞는 가장 작은 template을 선택해요.
+4. Record, 재현, Stop 순서로 짧은 trace를 만들어요.
+5. timeline에서 문제 구간을 inspection range로 제한해요.
+6. detail view와 source에서 원인 가설을 세워요.
+7. 한 가지 변경을 적용하고 같은 조건으로 다시 기록해요.
+8. baseline과 비교해 개선과 부작용을 함께 확인해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Instruments와 Xcode debugger는 무엇이 다른가요?
+
+debugger는 breakpoint에서 실행을 멈추고 값과 제어 흐름을 조사하는 데 적합해요. Instruments는 앱을 계속 실행하면서 시간에 따른 CPU, memory, task, thread와 응답성 데이터를 수집해 성능 특성을 분석해요.
+
+### Time Profiler에서 가장 위에 있는 함수가 항상 문제인가요?
+
+아니에요. recording 전체가 아니라 사용자가 느낀 문제 구간으로 inspection range를 제한하고, 앱 코드인지와 self weight·호출 경로를 함께 봐야 해요. CPU가 아닌 대기 문제라면 Time Profiler의 무거운 함수가 원인이 아닐 수도 있어요.
+
+### 왜 실제 기기에서 다시 측정해야 하나요?
+
+Simulator는 Mac의 하드웨어와 운영 환경을 사용하므로 기기의 CPU, GPU, memory pressure와 thermal 특성을 그대로 재현하지 못해요. 최종 성능 판단은 사용자가 실제로 실행할 기기, 특히 문제가 발생하는 기기 등급에서 해야 해요.
+
+### dSYM은 profiling에 왜 필요한가요?
+
+dSYM은 최적화된 binary의 기계 주소를 함수와 소스 위치로 바꾸는 debug symbol을 담아요. binary와 UUID가 맞는 dSYM이 없으면 call tree가 주소나 알아보기 어려운 symbol로 표시돼 원인 코드를 찾기 어려워요.
+
+## 참고 자료
+
+- [Apple Developer — Instruments Tutorials](https://developer.apple.com/tutorials/instruments)
+- [WWDC19 — Getting Started with Instruments](https://developer.apple.com/videos/play/wwdc2019/411/)
+- [Apple Developer — Improving your app’s performance](https://developer.apple.com/documentation/xcode/improving-your-app-s-performance/)
+- [Apple Developer — Performance and metrics](https://developer.apple.com/documentation/xcode/performance-and-metrics)
+- [Apple Developer — Running your app on simulated or physical devices](https://developer.apple.com/documentation/xcode/running-your-app-on-simulated-or-physical-devices)
+- [Apple Developer — Customizing the build schemes for a project](https://developer.apple.com/documentation/xcode/customizing-the-build-schemes-for-a-project)
+- [Apple Developer — Building your app to include debugging information](https://developer.apple.com/documentation/xcode/building-your-app-to-include-debugging-information)

--- a/docs/guide/instruments/memory-profiling.md
+++ b/docs/guide/instruments/memory-profiling.md
@@ -1,0 +1,304 @@
+---
+title: Allocations와 Leaks로 메모리 분석하기
+description: Xcode Memory Graph와 Instruments의 Allocations, Generations, Leaks를 구분하고 반복 동작 뒤 살아남는 객체, 일시적 peak와 retain cycle의 할당 경로를 찾는 방법을 설명합니다.
+---
+
+# Allocations와 Leaks로 메모리 분석하기
+
+> **면접 답변 한 줄 요약:** 메모리 분석은 Allocations로 언제 무엇이 할당되고 반복 동작 뒤 무엇이 살아남는지 찾고, Leaks와 Memory Graph로 도달할 수 없는 allocation과 retain cycle의 참조 경로를 확인하는 과정이에요.
+
+앱의 memory graph가 올라간다는 사실만으로 leak이라고 부를 수는 없어요. 큰 이미지를 처리하는 동안 잠깐 올라갔다가 내려오는 **일시적 증가**일 수 있고, cache가 계속 보관하는 **도달 가능한 미사용 객체**일 수 있으며, 참조를 잃었지만 해제되지 못한 실제 **leak**일 수도 있어요.
+
+도구마다 보는 대상이 달라요.
+
+- Xcode memory gauge는 현재 사용량과 peak를 빠르게 알려 줘요.
+- Allocations는 heap과 anonymous VM allocation의 수, 크기와 생성 stack을 기록해요.
+- Generations는 기능 실행 전후에 만들어져 계속 살아 있는 allocation을 좁혀요.
+- Leaks는 앱에서 도달할 수 없지만 해제되지 않은 memory 영역을 주기적으로 찾아요.
+- Memory Graph Debugger는 한 시점의 객체와 strong reference 경로를 보여 줘요.
+
+## 먼저 알아둘 메모리 분석 용어
+
+| 용어                 | 쉬운 뜻                                                                                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| heap                 | 실행 중 크기와 수명이 동적으로 정해지는 객체와 buffer가 저장되는 memory 영역이에요. Swift class, closure context와 여러 collection storage가 여기에 놓일 수 있어요. |
+| allocation           | 실행 중 memory block을 확보하는 일이에요. 하나의 Swift 객체가 내부 buffer를 포함해 여러 allocation을 만들 수도 있어요.                                              |
+| live allocation      | 아직 deallocate되지 않고 현재 살아 있는 allocation이에요. 앱이 실제로 유용하게 사용 중인지와는 별개의 의미예요.                                                     |
+| transient growth     | 작업 중 memory가 증가하지만 작업이 끝나면 내려오는 일시적 증가예요. Peak가 너무 크면 leak이 없어도 system 종료 위험이 생겨요.                                       |
+| persistent growth    | 화면을 닫거나 기능을 끝낸 뒤에도 이전보다 높은 memory가 남고 반복할수록 증가하는 상태예요.                                                                          |
+| leak                 | 더는 유용하게 접근할 방법이 없는데도 deallocate되지 않은 memory예요. strong reference cycle이나 수동 memory 관리 오류가 원인이 될 수 있어요.                        |
+| reachable memory     | root나 전역 cache처럼 앱이 여전히 참조 경로를 가진 memory예요. 사용하지 않아도 참조가 남아 있으면 Leaks가 leak으로 판단하지 않을 수 있어요.                         |
+| retain cycle         | 둘 이상의 객체나 closure가 strong reference로 서로를 붙잡아 외부 사용이 끝나도 reference count가 0이 되지 않는 구조예요.                                            |
+| generation           | Allocations에서 특정 시점 사이에 생긴 allocation을 묶어 비교하는 표식이에요. 기능 전, 실행 후, 화면 종료 후를 나누는 데 사용해요.                                   |
+| allocation backtrace | memory가 만들어진 시점의 call stack이에요. 현재 사용 위치가 아니라 누가 할당했는지 찾는 단서예요.                                                                   |
+| memory footprint     | 앱 process가 system memory에 미치는 전체적인 점유 규모예요. Swift heap allocation 합계와 완전히 같은 값은 아니에요.                                                 |
+
+ARC와 strong·weak reference의 언어 규칙을 먼저 복습하려면 [Swift 메모리 관리와 ARC](../swift/memory-management.md)를 읽어 보세요.
+
+## 먼저 증가 모양을 세 종류로 나눠요
+
+사진 편집 화면을 열어 filter를 적용하고 닫는 동작을 반복한다고 가정해 볼게요.
+
+```text
+Transient
+기준 100 MB → 편집 중 260 MB → 닫은 후 105 MB
+
+Persistent
+기준 100 MB → 1회 후 140 MB → 2회 후 180 MB → 3회 후 220 MB
+
+Plateau / Cache
+기준 100 MB → 1회 후 180 MB → 이후에도 약 180 MB 유지
+```
+
+세 모양의 조사 방향은 달라요.
+
+| 관찰 모양                 | 먼저 확인할 것                                                                   |
+| ------------------------- | -------------------------------------------------------------------------------- |
+| 순간 peak가 너무 커요.    | 같은 시점에 살아 있는 image buffer, autorelease object와 중간 collection을 봐요. |
+| 반복마다 바닥이 올라가요. | Generations로 각 반복 뒤 남은 객체와 allocation backtrace를 비교해요.            |
+| 한 번 올라간 뒤 유지돼요. | 의도한 cache인지, 최대 크기와 memory warning 정리 정책이 있는지 확인해요.        |
+| Leaks가 표시돼요.         | leak 상세의 allocation stack과 Memory Graph의 reference cycle을 확인해요.        |
+
+memory peak가 원래 수준으로 돌아오더라도 peak가 기기 한계를 넘으면 앱이 종료될 수 있어요. 반대로 앱이 살아 있는 객체를 의도적으로 cache하면 Leaks 표시가 없어도 footprint는 높을 수 있어요.
+
+## Xcode memory gauge로 증상을 빠르게 확인해요
+
+앱을 Xcode에서 실행하고 Debug navigator의 Memory report를 열면 현재 memory 사용량과 기록 중 peak를 볼 수 있어요. 다음 용도로 사용하세요.
+
+- 어떤 사용자 동작에서 memory가 갑자기 증가하는지 찾기
+- 화면을 닫은 뒤 대략적인 수준이 내려오는지 확인하기
+- 반복 동작에서 바닥과 peak가 계속 올라가는지 관찰하기
+- Memory Graph Debugger를 캡처할 시점을 정하기
+
+gauge 하나로 allocation 종류와 생성 stack을 알 수는 없어요. 재현 가능한 증가를 확인했으면 Allocations trace로 넘어가세요. Apple의 [Gathering information about memory use](https://developer.apple.com/documentation/xcode/gathering-information-about-memory-use)는 gauge, Memory Graph와 Allocations의 역할을 함께 설명해요.
+
+## Allocations로 할당 종류와 생성 경로를 찾아요
+
+Allocations instrument는 heap과 anonymous virtual memory allocation을 category별로 모으고 수, 크기와 생성 stack을 보여 줘요.
+
+1. 물리 기기를 선택하고 `Product > Profile`을 실행해요.
+2. Allocations template을 선택해요.
+3. Record를 누르고 앱을 기준 화면까지 이동해요.
+4. target process의 Allocations track과 Statistics를 선택해요.
+5. 사진 편집처럼 조사할 기능을 한 번 실행하고 닫아요.
+6. Stop한 뒤 inspection range와 allocation category를 좁혀요.
+7. persistent bytes, live count와 allocation backtrace를 확인해요.
+
+모든 allocation을 줄이는 것이 목표는 아니에요. 사용자 경험에 필요한 object와 buffer도 정상적으로 allocation돼요. 다음 질문으로 우선순위를 정하세요.
+
+- 크기가 큰가요, 수가 지나치게 많은가요?
+- 기능 종료 뒤에도 live 상태인가요?
+- 반복할수록 live count나 persistent bytes가 증가하나요?
+- allocation stack이 앱의 어느 소스 경로로 이어지나요?
+- 같은 결과를 위해 너무 많은 임시 값과 copy를 만들고 있나요?
+
+### allocation 시점과 현재 소유자를 구분해요
+
+Allocations의 stack은 객체가 **만들어진 위치**를 보여 줘요. 지금 누가 그 객체를 붙잡고 있는지는 Memory Graph의 reference path가 더 직접적인 단서예요.
+
+```text
+Allocations
+  “이 객체는 어디서 만들어졌나요?”
+
+Memory Graph
+  “지금 누가 이 객체를 strong reference로 붙잡나요?”
+```
+
+두 질문을 함께 사용하면 “Repository가 만들었고, 닫힌 View Controller의 callback chain이 아직 소유한다”처럼 원인을 연결할 수 있어요.
+
+## Generations로 기능 전후를 분리해요
+
+recording 전체 allocation에는 앱 시작, system framework와 다른 화면의 작업이 섞여요. Generations를 사용하면 관심 기능 사이에 생긴 allocation만 상대적으로 좁힐 수 있어요.
+
+사진 상세 화면의 persistent growth를 조사하는 순서는 다음과 같아요.
+
+1. 앱을 실행하고 사진 목록에서 안정될 때까지 기다려요.
+2. Allocations의 `Mark Generation`을 눌러 기준을 만들어요.
+3. 사진 상세 화면을 열고 이미지를 불러와요.
+4. 다시 `Mark Generation`을 눌러 기능 실행 구간을 나눠요.
+5. 상세 화면을 닫고 비동기 작업이 정리될 시간을 줘요.
+6. 다시 `Mark Generation`을 눌러 종료 뒤 상태를 나눠요.
+7. 같은 동작을 두세 번 반복해 각 generation에 계속 남는 타입을 비교해요.
+
+| generation 구간       | 기대하는 관찰                                                     |
+| --------------------- | ----------------------------------------------------------------- |
+| 기준 → 화면 열기      | View Controller, image, task와 cell이 만들어질 수 있어요.         |
+| 화면 열기 → 화면 닫기 | 화면 전용 객체 대부분이 deallocate되어야 해요.                    |
+| 2회·3회 반복          | 의도하지 않은 같은 타입의 live allocation이 누적되지 않아야 해요. |
+
+generation 사이에 만들어진 모든 allocation이 해당 기능의 것은 아니에요. system과 background activity도 함께 기록될 수 있으므로 type, size, backtrace와 반복 패턴을 함께 확인하세요.
+
+## Leaks가 찾는 것과 찾지 못하는 것을 구분해요
+
+Leaks instrument는 앱의 memory를 주기적으로 scan해 할당됐지만 도달할 수 없는 영역을 보고하고 allocation stack을 제공해요. C API로 할당한 memory를 free하지 않은 경우나 외부 참조가 끊긴 retain cycle을 찾는 데 도움이 돼요.
+
+그러나 다음 memory 증가는 Leaks에 나타나지 않을 수 있어요.
+
+- 전역 dictionary가 계속 보관하는 이미지 cache
+- 화면은 사라졌지만 coordinator가 실수로 계속 참조하는 View Controller
+- 완료되지 않은 task가 붙잡은 큰 response
+- 필요 없어졌지만 reachable 상태인 model graph
+- 기능 중 잠깐 발생하는 매우 큰 transient buffer
+
+Apple의 [Making changes to reduce memory use](https://developer.apple.com/documentation/xcode/making-changes-to-reduce-memory-use)도 앱이 접근 가능하지만 사용하지 않는 memory는 사용량을 높여도 Leaks 같은 leak detection tool에 나타나지 않을 수 있다고 설명해요. “Leaks가 0이므로 memory 문제가 없다”는 결론을 내리면 안 돼요.
+
+## Memory Graph로 retain cycle을 따라가요
+
+다음 View Model은 자신이 저장한 closure가 다시 자신을 strong capture해 cycle을 만들어요.
+
+```swift
+final class PhotoDetailViewModel {
+  var onRefresh: (() -> Void)?
+  private(set) var title = ""
+
+  func start() {
+    onRefresh = {
+      self.title = "새로고침 완료"
+    }
+  }
+
+  deinit {
+    print("PhotoDetailViewModel deinit")
+  }
+}
+```
+
+참조 관계는 다음과 같아요.
+
+```text
+PhotoDetailViewModel
+  └─ strong → onRefresh closure
+                   └─ strong → PhotoDetailViewModel
+```
+
+화면을 닫은 뒤 `deinit`이 호출되지 않고 같은 타입이 Generations에 남는다면 Xcode의 Debug Memory Graph 버튼으로 snapshot을 만들어요.
+
+1. 검색창에서 `PhotoDetailViewModel`을 찾아요.
+2. 의도보다 많은 instance가 남았는지 확인해요.
+3. instance를 선택해 incoming strong reference path를 따라가요.
+4. closure context나 coordinator가 소유하는 경로를 source와 대조해요.
+
+closure가 View Model을 소유할 필요가 없다면 weak capture로 cycle을 끊을 수 있어요.
+
+```swift
+func start() {
+  onRefresh = { [weak self] in
+    self?.title = "새로고침 완료"
+  }
+}
+```
+
+`weak`을 기계적으로 모든 closure에 추가하지 마세요. closure가 실행되는 동안 객체가 반드시 살아 있어야 하는 소유 관계라면 다른 lifecycle 설계가 필요할 수 있어요. `unowned`는 객체가 먼저 해제되면 runtime crash가 발생할 수 있으므로 수명이 논리적으로 보장될 때만 사용해요.
+
+### deinit log는 단서이지 전체 검사가 아니에요
+
+`deinit`에 breakpoint나 임시 log를 넣으면 화면 전용 객체가 해제되는지 빠르게 확인할 수 있어요. 그러나 모든 allocation이 Swift class는 아니고 compiler 최적화와 object lifecycle에 따라 timing이 달라질 수 있어요. 최종 원인은 Generations, allocation stack과 reference graph로 확인하세요.
+
+## transient memory peak를 줄여요
+
+leak이 없어도 큰 image나 file을 한꺼번에 처리하면 peak가 높아질 수 있어요. 다음 패턴을 확인하세요.
+
+- 원본 image, 변환 image와 encoded `Data`를 동시에 오래 보관해요.
+- 큰 배열을 `map`, `filter`, `sorted`로 연속 변환해 중간 buffer를 만들어요.
+- loop 안의 Objective-C autoreleased object가 iteration 끝까지 쌓여요.
+- 전체 file을 memory에 올린 뒤 다시 복사해요.
+- 화면 크기보다 훨씬 큰 image를 decode해요.
+
+대안은 원인에 따라 달라요.
+
+- image를 실제 표시 크기에 맞춰 downsample해요.
+- stream이나 chunk 단위 API로 전체 buffer 동시 보유를 피합니다.
+- 중간 collection 수명 범위를 줄이고 필요한 경우 lazy sequence를 검토해요.
+- 독립적인 큰 작업 iteration에 `autoreleasepool`이 도움이 되는지 trace로 확인해요.
+- cache에 count 또는 cost limit과 memory pressure 정리 정책을 둬요.
+
+작업을 여러 chunk로 나누면 총 allocation 횟수나 I/O가 늘어날 수도 있어요. peak만 줄인 뒤 CPU와 latency가 크게 나빠지지 않았는지 함께 측정하세요.
+
+## async task가 객체 수명을 늘리는지 확인해요
+
+비동기 작업은 시작한 화면보다 오래 살아남을 수 있어요. task closure가 View Model이나 큰 입력을 capture하고 취소되지 않으면 화면을 닫은 뒤에도 memory가 유지될 수 있어요.
+
+다음 항목을 Allocations와 Swift Tasks에서 함께 확인하세요.
+
+- 화면 종료 시 task를 취소하는 lifecycle이 있는지
+- 취소가 underlying operation까지 전달되는지
+- task가 큰 `Data`, image 배열이나 actor를 capture하는지
+- continuation이 모든 경로에서 resume되는지
+- Alive Tasks와 같은 타입의 live allocation이 함께 증가하는지
+
+task가 살아 있다는 사실만으로 leak은 아니에요. background upload처럼 의도된 lifetime일 수 있어요. 중요한 것은 누가 task를 소유하고 언제 끝나야 하는지 코드와 trace에서 설명할 수 있는가예요.
+
+## 도구별 역할을 비교해요
+
+| 도구               | 가장 잘 답하는 질문                               | 놓칠 수 있는 것                                |
+| ------------------ | ------------------------------------------------- | ---------------------------------------------- |
+| Xcode memory gauge | 언제 footprint와 peak가 증가하나요?               | 구체적인 allocation type과 소유 경로           |
+| Allocations        | 어떤 type이 어디서 얼마나 만들어지고 살아 있나요? | 현재 strong reference chain의 의미             |
+| Generations        | 기능 전후와 반복 사이에 무엇이 계속 남나요?       | generation 밖에서 만들어진 오래된 객체의 원인  |
+| Leaks              | 도달할 수 없고 해제되지 않은 memory가 있나요?     | reachable cache와 필요 없지만 참조가 남은 객체 |
+| Memory Graph       | 현재 snapshot에서 누가 객체를 참조하나요?         | 시간에 따른 allocation rate와 transient peak   |
+| Swift Tasks        | task lifetime이 객체와 작업을 오래 붙잡고 있나요? | heap allocation 전체의 크기와 종류             |
+
+## 흔한 실수를 피해야 해요
+
+### memory가 증가하면 모두 retain cycle이라고 단정하지 않아요
+
+large buffer, cache, VM mapping과 framework memory도 footprint를 높일 수 있어요. 증가 모양과 allocation category를 먼저 분류하세요.
+
+### object count만 보고 byte 비용을 놓치지 않아요
+
+작은 객체 수천 개보다 큰 image buffer 몇 개가 더 많은 memory를 사용할 수 있어요. live count와 persistent bytes를 함께 정렬해요.
+
+### 화면을 닫자마자 snapshot 하나만 보지 않아요
+
+animation, async cleanup과 autorelease drain이 끝날 시간을 주고 반복 결과를 비교하세요. 단, 무작정 오래 기다려 문제를 숨기지 말고 앱 lifecycle에서 기대하는 해제 시점을 먼저 정해요.
+
+### Leaks 결과만으로 통과 여부를 정하지 않아요
+
+reachable하지만 사용하지 않는 cache와 객체는 leak scan에 잡히지 않을 수 있어요. Allocations의 persistent growth와 Memory Graph를 함께 사용하세요.
+
+### 최적화 전후 조건을 바꾸지 않아요
+
+같은 image 크기, 반복 횟수, 기기와 화면 경로에서 peak와 바닥을 비교하세요. cache가 warm한 after run과 cold baseline을 비교하면 잘못된 개선처럼 보일 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. memory가 증가하는 기능과 반복 절차를 고정해요.
+2. gauge에서 transient, persistent와 plateau 모양을 구분해요.
+3. Allocations를 기록하고 Generations로 기능 전후를 나눠요.
+4. 남은 type의 live count, bytes와 allocation backtrace를 확인해요.
+5. Leaks 결과와 Memory Graph의 incoming reference를 대조해요.
+6. retain cycle, reachable cache, task lifetime과 peak buffer 중 원인을 분류해요.
+7. 가장 큰 원인을 하나 고치고 같은 조건으로 다시 기록해요.
+8. memory 감소가 CPU, latency와 기능 lifecycle을 해치지 않았는지 확인해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Allocations와 Leaks는 무엇이 다른가요?
+
+Allocations는 만들어진 heap과 anonymous VM allocation의 수, 크기, 수명과 생성 stack을 폭넓게 기록해요. Leaks는 그중 앱에서 도달할 수 없지만 해제되지 않은 memory를 찾아 보고하므로 reachable cache와 모든 persistent growth를 잡지는 못해요.
+
+### Leaks가 0이면 메모리 문제가 없나요?
+
+아니에요. 앱이 참조는 유지하지만 더는 사용하지 않는 객체, 제한 없는 cache와 transient peak는 Leaks에 표시되지 않을 수 있어요. footprint 모양, Generations와 Memory Graph를 함께 확인해야 해요.
+
+### Generations는 왜 사용하나요?
+
+recording 전체 allocation에서 특정 기능 사이에 만들어진 객체를 상대적으로 분리하기 위해 사용해요. 기능 전, 실행 후, 화면 종료 후에 mark하고 반복하면 매번 새로 남는 type과 allocation stack을 찾기 쉬워져요.
+
+### Memory Graph와 allocation backtrace는 무엇이 다른가요?
+
+allocation backtrace는 객체가 만들어진 과거의 호출 경로를 보여 줘요. Memory Graph는 snapshot 시점에 어떤 객체가 strong reference로 붙잡고 있는지 보여 주므로 생성 원인과 현재 소유 원인을 서로 보완해요.
+
+### weak와 unowned 중 무엇을 선택해야 하나요?
+
+참조 대상이 먼저 해제될 수 있으면 `weak`으로 optional 접근을 사용해요. closure가 실행되는 동안 대상이 반드시 살아 있다는 수명 규칙을 증명할 수 있을 때만 `unowned`를 선택하며, 보장이 깨지면 crash가 발생할 수 있어요.
+
+## 참고 자료
+
+- [Apple Developer — Gathering information about memory use](https://developer.apple.com/documentation/xcode/gathering-information-about-memory-use)
+- [Apple Developer — Making changes to reduce memory use](https://developer.apple.com/documentation/xcode/making-changes-to-reduce-memory-use)
+- [WWDC24 — Analyze heap memory](https://developer.apple.com/videos/play/wwdc2024/10173/)
+- [WWDC21 — Detect and diagnose memory issues](https://developer.apple.com/videos/play/wwdc2021/10180/)
+- [Apple Developer — Diagnosing memory, thread, and crash issues early](https://developer.apple.com/documentation/xcode/diagnosing-memory-thread-and-crash-issues-early)
+- [Apple Developer — Finding Memory Leaks](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/FindingLeaks.html)

--- a/docs/guide/instruments/responsiveness-and-hangs.md
+++ b/docs/guide/instruments/responsiveness-and-hangs.md
@@ -1,0 +1,277 @@
+---
+title: Hangs와 앱 응답성 분석하기
+description: Instruments의 Hangs, Time Profiler, System Trace와 Swift Tasks를 함께 사용해 Main Thread가 CPU 작업, lock·I/O 대기 또는 Main Actor task로 멈추는 원인을 구분합니다.
+---
+
+# Hangs와 앱 응답성 분석하기
+
+> **면접 답변 한 줄 요약:** 앱의 hang은 Main Thread가 사용자 event와 다음 frame을 제때 처리하지 못한 구간이며, Hangs로 증상을 찾고 CPU가 높으면 profiler, 낮으면 thread state, 비동기 작업이면 Swift Tasks를 겹쳐 원인을 구분해요.
+
+버튼을 눌렀는데 화면이 늦게 바뀌거나 scrolling이 잠깐 멎으면 사용자는 앱이 자신의 입력을 무시했다고 느껴요. 이때 “background로 보내면 된다”는 처방부터 적용하면 실제 원인이 lock이나 Main Actor task 경합일 때 문제를 옮기거나 새로운 data race를 만들 수 있어요.
+
+응답성 문제는 먼저 Main Thread가 무엇을 하고 있었는지에 따라 나눠야 해요.
+
+- Main Thread가 CPU 계산을 계속 실행하는 **busy hang**
+- lock, file I/O나 다른 thread를 기다리는 **blocked hang**
+- 나중에 예약된 Main Actor task가 긴 작업을 실행해 event를 늦추는 **비동기 hang**
+
+Apple의 [Analyze hangs with Instruments](https://developer.apple.com/videos/play/wwdc2023/10248/)도 이 세 종류를 실제 trace에서 구분해 분석해요.
+
+## 먼저 알아둘 응답성 용어
+
+| 용어                 | 쉬운 뜻                                                                                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Main Thread          | UIKit과 AppKit의 event 처리와 많은 UI update가 실행되는 process의 중심 thread예요. 오래 점유하거나 막으면 입력과 rendering이 늦어질 수 있어요.            |
+| Main Actor           | Swift Concurrency에서 UI 관련 상태를 직렬화하는 전역 actor예요. 보통 Main Thread에서 실행되지만 actor는 thread 자체가 아니라 격리와 실행 순서를 나타내요. |
+| event loop와 frame   | system이 입력 event를 받고 앱 코드를 실행한 뒤 화면을 update하는 반복 흐름이에요. 한 작업이 길면 다음 event와 frame이 기다려요.                           |
+| hang                 | 앱이 사용자 입력에 눈에 띄게 늦게 응답하는 정지 구간이에요. crash와 달리 process는 살아 있고 나중에 다시 진행할 수 있어요.                                |
+| hitch                | animation이나 scrolling의 frame이 제시간에 준비되지 않아 시각적으로 끊기는 현상이에요. hang과 겹칠 수 있지만 rendering pipeline 문제일 수도 있어요.       |
+| running              | thread가 CPU에서 명령을 실행 중인 상태예요.                                                                                                               |
+| blocked 또는 waiting | thread가 lock, I/O, sleep나 다른 자원을 기다려 CPU에서 실행되지 않는 상태예요.                                                                            |
+| synchronous hang     | 사용자 action이 바로 긴 함수를 호출해 그 호출이 돌아올 때까지 Main Thread를 막는 경우예요.                                                                |
+| asynchronous hang    | 나중에 실행된 queue block이나 Main Actor task가 Main Thread를 오래 차지해 다른 event를 늦추는 경우예요.                                                   |
+| critical path        | 사용자의 action부터 결과가 보일 때까지 반드시 지나야 하는 작업 경로예요. 이 경로의 지연이 직접 체감돼요.                                                  |
+
+Main Actor의 격리와 실행 규칙은 [MainActor 문서](../swift/concurrency/main-actor.md)에서 먼저 볼 수 있어요.
+
+## 100ms보다 긴 Main Thread 작업을 조사 대상으로 봐요
+
+사람이 느끼는 “즉시 반응”에는 여유가 크지 않아요. Apple의 WWDC23 hang 분석 세션은 Main Thread의 개별 작업을 100ms 아래로 유지하는 목표를 제시해요. 이 값은 모든 device와 UX에 똑같이 적용되는 합격선이 아니라, 눈에 띄는 지연을 피하기 위한 조사 기준이에요.
+
+frame budget은 display refresh rate에 따라 더 짧을 수 있어요. 60Hz 화면은 frame 하나당 약 16.7ms이고 120Hz는 약 8.3ms예요. Main Thread 작업이 100ms보다 짧더라도 여러 frame을 놓쳐 scrolling hitch가 생길 수 있어요.
+
+따라서 두 목표를 나눠요.
+
+- tap과 화면 전환 같은 interaction latency는 Hangs와 event 처리 구간으로 조사해요.
+- animation과 scrolling의 매끄러움은 hitch와 frame 관련 instrument로 조사해요.
+
+## Time Profiler template으로 hang을 기록해요
+
+원인을 모르는 UI 멈춤은 Time Profiler template이 좋은 출발점이에요. 현재 template에는 Time Profiler와 Hangs를 비롯한 관련 track이 포함될 수 있어 시간과 CPU를 함께 볼 수 있어요.
+
+1. 문제가 발생하는 물리 기기와 scheme을 선택해요.
+2. `Product > Profile`에서 Time Profiler template을 열어요.
+3. Record를 누르고 문제가 생기는 action만 재현해요.
+4. UI가 다시 반응하면 Stop을 눌러 짧은 trace를 만들어요.
+5. Hangs track에서 표시된 interval을 찾아 inspection range로 설정해요.
+6. Main Thread track과 Time Profiler의 CPU graph를 같은 범위에서 봐요.
+
+자동 표시된 hang이 없어도 사용자가 지연을 느낀 정확한 구간을 signpost로 표시할 수 있어요. 버튼 action 시작부터 첫 결과 표시까지 interval을 추가하고 그 범위에서 Main Thread를 조사하세요.
+
+### 먼저 Main Thread CPU가 높은지 확인해요
+
+hang 구간을 선택한 뒤 첫 분기는 단순해요.
+
+```text
+Main Thread의 CPU가 높아요?
+├─ 예 → CPU에서 긴 코드를 실행 중
+│      Time Profiler / CPU Profiler call tree
+└─ 아니요 → 다른 자원을 기다릴 가능성
+       Thread State / System Trace / Swift Tasks
+```
+
+CPU가 높다는 이유만으로 무조건 계산 알고리즘 문제는 아니에요. 같은 함수를 지나치게 자주 호출하거나 Main Actor에 필요 없는 작업을 올렸을 수도 있어요. call tree에서 앱의 호출 경로와 반복 횟수를 함께 확인하세요.
+
+## busy Main Thread hang은 call tree로 내려가요
+
+Main Thread가 hang interval 내내 running이고 CPU가 높다면 Time Profiler의 call tree를 열어요.
+
+1. inspection range를 hang interval로 제한해요.
+2. Main Thread를 pin하거나 해당 process track을 선택해요.
+3. call tree에서 앱 symbol이 나올 때까지 경로를 펼쳐요.
+4. `Hide System Libraries`와 `Invert Call Tree`로 무거운 앱 leaf를 찾아요.
+5. Source Viewer에서 반복 loop, decode, image 처리와 layout 호출을 확인해요.
+
+다음 코드는 `async`로 선언됐지만 실제 decode를 Main Actor에서 동기적으로 실행해요.
+
+```swift
+import Foundation
+
+struct ImportRecord: Decodable, Sendable {
+  let id: Int
+  let title: String
+}
+
+@MainActor
+final class ImportViewModel {
+  private(set) var records: [ImportRecord] = []
+
+  func importData(_ data: Data) async throws {
+    records = try JSONDecoder().decode(
+      [ImportRecord].self,
+      from: data
+    )
+  }
+}
+```
+
+`async` keyword는 함수 본문의 CPU 계산을 자동으로 background thread에 보내지 않아요. 이 메서드에는 suspension point도 없고 `ImportViewModel`이 Main Actor에 격리되어 있으므로 큰 decode가 UI event와 경쟁할 수 있어요.
+
+별도 worker actor가 decode를 소유하도록 경계를 바꿀 수 있어요.
+
+```swift
+actor ImportWorker {
+  private let decoder = JSONDecoder()
+
+  func decode(_ data: Data) throws -> [ImportRecord] {
+    try decoder.decode(
+      [ImportRecord].self,
+      from: data
+    )
+  }
+}
+
+@MainActor
+final class ImportViewModel {
+  private let worker = ImportWorker()
+  private(set) var records: [ImportRecord] = []
+
+  func importData(_ data: Data) async throws {
+    let decoded = try await worker.decode(data)
+    records = decoded
+  }
+}
+```
+
+이 변경은 decode가 Main Actor의 UI 상태와 분리된 actor에서 실행될 수 있게 해요. `Data`와 결과 모델처럼 경계를 넘는 값은 concurrency safety를 만족해야 해요. actor를 추가하면 scheduling과 구조 비용도 생기므로 before/after trace에서 Main Thread hang과 전체 latency가 실제로 줄었는지 확인하세요.
+
+CPU 병목의 call tree 읽기는 [CPU Profiler와 Time Profiler](./cpu-profiling.md)에서 더 자세히 다뤄요.
+
+## blocked Main Thread hang은 기다리는 대상을 찾아요
+
+hang은 긴데 Main Thread의 CPU가 낮다면 thread가 실행할 수 없는 상태일 수 있어요. 다음 원인이 흔해요.
+
+- synchronous file read 또는 database I/O
+- serial queue의 `sync` 호출
+- mutex, unfair lock, semaphore 대기
+- 다른 thread 작업의 완료를 `wait`로 기다림
+- IPC나 system service 응답 대기
+- page fault와 memory pressure
+
+System Trace와 thread state를 추가해 Main Thread가 blocked된 시점과 이를 깨우는 thread를 찾아요.
+
+1. hang interval로 inspection range를 설정해요.
+2. Main Thread의 running, runnable, blocked 상태를 확인해요.
+3. blocked 전의 stack에서 lock, file와 queue API를 찾아요.
+4. 같은 시점에 관련 background thread가 무엇을 실행했는지 봐요.
+5. Main Thread를 깨운 event와 dependency 방향을 확인해요.
+
+blocked stack에 `Data(contentsOf:)`가 보인다면 file 읽기를 Main Thread 밖으로 옮기고 async 결과만 UI에 적용하는 구조를 검토해요. lock 대기라면 lock을 더 빠르게 만드는 것보다 공유 상태 범위와 Main Thread가 그 lock을 꼭 가져야 하는지 먼저 봐요.
+
+### CPU가 낮은 blocked time을 빠른 코드로 오해하지 않아요
+
+Time Profiler sample이 적다는 것은 CPU를 적게 사용했다는 뜻이지 사용자가 덜 기다렸다는 뜻이 아니에요. Main Thread는 1초 동안 CPU를 거의 쓰지 않고 lock을 기다려도 앱을 1초간 멈출 수 있어요.
+
+## asynchronous hang은 Swift Tasks를 겹쳐 봐요
+
+버튼 action 자체는 빨랐는데 잠시 뒤 scrolling이 멎는다면 Main Actor에 예약된 task가 긴 CPU 작업을 실행했을 수 있어요.
+
+1. 기존 trace에 Swift Tasks instrument를 추가하거나 Swift Concurrency template으로 다시 기록해요.
+2. hang interval에 Main Thread에서 실행된 task lane을 찾아요.
+3. task의 creation backtrace를 열어 어디서 생성됐는지 확인해요.
+4. task가 Main Actor를 상속했는지와 어떤 함수가 CPU를 사용했는지 봐요.
+5. Task Forest에서 child task가 병렬인지 직렬인지 확인해요.
+6. Swift Actors에서 하나의 actor에 긴 task가 몰리는지 확인해요.
+
+SwiftUI의 `.task`, `Task {}`와 `async` 함수 이름만 보고 background 실행이라고 가정하지 마세요. actor isolation과 생성 context에 따라 Main Actor에서 실행될 수 있어요. Apple의 [Visualize and optimize Swift concurrency](https://developer.apple.com/videos/play/wwdc2022/110350/)와 [Analyze hangs with Instruments](https://developer.apple.com/videos/play/wwdc2023/10248/)는 Swift Tasks lane으로 Main Thread의 비동기 CPU 작업을 찾는 과정을 보여 줘요.
+
+## 호출 횟수와 한 번의 비용을 나눠요
+
+한 함수가 한 번에 2ms밖에 걸리지 않아도 한 frame에 100번 호출되면 200ms가 돼요. 반대로 150ms 함수가 사용자가 기다리지 않는 background 시점에 한 번 실행된다면 hang의 원인이 아닐 수 있어요.
+
+| 관찰                              | 개선 방향                                                          |
+| --------------------------------- | ------------------------------------------------------------------ |
+| 한 번의 호출이 너무 길어요.       | 알고리즘, I/O 경계, 입력 크기와 실행 actor를 개선해요.             |
+| 짧은 호출이 너무 많아요.          | 중복 update, 불필요한 view recomputation과 반복 API 호출을 줄여요. |
+| Main Actor task가 연속돼요.       | UI update를 batch하고 CPU-only 작업의 격리를 분리해요.             |
+| background 결과가 너무 자주 와요. | throttle, coalescing 또는 최신 결과만 반영하는 정책을 검토해요.    |
+
+최적화 목표는 모든 함수의 시간을 줄이는 것이 아니라 Main Thread가 다음 event와 frame을 처리할 기회를 제때 돌려주는 것이에요.
+
+## 수정 전후 응답성을 검증해요
+
+hang을 없앤 뒤 전체 작업이 훨씬 느려지거나 memory를 과도하게 쓸 수도 있어요. 같은 재현 절차에서 다음을 함께 비교하세요.
+
+- Hangs interval의 수와 duration
+- 사용자 action부터 첫 결과 표시까지 signpost duration
+- Main Thread CPU와 blocked time
+- Swift task lifetime과 Alive Tasks
+- peak memory와 energy 영향
+- 취소, 화면 이탈과 app background 전환의 동작
+
+Apple의 [Improving app responsiveness](https://developer.apple.com/documentation/xcode/improving-app-responsiveness)는 실제 기기에서 hitch를 측정하고, 배포 후에는 Xcode Organizer와 MetricKit 같은 field data로 사용자 환경의 문제를 확인하도록 안내해요. 개발 기기의 한 trace로 모든 사용자 문제를 대표할 수는 없어요.
+
+## 증상별 도구를 정리해요
+
+| trace에서 보이는 것                  | 다음 instrument                   | 확인할 핵심                                 |
+| ------------------------------------ | --------------------------------- | ------------------------------------------- |
+| Main Thread CPU가 계속 높아요.       | Time Profiler 또는 CPU Profiler   | 무거운 call tree와 반복 호출                |
+| Main Thread CPU는 낮고 blocked돼요.  | System Trace와 Thread State       | lock, I/O와 unblock dependency              |
+| Main Actor task가 길게 실행돼요.     | Swift Tasks, Swift Actors         | 생성 context, actor isolation과 task 구조   |
+| scrolling frame만 끊겨요.            | Hitches, Core Animation 관련 도구 | frame budget과 rendering pipeline           |
+| network 결과를 기다리며 UI가 멈춰요. | Network와 System Trace            | synchronous wait와 Main Thread 호출         |
+| 반복할수록 멈춤이 심해져요.          | Allocations와 Swift Tasks         | 누적 객체, 살아 있는 task와 memory pressure |
+
+## 흔한 실수를 피해야 해요
+
+### `async`를 붙이면 Main Thread 문제가 해결된다고 생각하지 않아요
+
+`async`는 suspension 가능성을 표현하지만 CPU work의 실행 actor를 자동으로 바꾸지 않아요. Instruments에서 실제 thread, task와 actor를 확인하세요.
+
+### Main Thread의 모든 작업을 background로 보내지 않아요
+
+UI 상태 접근과 framework API는 Main Thread 또는 Main Actor가 필요할 수 있어요. CPU-only와 I/O 작업의 경계를 분리하고 결과 적용만 Main Actor에서 짧게 수행하세요.
+
+### sleep이나 인위적인 delay로 경합을 숨기지 않아요
+
+실행 순서를 우연히 바꿔 증상이 줄 수 있지만 dependency 문제는 남아요. thread state와 task 구조에서 실제 기다림 관계를 찾아요.
+
+### hang interval 밖의 무거운 함수를 고치지 않아요
+
+recording 전체의 CPU hotspot이 background indexing일 수 있어요. 사용자가 멈춤을 느낀 inspection range와 Main Thread에 해당하는지 먼저 확인하세요.
+
+### 최신 기기에서만 검증하지 않아요
+
+같은 Main Thread 작업도 오래된 기기에서는 더 긴 hang이 돼요. 최소 지원 기기와 실제 보고가 많은 기기 등급에서 확인하세요.
+
+## 적용 순서를 정리해요
+
+1. 멈춤이 시작되고 끝나는 사용자 action을 정해요.
+2. 물리 기기에서 Time Profiler template으로 짧은 trace를 기록해요.
+3. Hangs 또는 signpost interval로 inspection range를 제한해요.
+4. Main Thread CPU가 높은지 낮은지 먼저 나눠요.
+5. 높으면 call tree, 낮으면 System Trace의 wait 원인을 확인해요.
+6. Swift task가 관련되면 creation context, actor와 Task Forest를 봐요.
+7. CPU-only·I/O 작업과 UI update 경계를 분리해 수정해요.
+8. 같은 조건의 after trace와 field metric으로 개선을 검증해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### hang과 crash는 무엇이 다른가요?
+
+crash는 process가 비정상 종료되는 사건이고, hang은 process는 살아 있지만 Main Thread가 event에 제때 응답하지 못하는 구간이에요. hang은 나중에 회복될 수 있어도 사용자에게 앱이 멈춘 경험을 줘요.
+
+### Main Actor와 Main Thread는 같은가요?
+
+Main Actor는 Swift Concurrency의 격리와 직렬 실행 개념이고 Main Thread는 운영체제 thread예요. UI 관련 Main Actor 작업은 일반적으로 Main Thread에서 수행되지만, 코드를 분석할 때 actor isolation과 실제 thread state를 구분해 보는 것이 좋아요.
+
+### CPU가 낮은데도 hang이 생길 수 있나요?
+
+네. Main Thread가 lock, file I/O, semaphore나 다른 thread의 결과를 기다리면 CPU를 거의 사용하지 않으면서 event 처리를 멈출 수 있어요. System Trace와 Thread State로 blocked 원인과 깨우는 dependency를 찾아야 해요.
+
+### `Task {}`로 감싸면 CPU 작업이 Main Actor 밖으로 가나요?
+
+항상 그렇지 않아요. task는 생성 context의 actor isolation을 상속할 수 있어 Main Actor에서 긴 계산을 계속 실행할 수 있어요. Swift Tasks와 Main Thread track에서 실제 실행 위치를 확인하고 명시적인 격리 경계를 설계해야 해요.
+
+### Hangs를 수정한 뒤 무엇을 검증해야 하나요?
+
+hang duration뿐 아니라 사용자 action의 전체 latency, Main Thread CPU와 blocked time, task 수, memory와 취소 동작을 같은 조건에서 확인해야 해요. 작업을 background로 옮기면서 결과가 늦거나 lifecycle bug가 생기지 않았는지도 검증해요.
+
+## 참고 자료
+
+- [WWDC23 — Analyze hangs with Instruments](https://developer.apple.com/videos/play/wwdc2023/10248/)
+- [Apple Developer — Improving app responsiveness](https://developer.apple.com/documentation/xcode/improving-app-responsiveness)
+- [Apple Developer — Executing work asynchronously](https://developer.apple.com/tutorials/instruments/executing-work-asynchronously)
+- [WWDC22 — Visualize and optimize Swift concurrency](https://developer.apple.com/videos/play/wwdc2022/110350/)
+- [WWDC26 — Profile, fix, and verify: Improve app responsiveness with Instruments](https://developer.apple.com/videos/play/wwdc2026/268/)
+- [Apple Developer — Analyzing CPU profiles with call tree views](https://developer.apple.com/documentation/xcode/analyzing-cpu-profiles-with-call-tree-views)

--- a/docs/guide/swift/_meta.json
+++ b/docs/guide/swift/_meta.json
@@ -20,6 +20,11 @@
     "label": "핵심 프로토콜"
   },
   {
+    "type": "dir-section-header",
+    "name": "concurrency",
+    "label": "Swift Concurrency"
+  },
+  {
     "type": "file",
     "name": "opaque-types",
     "label": "some과 불투명 타입"

--- a/docs/guide/swift/concurrency/_meta.json
+++ b/docs/guide/swift/concurrency/_meta.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "file",
+    "name": "gcd-vs-swift-concurrency",
+    "label": "GCD와 Swift Concurrency"
+  },
+  {
+    "type": "file",
+    "name": "actors",
+    "label": "Actor와 데이터 격리"
+  },
+  {
+    "type": "file",
+    "name": "main-actor",
+    "label": "MainActor와 UI 격리"
+  }
+]

--- a/docs/guide/swift/concurrency/actors.md
+++ b/docs/guide/swift/concurrency/actors.md
@@ -1,0 +1,565 @@
+---
+title: Swift로 이해하는 Actor와 데이터 격리
+description: Swift Actor가 mutable state를 격리하는 원리와 cross-actor await, Sendable, reentrancy, nonisolated, protocol 준수와 테스트 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Actor와 데이터 격리
+
+> **면접 답변 한 줄 요약:** Actor는 공유 mutable state와 그 state를 다루는 동작을 하나의 isolation domain에 묶고 compiler가 외부 접근을 `await`와 `Sendable` 경계로 제한해 data race를 막는 reference type이며, suspension 사이에는 다른 작업이 끼어들 수 있어 reentrancy까지 설계해야 해요.
+
+여러 task가 하나의 class를 동시에 수정하면 실행 순서에 따라 결과가 달라질 수 있어요. lock이나 serial dispatch queue로 접근을 한 줄씩 감싸면 막을 수 있지만, 한 곳이라도 synchronization을 빠뜨리면 다시 data race가 생겨요.
+
+Actor는 이 규칙을 Swift type system에 넣어요. actor의 mutable state는 기본적으로 actor instance에 격리되고, 외부 코드는 actor가 실행할 수 있을 때까지 비동기적으로 기다려야 해요. 하지만 actor를 “자동 lock class”나 “항상 FIFO로 실행되는 전용 thread”로 이해하면 `await`를 포함한 method에서 논리적인 race condition을 만들 수 있어요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- class와 serial queue로 state를 보호할 때 생기는 문제
+- actor instance isolation과 cross-actor `await`
+- actor와 thread·serial queue의 차이
+- isolation boundary를 넘는 `Sendable` 값
+- actor reentrancy와 `await` 전후 invariant
+- `nonisolated`와 `isolated` parameter
+- actor의 protocol conformance와 테스트 방법
+- actor를 사용하지 않아도 되는 경우
+
+## 먼저 알아둘 Actor 용어
+
+| 용어                  | 쉬운 뜻                                                                                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| shared mutable state  | 여러 실행 흐름이 같은 instance를 참조하면서 바꿀 수 있는 값이에요.                                                                                 |
+| mutual exclusion      | 한 순간에 하나의 실행 흐름만 보호된 state를 다루게 하는 성질이에요.                                                                                |
+| actor instance        | `actor` 선언으로 만든 reference value예요. actor instance마다 독립적인 state와 isolation domain이 있어요.                                          |
+| actor-isolated member | 해당 actor의 executor에서만 동기적으로 접근할 수 있는 property나 method예요. actor의 mutable instance member는 기본적으로 여기에 속해요.           |
+| cross-actor reference | 현재 isolation과 다른 actor instance의 member에 접근하는 일이에요. potential suspension이므로 보통 `await`가 필요해요.                             |
+| reentrancy            | actor method가 `await`에서 suspend한 동안 같은 actor의 다른 job이 실행되고, 원래 method가 나중에 바뀐 state 위에서 재개될 수 있는 성질이에요.      |
+| invariant             | state가 항상 만족해야 하는 규칙이에요. 예를 들어 잔여 독서 시간은 0보다 작아지면 안 된다는 조건이에요.                                             |
+| `Sendable`            | isolation domain을 넘어 전달해도 data race 위험이 없음을 나타내는 protocol이에요. 자세한 내용은 [Sendable 문서](../protocols/sendable)를 참고해요. |
+| `nonisolated`         | actor member가 actor state에 격리되지 않음을 명시해 어느 isolation에서도 동기 호출할 수 있게 하는 modifier예요.                                    |
+| `isolated` parameter  | 함수가 전달받은 actor의 isolation에서 실행되게 해 함수 내부에서 여러 member를 추가 `await` 없이 다루게 하는 parameter예요.                         |
+
+## 일반 class를 동시에 수정하면 data race가 생길 수 있어요
+
+독서 시간을 누적하는 작은 저장소를 만들어 볼게요.
+
+```swift
+final class ReadingProgressStore {
+  private var minutesByBookID: [Int: Int] = [:]
+
+  func add(minutes: Int, to bookID: Int) {
+    minutesByBookID[bookID, default: 0] += minutes
+  }
+
+  func minutes(for bookID: Int) -> Int {
+    minutesByBookID[bookID, default: 0]
+  }
+}
+```
+
+Dictionary를 읽고 기본값을 만들고 더한 뒤 쓰는 과정은 하나의 원자적 연산이 아니에요. 서로 다른 task나 thread가 같은 `bookID`를 동시에 수정하면 update가 사라지거나 Dictionary 내부 접근이 충돌할 수 있어요.
+
+GCD에서는 private serial queue를 모든 접근 경로에 사용해 보호할 수 있어요.
+
+```swift
+final class QueueReadingProgressStore {
+  private let queue = DispatchQueue(
+    label: "com.example.reading.progress"
+  )
+  private var minutesByBookID: [Int: Int] = [:]
+
+  func add(minutes: Int, to bookID: Int) {
+    queue.sync {
+      minutesByBookID[bookID, default: 0] += minutes
+    }
+  }
+
+  func minutes(for bookID: Int) -> Int {
+    queue.sync {
+      minutesByBookID[bookID, default: 0]
+    }
+  }
+}
+```
+
+mutual exclusion은 생겼지만 안전성이 convention에 의존해요.
+
+- 새 property나 method도 같은 queue를 사용해야 해요.
+- queue 밖에서 state를 노출하는 reference를 반환하면 보호가 깨져요.
+- 같은 queue 안에서 다시 `sync`하면 deadlock이 생길 수 있어요.
+- blocking `sync` 호출은 actor 기반 async 흐름과 잘 맞지 않을 수 있어요.
+
+제공된 [Actor 참고 글](https://green1229.tistory.com/341)도 class의 Dictionary 접근을 serial queue로 감싼 뒤 actor로 옮기는 흐름을 보여 줘요. Actor의 차이는 synchronization 규칙이 comment나 개발자의 기억이 아니라 선언과 compiler 검사에 들어간다는 점이에요.
+
+## `actor`는 state와 접근 규칙을 함께 선언해요
+
+`class`를 `actor`로 바꾸고 수동 queue를 제거해요.
+
+```swift
+actor ReadingProgressStore {
+  private var minutesByBookID: [Int: Int] = [:]
+
+  func add(minutes: Int, to bookID: Int) {
+    minutesByBookID[bookID, default: 0] += minutes
+  }
+
+  func minutes(for bookID: Int) -> Int {
+    minutesByBookID[bookID, default: 0]
+  }
+}
+```
+
+Actor는 class처럼 identity가 있는 reference type이에요. let에 저장해도 같은 actor instance의 내부 state는 actor method를 통해 바뀔 수 있어요. 반면 class inheritance는 지원하지 않으며 actor type끼리 상속 관계를 만들 수 없어요.
+
+```swift
+let store = ReadingProgressStore()
+
+await store.add(minutes: 10, to: 1)
+let minutes = await store.minutes(for: 1)
+```
+
+외부에서 actor-isolated method를 호출하는 일은 cross-actor access예요. 호출을 actor의 executor에 제출하고 기다릴 수 있으므로 `await`가 필요해요. method 선언 자체가 동기 함수여도 **호출자의 위치**가 다른 actor라면 호출은 비동기가 돼요.
+
+### 같은 actor 안에서는 동기적으로 접근해요
+
+Actor method의 `self`는 현재 actor에 isolated되어 있어요.
+
+```swift
+actor ReadingProgressStore {
+  private var minutesByBookID: [Int: Int] = [:]
+
+  func add(minutes: Int, to bookID: Int) {
+    minutesByBookID[bookID, default: 0] += minutes
+  }
+
+  func addHalfHour(to bookID: Int) {
+    add(minutes: 30, to: bookID)
+  }
+}
+```
+
+`addHalfHour`가 자신의 `add`를 호출할 때는 이미 같은 actor isolation에 있으므로 `await`가 없어요. 다른 `ReadingProgressStore` instance를 호출하면 같은 actor **타입**이어도 서로 다른 isolation domain이라 `await`가 필요해요.
+
+```swift
+extension ReadingProgressStore {
+  func copyProgress(
+    for bookID: Int,
+    to other: ReadingProgressStore
+  ) async {
+    let current = minutesByBookID[bookID, default: 0]
+    await other.add(minutes: current, to: bookID)
+  }
+}
+```
+
+Swift의 [Actor 제안 SE-0306](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md)은 `self`와 `other`를 구분해 같은 actor type의 instance라도 cross-actor 접근을 검사해요.
+
+## Actor는 전용 thread도 FIFO queue도 아니에요
+
+Actor는 mutable state에 대한 **동시 접근 금지**를 보장해요. 구현 세부로 특정 thread 하나를 영구 소유한다는 뜻은 아니에요. actor의 executor는 실행 가능한 job을 system thread에 scheduling하고, suspension 뒤에는 다른 thread에서 같은 actor isolation으로 재개할 수 있어요.
+
+serial `DispatchQueue`와 비교하면 다음 차이가 있어요.
+
+| 기준                | serial DispatchQueue                                       | Swift actor                                                              |
+| ------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------ |
+| 보호 규칙           | 모든 접근을 queue에 넣는 convention을 직접 지켜요.         | compiler가 actor-isolated 접근을 검사해요.                               |
+| 제출 순서           | FIFO로 block을 시작해요.                                   | priority를 고려할 수 있어 대기한 순서대로 실행된다고 보장하지 않아요.    |
+| 기다림              | `sync`는 thread를 막고 `async`는 callback 구조가 필요해요. | cross-actor 호출은 task를 suspend하고 `await` 뒤에서 결과를 이어 받아요. |
+| method 중간 `await` | block 안에는 Swift suspension 의미가 없어요.               | suspend한 동안 같은 actor의 다른 job이 실행될 수 있어요.                 |
+| 값 전달 검사        | capture와 반환값의 thread safety를 compiler가 몰라요.      | isolation boundary의 argument와 result에 `Sendable` 검사가 적용돼요.     |
+
+Actor는 한 시점에 actor-isolated code의 job 하나만 실행해요. 다만 하나의 async method 전체가 처음부터 끝까지 다른 작업을 막는 것은 아니에요. method가 `await`에서 suspend하면 다음 job이 actor에 들어올 수 있어요.
+
+## isolation boundary에는 안전한 값을 전달해요
+
+Actor 밖으로 mutable reference를 그대로 반환하면 내부 state 보호를 우회할 수 있어요. Swift는 cross-actor argument와 result가 안전하게 전달될 수 있도록 `Sendable`을 검사해요.
+
+```swift
+struct ReadingProgress: Sendable, Equatable {
+  let bookID: Int
+  let minutes: Int
+}
+
+actor ReadingProgressStore {
+  private var minutesByBookID: [Int: Int] = [:]
+
+  func progress(for bookID: Int) -> ReadingProgress {
+    ReadingProgress(
+      bookID: bookID,
+      minutes: minutesByBookID[bookID, default: 0]
+    )
+  }
+}
+```
+
+`ReadingProgress`는 immutable value type이고 stored property가 모두 `Sendable`이라 actor 밖으로 snapshot을 전달하기 좋아요.
+
+```swift
+let snapshot = await store.progress(for: 1)
+```
+
+다음 방식은 피해야 해요.
+
+```swift
+final class MutableProgress {
+  var minutes = 0
+}
+
+actor UnsafeStore {
+  private let progress = MutableProgress()
+
+  // strict concurrency에서는 non-Sendable mutable reference가
+  // actor boundary를 빠져나가는 반환을 진단해요.
+}
+```
+
+Actor 자체는 implicit `Sendable`이에요. reference를 여러 concurrency domain에 전달해도 내부 mutable state 접근은 actor isolation이 보호하기 때문이에요. 그러나 actor가 반환하는 모든 값이 자동으로 `Sendable`이 되는 것은 아니에요.
+
+## reentrancy 때문에 `await` 전의 가정이 깨질 수 있어요
+
+Actor는 data race를 막지만 모든 logical race를 자동으로 막지는 않아요. 잔여 독서 시간을 예약하는 actor를 볼게요.
+
+```swift
+actor DailyReadingBudget {
+  private var remainingMinutes = 30
+
+  func reserve(
+    minutes: Int,
+    authorize: @Sendable () async throws -> Void
+  ) async throws -> Bool {
+    guard remainingMinutes >= minutes else {
+      return false
+    }
+
+    try await authorize()
+    remainingMinutes -= minutes
+    return true
+  }
+}
+```
+
+두 task가 동시에 `reserve(minutes: 20)`을 호출한다고 생각해 볼게요.
+
+1. 첫 번째 job이 `remainingMinutes == 30`을 확인하고 `authorize()`에서 suspend해요.
+2. 두 번째 job도 같은 actor에 들어와 30을 확인하고 suspend해요.
+3. 두 authorization이 끝난 뒤 각각 20을 빼면 `remainingMinutes == -10`이 돼요.
+
+한 순간에 두 job이 property를 동시에 만진 data race는 없지만 “0보다 작아지지 않는다”는 invariant가 깨졌어요. `await`는 다른 job이 끼어들 수 있는 경계라고 읽어야 해요.
+
+### 먼저 state를 확정하고 실패하면 되돌려요
+
+authorization 전에 예약을 확정하면 같은 actor의 동기 구간에서 검사와 변경을 하나로 묶을 수 있어요.
+
+```swift
+actor DailyReadingBudget {
+  private var remainingMinutes = 30
+
+  func reserve(
+    minutes: Int,
+    authorize: @Sendable () async throws -> Void
+  ) async throws -> Bool {
+    guard remainingMinutes >= minutes else {
+      return false
+    }
+
+    remainingMinutes -= minutes
+
+    do {
+      try await authorize()
+      return true
+    } catch {
+      remainingMinutes += minutes
+      throw error
+    }
+  }
+}
+```
+
+이 방식은 oversubscription을 막지만 rollback 정책이 필요해요. authorization 동안 다른 호출은 이미 줄어든 잔여 시간을 관찰해요. domain에서 “예약 중” 상태를 별도로 모델링해야 할 수도 있어요.
+
+### `await` 뒤에서 조건을 다시 확인해요
+
+원격 결과가 최신 state에만 적용되어야 한다면 revision을 비교할 수 있어요.
+
+```swift
+actor ReadingRecommendations {
+  private var revision = 0
+  private var books: [Book] = []
+
+  func replacePreference() {
+    revision += 1
+  }
+
+  func refresh(
+    using client: any RecommendationClient
+  ) async throws {
+    let requestedRevision = revision
+    let response = try await client.fetchBooks()
+
+    guard revision == requestedRevision else {
+      return
+    }
+
+    books = response
+  }
+}
+```
+
+`await` 뒤에서 현재 revision이 요청 당시와 같은지 확인해 오래된 응답이 새 설정을 덮어쓰지 않게 했어요.
+
+Apple의 [Protect mutable state with Swift actors](https://developer.apple.com/videos/play/wwdc2021/10133/)도 `await`에서 세상이 진행되어 이전 가정이 무효가 될 수 있으므로 reentrancy를 고려하라고 설명해요.
+
+## `nonisolated`는 actor state가 필요 없는 member에 사용해요
+
+Actor member는 기본적으로 actor-isolated예요. instance identity처럼 생성 뒤 바뀌지 않고 actor state를 읽지 않는 API는 `nonisolated`로 만들 수 있어요.
+
+```swift
+actor ReadingProgressStore {
+  nonisolated let storeID: String
+  private var minutesByBookID: [Int: Int] = [:]
+
+  init(storeID: String) {
+    self.storeID = storeID
+  }
+
+  nonisolated var description: String {
+    "ReadingProgressStore(\(storeID))"
+  }
+}
+```
+
+호출자는 `await` 없이 사용할 수 있어요.
+
+```swift
+print(store.description)
+```
+
+`nonisolated` member는 actor의 isolated mutable property에 접근할 수 없어요. synchronization 비용을 줄이려고 mutable state에 `nonisolated(unsafe)`를 붙이면 actor의 안전 보장을 직접 해제하게 돼요. lock이나 atomic처럼 별도의 정확한 보호가 있고 그 책임을 설명할 수 있는 제한된 interop에서만 검토해요.
+
+## `isolated` parameter로 같은 actor에서 여러 동작을 묶어요
+
+Actor method를 외부에서 여러 번 호출하면 호출마다 isolation boundary를 넘어요.
+
+```swift
+let before = await store.minutes(for: 1)
+await store.add(minutes: 10, to: 1)
+let after = await store.minutes(for: 1)
+```
+
+각 `await` 사이에 다른 job이 actor state를 바꿀 수 있어요. 하나의 actor isolation에서 atomic한 동기 sequence로 실행해야 한다면 `isolated` parameter를 받을 수 있어요.
+
+```swift
+func addAndRead(
+  store: isolated ReadingProgressStore,
+  minutes: Int,
+  bookID: Int
+) -> Int {
+  store.add(minutes: minutes, to: bookID)
+  return store.minutes(for: bookID)
+}
+```
+
+외부 호출은 actor로 한 번 hop해요.
+
+```swift
+let total = await addAndRead(
+  store: store,
+  minutes: 10,
+  bookID: 1
+)
+```
+
+함수 안에서는 `store`의 isolation에 이미 있으므로 각 method에 `await`가 필요 없어요. isolated parameter는 한 함수에 하나만 둘 수 있어요. 서로 다른 두 actor를 동시에 lock하는 기능이 아니며, 다른 actor에 접근하면 다시 `await`해야 해요.
+
+## protocol requirement의 isolation도 맞아야 해요
+
+Actor가 synchronous nonisolated protocol requirement를 actor-isolated method로 구현하면 caller가 `await` 없이 state에 접근할 수 있어 안전하지 않아요.
+
+요구사항 자체가 `async`이면 actor의 synchronous method도 구현으로 사용할 수 있어요.
+
+```swift
+protocol ProgressReading: Sendable {
+  func minutes(for bookID: Int) async -> Int
+}
+
+actor ReadingProgressStore: ProgressReading {
+  nonisolated let storeID: String
+  private var minutesByBookID: [Int: Int] = [:]
+
+  init(storeID: String) {
+    self.storeID = storeID
+  }
+
+  func minutes(for bookID: Int) -> Int {
+    minutesByBookID[bookID, default: 0]
+  }
+}
+```
+
+Protocol을 통한 호출은 항상 async이므로 actor가 실행 가능할 때까지 안전하게 기다릴 수 있어요.
+
+동기 protocol requirement가 actor state를 필요로 하지 않는다면 `nonisolated` witness로 구현해요.
+
+```swift
+extension ReadingProgressStore: CustomStringConvertible {
+  nonisolated var description: String {
+    "ReadingProgressStore(\(storeID))"
+  }
+}
+```
+
+기존 protocol을 actor에 맞추기 위해 무조건 `@preconcurrency`나 `nonisolated(unsafe)`로 검사를 끄기보다 requirement가 실제로 async여야 하는지, 특정 global actor에 격리되어야 하는지 API contract부터 검토해요.
+
+## Actor 안에서도 오래 걸리는 동기 작업은 다른 job을 막아요
+
+Actor가 thread를 직접 막지는 않아도, actor-isolated synchronous code가 반환하거나 suspend하기 전에는 같은 actor의 다음 job이 실행되지 못해요.
+
+```swift
+actor SearchIndexStore {
+  private var index = SearchIndex()
+
+  func rebuild(from books: [Book]) {
+    // 큰 배열을 오래 계산하면 이 actor의 다른 요청이 기다려요.
+    index = makeSearchIndex(from: books)
+  }
+}
+```
+
+큰 CPU 계산은 sendable snapshot을 받아 actor 밖의 concurrent 함수에서 수행하고 결과만 actor에 적용해요.
+
+```swift
+@concurrent
+func buildSearchIndex(
+  from books: [Book]
+) async -> SearchIndex {
+  makeSearchIndex(from: books)
+}
+
+actor SearchIndexStore {
+  private var index = SearchIndex()
+
+  func rebuild(from books: [Book]) async {
+    let newIndex = await buildSearchIndex(from: books)
+    index = newIndex
+  }
+}
+```
+
+여기서도 `await` 동안 다른 rebuild나 update가 들어올 수 있어요. 마지막 완료 결과를 적용할지, 요청 순서를 보존할지 revision이나 task cancellation 정책을 정해야 해요.
+
+## 테스트에서는 결과와 interleaving 조건을 나눠 검증해요
+
+기본 mutation은 여러 child task에서 호출해 최종 결과를 확인할 수 있어요.
+
+```swift
+import Testing
+
+@Test
+func accumulatesConcurrentUpdates() async {
+  let store = ReadingProgressStore(storeID: "test")
+
+  await withTaskGroup(of: Void.self) { group in
+    for _ in 0..<100 {
+      group.addTask {
+        await store.add(minutes: 1, to: 1)
+      }
+    }
+  }
+
+  let total = await store.minutes(for: 1)
+  #expect(total == 100)
+}
+```
+
+이 테스트는 actor가 update를 잃지 않는지 확인하지만 특정 실행 순서를 검증하지 않아요. Actor는 FIFO를 보장하지 않기 때문이에요.
+
+Reentrancy bug를 재현하려면 임의의 `Task.sleep`에 기대지 말고 test가 suspension과 재개 시점을 제어하는 dependency를 주입해요.
+
+```swift
+actor AuthorizationGate {
+  private var continuations: [CheckedContinuation<Void, Never>] = []
+
+  func wait() async {
+    await withCheckedContinuation { continuation in
+      continuations.append(continuation)
+    }
+  }
+
+  func openAll() {
+    let pending = continuations
+    continuations.removeAll()
+    pending.forEach { $0.resume() }
+  }
+}
+```
+
+Production actor를 test-only method로 오염시키기보다 clock, client, gate protocol을 주입하면 `await` 사이 state 변화를 결정적으로 만들 수 있어요.
+
+## Actor를 선택하기 전에 비용도 확인해요
+
+Actor가 잘 맞는 경우예요.
+
+- 여러 task가 하나의 mutable state를 공유해야 해요.
+- state와 mutation 규칙을 한 타입에 모을 수 있어요.
+- caller API가 async가 되어도 자연스러워요.
+- compiler의 isolation과 `Sendable` 검사를 활용하고 싶어요.
+- cache, session, repository state처럼 state owner가 명확해요.
+
+다른 방법이 더 단순할 수 있는 경우예요.
+
+- state가 immutable value라 공유해도 mutation이 없어요.
+- 각 task가 독립적인 value copy만 사용해요.
+- synchronous callback 안에서 아주 짧은 critical section을 즉시 완료해야 해요. lock이나 `Mutex`를 비교해요.
+- state가 UI에만 속해 main thread 격리가 필요해요. 일반 actor보다 [`@MainActor`](./main-actor)가 요구를 정확히 표현해요.
+- actor method 대부분이 긴 CPU 작업이라 하나의 actor에 contention만 만들어요. state owner와 계산 worker를 분리해요.
+
+Actor를 data container마다 기계적으로 추가하면 모든 property access가 async 경계가 되고 actor 사이 hop이 늘어요. **어떤 invariant를 하나의 isolation domain이 보호하는가**를 먼저 답할 수 있어야 해요.
+
+## 적용 순서를 정리해요
+
+1. 여러 task가 공유하는 mutable state와 현재 synchronization 방식을 표시해요.
+2. 같은 invariant를 지키는 property와 method를 하나의 actor에 모아요.
+3. actor 밖으로 반환할 값은 immutable `Sendable` snapshot으로 설계해요.
+4. cross-actor 호출에 생긴 `await`를 단순 문법 오류로 보지 말고 실제 suspension boundary로 검토해요.
+5. 각 actor method에서 `await` 전의 가정을 목록으로 만들고 재개 뒤 다시 확인하거나 state transition을 먼저 확정해요.
+6. actor state가 필요 없는 identity와 protocol witness만 `nonisolated`로 분리해요.
+7. 여러 actor call을 하나의 isolation에서 묶어야 할 때만 `isolated` parameter를 사용해요.
+8. 긴 CPU 작업은 sendable input으로 actor 밖에서 수행하고 stale result 처리 정책을 정해요.
+9. Swift 6 strict concurrency와 결정적인 suspension dependency를 사용해 data race와 logical race를 각각 테스트해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Actor는 data race를 완전히 없애나요?
+
+Actor-isolated state에 대한 unsafe한 동시 접근을 막아 해당 state의 data race를 방지해요. 하지만 actor 밖의 shared mutable state, `nonisolated(unsafe)`, 잘못된 `@unchecked Sendable`까지 보호하지는 않으며 reentrancy로 인한 logical race도 별도로 설계해야 해요.
+
+### Actor method가 동기 함수인데 외부에서 왜 `await`하나요?
+
+Method body에 suspension이 없어도 다른 actor에서 호출하면 target actor가 실행 가능할 때까지 기다려야 해요. 그래서 cross-actor access 자체가 potential suspension이고, 같은 actor의 `self`에서 호출할 때만 동기적으로 실행할 수 있어요.
+
+### Actor는 한 method가 끝날 때까지 다른 호출을 모두 막나요?
+
+`await`가 없는 동기 구간은 mutual exclusion으로 실행돼요. Async method가 `await`에서 suspend하면 같은 actor의 다른 job이 실행될 수 있고, 원래 method는 바뀐 state 위에서 재개될 수 있어요. 이를 actor reentrancy라고 해요.
+
+### Actor의 실행 순서는 FIFO인가요?
+
+아니요. Swift runtime은 priority inversion을 줄이기 위해 task priority 등을 고려할 수 있어 actor 대기 순서를 FIFO로 보장하지 않아요. 순서가 domain 요구라면 sequence number, explicit queue state 또는 하나의 actor method 안에서 처리하는 별도 정책을 설계해요.
+
+### `nonisolated`는 언제 사용하나요?
+
+Actor의 mutable state를 전혀 읽거나 바꾸지 않는 identity, immutable metadata와 synchronous protocol witness에 사용해요. `await`를 없애기 위한 성능 annotation이 아니며, isolated state가 필요한 member에 붙일 수 없어요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Concurrency: Actors](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#Actors)
+- [The Swift Programming Language — Declarations: Actor declarations](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/declarations/#Actor-Declaration)
+- [Swift Evolution SE-0306 — Actors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md)
+- [Swift Evolution SE-0302 — Sendable and @Sendable closures](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md)
+- [Swift Evolution SE-0313 — Improved control over actor isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md)
+- [Swift Evolution SE-0327 — On Actors and Initialization](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0327-actor-initializers.md)
+- [Apple Developer — Actor](https://developer.apple.com/documentation/swift/actor)
+- [Apple Developer — Sendable](https://developer.apple.com/documentation/swift/sendable)
+- [WWDC21 — Protect mutable state with Swift actors](https://developer.apple.com/videos/play/wwdc2021/10133/)
+- [WWDC21 — Swift concurrency: Behind the scenes](https://developer.apple.com/videos/play/wwdc2021/10254/)
+- [Swift 6 Concurrency Migration Guide — Common compiler errors](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/commonproblems/)
+- [iOYES — Swift Concurrency: Actor](https://green1229.tistory.com/341)

--- a/docs/guide/swift/concurrency/gcd-vs-swift-concurrency.md
+++ b/docs/guide/swift/concurrency/gcd-vs-swift-concurrency.md
@@ -1,0 +1,438 @@
+---
+title: Swift로 이해하는 GCD와 Swift Concurrency
+description: GCD의 queue·thread와 Swift Concurrency의 task·executor를 비교하고 async/await, 구조화된 동시성, 취소와 점진적 전환 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 GCD와 Swift Concurrency
+
+> **면접 답변 한 줄 요약:** GCD는 block을 dispatch queue에 제출해 실행 순서와 thread 사용을 관리하는 시스템 library이고, Swift Concurrency는 비동기 작업을 task 구조로 표현해 결과·오류·우선순위·협력적 취소를 전파하며 actor isolation을 compiler가 검사하게 하는 언어 실행 모델이에요.
+
+GCD(Grand Central Dispatch)와 Swift Concurrency는 둘 다 여러 작업을 효율적으로 실행하도록 도와줘요. 하지만 `DispatchQueue.global().async`를 `Task {}`로 바꾸는 단순한 문법 차이는 아니에요.
+
+GCD에서는 **어느 queue에 block을 제출할지**를 중심으로 생각해요. Swift Concurrency에서는 **작업이 어떤 task에 속하고, 어디에서 중단되며, 어떤 isolation에서 다시 실행되는지**를 중심으로 생각해요. 이 차이를 이해해야 불필요한 thread hop, 취소되지 않는 작업, main actor 정체와 data race를 피할 수 있어요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- GCD의 queue와 Swift Concurrency의 task·executor 차이
+- `async`와 `await`이 보장하는 것과 보장하지 않는 것
+- 순차 실행, `async let`, task group의 선택 기준
+- structured task, `Task`, `Task.detached`의 생명주기 차이
+- 협력적 cancellation과 priority
+- callback API를 continuation으로 연결하는 방법
+- GCD 코드를 점진적으로 전환하는 기준
+
+## 먼저 알아둘 동시성 용어
+
+| 용어                   | 쉬운 뜻                                                                                                                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| concurrency            | 여러 작업이 같은 시간 구간에 진행되도록 구성하는 방식이에요. 실제로 동시에 실행되는 parallelism과는 구분해요.                                                   |
+| thread                 | 운영체제가 CPU에서 명령을 실행하도록 scheduling하는 실행 흐름이에요.                                                                                            |
+| dispatch queue         | GCD에 block을 제출하는 FIFO 대기열이에요. serial queue는 한 번에 하나를 시작하고 concurrent queue는 여러 작업을 겹쳐 실행할 수 있어요.                          |
+| task                   | Swift 비동기 코드의 기본 실행 단위예요. priority, cancellation 상태와 task-local 값을 가지고 async 함수를 실행해요.                                             |
+| suspension point       | async 함수가 thread를 점유하지 않고 잠시 멈출 가능성이 있는 지점이에요. `await`가 이 가능성을 표시해요.                                                         |
+| job                    | task가 한 suspension point에서 다음 suspension point까지 실행하는 scheduling 단위예요.                                                                          |
+| executor               | 실행 가능한 job을 받아 어떤 thread에서 실행할지 정하는 service예요. actor와 global actor는 자신의 executor에 격리될 수 있어요.                                  |
+| structured concurrency | child task의 수명과 결과를 lexical scope 안에 묶어 부모가 scope를 나가기 전에 모든 child를 기다리게 하는 구조예요.                                              |
+| unstructured task      | `Task {}`처럼 생성 scope를 벗어나서도 실행될 수 있는 task예요. handle로 결과와 cancellation을 직접 관리해야 해요.                                               |
+| data race              | 여러 실행 흐름이 synchronization 없이 같은 memory에 접근하고 그중 하나 이상이 쓰는 상황이에요.                                                                  |
+| actor isolation        | actor가 자신의 mutable state를 보호하고 compiler가 isolation boundary를 넘는 접근을 검사하는 Swift 규칙이에요. 자세한 내용은 [Actor 문서](./actors)를 참고해요. |
+
+## GCD는 block을 queue에 제출해요
+
+`DispatchQueue`는 실행할 closure인 block을 받아 system이 관리하는 thread pool에서 실행해요.
+
+```swift
+import Dispatch
+
+let imageQueue = DispatchQueue(
+  label: "com.example.reading.image",
+  qos: .userInitiated
+)
+
+imageQueue.async {
+  let thumbnail = makeThumbnail()
+
+  DispatchQueue.main.async {
+    show(thumbnail)
+  }
+}
+```
+
+이 코드에는 두 가지 정책이 직접 드러나요.
+
+1. thumbnail 생성 block을 `imageQueue`에 비동기로 제출해요.
+2. UI 갱신 block을 main queue에 다시 제출해요.
+
+Apple의 [`DispatchQueue` 문서](https://developer.apple.com/documentation/dispatch/dispatchqueue)는 queue를 serial 또는 concurrent하게 block을 실행하는 FIFO 대기열로 설명해요. 여기서 FIFO는 **제출된 작업을 꺼내 시작하는 순서**에 관한 규칙이에요. concurrent queue에 제출한 작업의 완료 순서까지 같다는 뜻은 아니에요.
+
+### `sync`와 `async`는 호출자가 기다리는지가 달라요
+
+```swift
+queue.sync {
+  updateIndex()
+}
+
+queue.async {
+  updateIndex()
+}
+```
+
+- `sync`는 block이 끝날 때까지 현재 호출을 막아요.
+- `async`는 block을 제출하고 바로 반환해요.
+
+main thread에서 `DispatchQueue.main.sync`를 호출하면 현재 main thread는 block이 끝나기를 기다리고, block은 main thread가 비워지기를 기다려 deadlock이 생겨요. 어느 queue에 있는지 사람이 정확히 추적해야 하는 이유예요.
+
+serial queue를 mutable state의 유일한 접근 경로로 사용하면 data race를 막을 수 있어요. 하지만 property를 직접 읽는 경로가 하나라도 생기면 compiler는 실수를 막아 주지 못해요.
+
+## `async`는 함수가 중단될 수 있다는 타입 정보예요
+
+Swift에서는 시간이 걸릴 수 있는 함수에 `async`를 선언해요.
+
+```swift
+struct ReadingSummary: Sendable {
+  let completedMinutes: Int
+}
+
+func fetchSummary() async throws -> ReadingSummary {
+  // 실제 앱에서는 URLSession 같은 async API를 호출해요.
+  ReadingSummary(completedMinutes: 30)
+}
+```
+
+호출하는 쪽은 potential suspension point에 `await`를 써요.
+
+```swift
+let summary = try await fetchSummary()
+print(summary.completedMinutes)
+```
+
+Swift Evolution의 [async/await 제안](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0296-async-await.md)은 suspension이 발생하면 함수가 현재 thread를 양보할 수 있다고 설명해요. 작업이 준비되면 이어서 실행하지만 suspension 전과 같은 thread에서 재개된다고 보장하지 않아요.
+
+중요한 오해를 나눠 볼게요.
+
+| 표현                 | 실제 의미                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| `async` 함수         | 실행 중 중단될 수 있어요. 호출만으로 새 task나 background thread가 생기지는 않아요.              |
+| `await`              | 이 지점에서 중단될 가능성을 표시해요. 항상 중단된다는 뜻은 아니에요.                             |
+| `Task { ... }`       | async 코드를 실행할 새 unstructured task를 만들어요. 곧바로 background thread를 지정하지 않아요. |
+| actor 또는 MainActor | 재개해야 할 isolation과 executor를 표현해요. 일반 actor는 특정 고정 thread를 뜻하지 않아요.      |
+| `@concurrent` 함수   | Swift 6.2 이상에서 caller actor를 떠나 concurrent executor에서 실행할 의도를 명시해요.           |
+
+`await` 뒤에서 같은 **actor**로 돌아오는 것은 보장할 수 있지만 같은 **thread**로 돌아온다고 가정하면 안 돼요. UI처럼 main thread 실행이 필요한 코드는 thread를 추측하지 말고 [`@MainActor`](./main-actor)로 isolation을 선언해요.
+
+## `await`를 두 번 쓴다고 두 작업이 동시에 시작되지는 않아요
+
+다음 코드는 첫 번째 호출이 끝난 뒤 두 번째 호출을 시작해요.
+
+```swift
+let profile = try await fetchProfile()
+let sessions = try await fetchSessions()
+```
+
+두 결과가 서로 독립적이고 함께 필요하다면 `async let`으로 child task를 만들 수 있어요.
+
+```swift
+async let profile = fetchProfile()
+async let sessions = fetchSessions()
+
+let page = try await ReadingPage(
+  profile: profile,
+  sessions: sessions
+)
+```
+
+`async let`으로 만든 두 child task는 동시에 진행될 수 있어요. enclosing scope는 두 child가 끝나기 전에 반환하지 않아요. 오류가 발생하거나 scope가 먼저 끝나면 남은 child는 자동으로 cancellation 요청을 받아요.
+
+| 상황                                  | 알맞은 방식             |
+| ------------------------------------- | ----------------------- |
+| 앞 결과가 다음 요청에 필요해요.       | 순서대로 `try await`    |
+| 서로 다른 고정 개수 결과가 필요해요.  | `async let`             |
+| 실행 중 동적으로 child 수가 정해져요. | `withThrowingTaskGroup` |
+
+### 동적인 작업 수에는 task group을 사용해요
+
+여러 책의 독서 시간을 동시에 불러오는 예예요.
+
+```swift
+func fetchMinutes(
+  for bookIDs: [Int],
+  client: any ReadingClient
+) async throws -> [Int] {
+  try await withThrowingTaskGroup(
+    of: (Int, Int).self,
+    returning: [Int].self
+  ) { group in
+    for (index, bookID) in bookIDs.enumerated() {
+      group.addTask {
+        let minutes = try await client.fetchMinutes(bookID: bookID)
+        return (index, minutes)
+      }
+    }
+
+    var indexedMinutes: [(Int, Int)] = []
+
+    for try await result in group {
+      indexedMinutes.append(result)
+    }
+
+    return indexedMinutes
+      .sorted { $0.0 < $1.0 }
+      .map(\.1)
+  }
+}
+```
+
+child가 끝나는 순서는 입력 순서와 다를 수 있어요. 결과 순서가 중요하므로 원래 index를 함께 반환해 정렬했어요. task group을 사용하면 모든 child가 scope 안에서 완료되고, child가 던진 오류와 cancellation을 부모가 구조적으로 처리할 수 있어요.
+
+## Task 종류는 생명주기와 상속 범위가 달라요
+
+모든 async 함수는 어떤 task 안에서 실행돼요. 일반 async 함수를 `await`해 호출하면 새 task를 만드는 것이 아니라 현재 task에서 이어서 실행해요.
+
+| 생성 방식               | 구조화 여부  | creator의 actor context     | priority·task-local      | cancellation 관계                                                                    |
+| ----------------------- | ------------ | --------------------------- | ------------------------ | ------------------------------------------------------------------------------------ |
+| 일반 async 함수 `await` | 같은 task    | 현재 isolation을 따름       | 같은 task 정보           | 같은 task의 cancellation 상태를 봐요.                                                |
+| `async let`             | child task   | closure 규칙에 따라 결정    | 부모에서 상속            | 부모 취소가 child로 전파되고 scope가 child 완료를 기다려요.                          |
+| `group.addTask`         | child task   | 명시된 isolation을 따름     | 부모에서 상속            | group이 lifetime을 묶고 오류·취소를 관리해요.                                        |
+| `Task { ... }`          | unstructured | 현재 actor를 상속할 수 있음 | priority·task-local 상속 | parent-child lifetime이 없어 creator 취소가 자동 전파되지 않아요. handle을 관리해요. |
+| `Task.detached { ... }` | unstructured | 상속하지 않음               | 상속하지 않음            | 독립적이에요. 필요한 경우 handle을 저장하고 직접 취소해요.                           |
+
+`Task {}`를 구조화된 child task라고 부르면 안 돼요. 현재 actor context와 일부 task 정보를 상속할 수 있지만 생성한 함수가 반환된 뒤에도 실행될 수 있어요.
+
+```swift
+@MainActor
+final class ThumbnailLoader {
+  private var task: Task<Void, Never>?
+
+  func start() {
+    task = Task {
+      await loadThumbnails()
+    }
+  }
+
+  func cancel() {
+    task?.cancel()
+    task = nil
+  }
+}
+```
+
+unstructured task가 화면이나 객체 lifetime에 묶여야 한다면 handle을 보관하고 명확한 시점에 취소해요. 단순히 async 함수 안에서 병렬 child가 필요하다면 `Task {}`보다 `async let`이나 task group을 먼저 검토해요.
+
+`Task.detached`는 actor context까지 끊어야 하는 드문 작업에 사용해요. isolation 오류를 피하려고 습관적으로 쓰면 non-`Sendable` capture와 lifetime 관리가 더 어려워져요.
+
+## cancellation은 요청이며 작업이 협력해야 해요
+
+Swift task를 취소해도 runtime이 임의의 줄에서 작업을 강제로 종료하지 않아요. 취소 상태를 기록하고 child task로 요청을 전파해요. 작업은 적절한 지점에서 상태를 확인해야 해요.
+
+```swift
+func buildSearchIndex(
+  from books: [Book]
+) async throws -> [SearchEntry] {
+  var entries: [SearchEntry] = []
+
+  for book in books {
+    try Task.checkCancellation()
+    entries.append(makeSearchEntry(from: book))
+  }
+
+  return entries
+}
+```
+
+`Task.checkCancellation()`은 취소되었다면 `CancellationError`를 던져요. 오류를 던질 수 없는 함수에서는 `Task.isCancelled`를 확인하고 지금까지 만든 결과를 버리거나 반환할 정책을 정해요.
+
+`Task.sleep(for:)`처럼 cancellation을 확인하는 API도 있지만 **모든 `await`가 자동으로 `CancellationError`를 던지는 것은 아니에요.** 사용하는 API의 cancellation 계약을 확인해야 해요.
+
+GCD의 `DispatchWorkItem.cancel()`도 이미 실행 중인 block을 강제로 멈추지 않아요. 차이는 Swift structured concurrency가 부모와 child 관계를 알고 cancellation 요청을 아래로 전파할 수 있다는 점이에요. 실제 종료가 협력적이라는 사실은 둘 다 코드가 책임져야 해요.
+
+## priority는 실행 순서를 확정하지 않아요
+
+Swift task는 `TaskPriority`를 가지고 child task가 부모 priority를 상속할 수 있어요. 높은 priority task가 낮은 priority task의 결과를 기다리면 priority inversion을 완화하기 위한 escalation도 일어날 수 있어요.
+
+```swift
+let task = Task(priority: .userInitiated) {
+  try await fetchReadingPage()
+}
+
+let page = try await task.value
+```
+
+priority는 executor가 scheduling 판단에 사용할 **힌트**예요. 높은 priority task가 항상 먼저 완료된다는 보장은 없어요. GCD의 QoS도 작업의 중요도와 latency 기대를 전달하지만 dependency와 실제 resource 상태에 따라 순서가 달라질 수 있어요.
+
+priority를 작업 순서 제어 장치로 사용하지 말고 필요한 dependency는 `await`로 표현해요.
+
+## callback API는 continuation으로 한 번만 연결해요
+
+기존 library가 completion handler만 제공한다면 continuation으로 async 함수 하나를 만들 수 있어요.
+
+```swift
+protocol LegacyReadingAPI: Sendable {
+  func loadSummary(
+    completion: @escaping @Sendable (
+      Result<ReadingSummary, any Error>
+    ) -> Void
+  )
+}
+
+func loadSummary(
+  from api: any LegacyReadingAPI
+) async throws -> ReadingSummary {
+  try await withCheckedThrowingContinuation { continuation in
+    api.loadSummary { result in
+      continuation.resume(with: result)
+    }
+  }
+}
+```
+
+continuation은 callback이 어느 queue에서 호출되는지를 caller에게 다시 노출하지 않으면서 중단된 task를 재개해요. 재개된 코드는 자신의 actor isolation과 executor 규칙을 따라요.
+
+반드시 지켜야 할 계약이 있어요.
+
+- 모든 실행 경로에서 정확히 한 번 `resume`해요.
+- callback이 두 번 올 수 있다면 먼저 한 번만 전달되도록 adapter가 상태를 보호해요.
+- callback이 오지 않을 수 있다면 취소·timeout·실패 경로를 설계해요.
+- continuation closure 안에서 오래 걸리는 동기 작업으로 thread를 막지 않아요.
+
+`CheckedContinuation`은 일부 오용을 진단하지만 API의 취소를 자동으로 구현하지 않아요. underlying request를 취소해야 한다면 `withTaskCancellationHandler`와 library의 cancel handle을 함께 설계해야 해요.
+
+제공된 [Actor 참고 글](https://green1229.tistory.com/341)과 [MainActor 참고 글](https://green1229.tistory.com/343)은 completion handler를 async 함수로 감싸고 serial queue 기반 저장소를 actor로 옮기는 흐름을 보여 줘요. 이 문서에서는 그 전환 흐름에 structured task, cooperative cancellation과 Swift 6 isolation 규칙을 더해 설명해요.
+
+## GCD와 Swift Concurrency를 같은 기준으로 비교해요
+
+| 비교 기준          | GCD                                                                | Swift Concurrency                                                                                  |
+| ------------------ | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| 기본 실행 단위     | queue에 제출한 block 또는 `DispatchWorkItem`                       | async 함수를 실행하는 task와 suspension 사이의 job                                                 |
+| scheduling 표현    | serial·concurrent queue, target queue와 QoS를 직접 선택해요.       | executor가 job을 scheduling하고 코드는 task·actor isolation을 표현해요.                            |
+| 결과와 오류        | completion handler, shared storage, `DispatchGroup` 등을 조립해요. | async 함수의 return과 `throws`가 일반 control flow처럼 전파돼요.                                   |
+| 병렬 child의 수명  | 제출한 block의 lifetime을 별도로 추적해요.                         | `async let`과 task group은 child가 scope 밖으로 나가지 못하게 해요.                                |
+| cancellation       | work item과 underlying API별로 flag와 전달 방식을 설계해요.        | task tree로 요청을 전파하지만 실제 중단은 작업이 협력해요.                                         |
+| mutable state 보호 | serial queue, barrier, lock을 빠짐없이 사용해야 해요.              | actor와 `Sendable` 계약을 compiler가 검사할 수 있어요.                                             |
+| main UI 실행       | `DispatchQueue.main.async`를 호출 지점마다 선택해요.               | 선언에 `@MainActor` 요구를 기록하고 isolation boundary에서 hop해요.                                |
+| 순서               | serial queue는 제출 순서대로 block을 시작해요.                     | actor와 executor는 priority를 고려할 수 있어 FIFO를 보장하지 않아요.                               |
+| thread blocking    | `sync`, semaphore와 blocking API를 사용할 수 있지만 주의해야 해요. | suspension을 전제로 한 cooperative pool에서 thread blocking은 다른 task의 진행까지 막을 수 있어요. |
+| 적용 범위          | C·Objective-C·Swift에서 사용하는 Darwin system concurrency library | Swift type system, runtime, standard library가 함께 제공하는 언어 수준 모델                        |
+
+둘 중 하나가 모든 상황에서 무조건 더 빠른 것은 아니에요. Swift Concurrency의 task는 suspension할 때 thread를 양보해 많은 비동기 작업을 적은 thread로 진행할 수 있어요. 반대로 아주 작은 동기 critical section이나 DispatchSource 같은 system primitive까지 actor로 감싸면 async 경계와 hop 비용만 늘 수 있어요.
+
+Apple의 [Swift concurrency: Behind the scenes](https://developer.apple.com/videos/play/wwdc2021/10254/)는 cooperative thread pool이 원활히 동작하려면 task가 thread를 오래 막지 않아야 한다고 설명해요. async 코드 안에서 semaphore로 다른 async 결과를 동기적으로 기다리거나 blocking I/O를 대량 실행하면 thread starvation이 생길 수 있어요.
+
+## Swift 6.2 이후에는 기본 isolation 설정도 확인해요
+
+Swift 6.2는 executable target을 main actor에 기본 격리할 수 있는 선택지를 추가했어요. Xcode의 **Default Actor Isolation**을 `MainActor`로 설정하거나 Swift Package에서 다음과 같이 지정할 수 있어요.
+
+```swift
+.target(
+  name: "ReadingApp",
+  swiftSettings: [
+    .defaultIsolation(MainActor.self),
+  ]
+)
+```
+
+이 설정을 사용하면 annotation이 없는 많은 선언이 암시적으로 main actor에 격리돼요. 설정하지 않으면 module 기본은 `nonisolated`예요. library target과 app target의 설정이 다를 수 있으므로 “annotation이 없으니 어느 actor에도 속하지 않는다”고 단정하지 말고 build setting을 확인해요.
+
+같은 release에서 `@concurrent`는 caller actor를 떠나 concurrent executor에서 실행해야 하는 CPU 작업의 의도를 명시해요.
+
+```swift
+import Foundation
+
+struct SearchIndex: Decodable, Sendable {}
+
+@concurrent
+func decodeSearchIndex(
+  from data: Data
+) async throws -> SearchIndex {
+  try JSONDecoder().decode(SearchIndex.self, from: data)
+}
+```
+
+`async`만 붙이면 자동으로 main actor를 떠난다는 오래된 설명에 의존하지 마세요. Swift 6.2의 `NonisolatedNonsendingByDefault` 기능과 default isolation 설정에 따라 annotation이 없는 async 함수의 isolation이 달라질 수 있어요. main actor를 비워야 하는 계산은 의도를 명시하고 실제 Instruments 측정으로 확인해요.
+
+## GCD를 한 번에 지우지 말고 경계부터 옮겨요
+
+| 기존 패턴                                   | 먼저 검토할 Swift Concurrency 표현              | 확인할 점                                                                  |
+| ------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| completion handler                          | native async overload 또는 checked continuation | callback이 정확히 한 번 오는지, underlying cancellation이 있는지 확인해요. |
+| 독립된 두 `DispatchGroup` 작업              | `async let`                                     | 두 결과가 모두 필요하고 고정 개수인지 확인해요.                            |
+| 반복문에서 동적으로 group에 작업 추가       | throwing task group                             | 결과 순서, 동시 요청 상한과 오류 정책을 정해요.                            |
+| mutable state를 지키는 private serial queue | actor                                           | API가 async로 바뀌는 비용과 reentrancy를 함께 설계해요.                    |
+| `DispatchQueue.main.async` UI 갱신          | type 또는 method의 `@MainActor`                 | 호출 지점의 hop보다 UI state 소유 타입의 isolation을 먼저 선언해요.        |
+| `asyncAfter` 지연 실행                      | `Task.sleep(for:)`                              | duration과 clock, cancellation 처리를 확인해요.                            |
+| background queue의 CPU 계산                 | 명확한 nonisolated/`@concurrent` async 함수     | `Sendable` 입력·출력과 main actor를 막지 않는지 확인해요.                  |
+| `DispatchSource`, low-level event source    | GCD를 유지하고 async interface로 감싸기         | system API의 lifecycle과 handler queue 의미를 보존해요.                    |
+
+새 코드라고 GCD를 사용할 수 없는 것은 아니에요. DispatchSource, file descriptor event, 기존 library의 queue contract처럼 GCD가 직접 표현하는 system 기능은 그대로 사용할 수 있어요. 반대로 단순히 결과를 반환하는 비동기 흐름과 공유 상태 보호에는 async 함수, structured task와 actor가 더 많은 정보를 compiler에 제공해요.
+
+## 언제 어떤 방식을 선택해야 하나요
+
+Swift Concurrency를 먼저 검토하기 좋은 경우예요.
+
+- 새 Swift API가 결과를 비동기로 반환하고 오류와 취소를 caller에게 전달해요.
+- 여러 child 작업의 lifetime을 하나의 operation scope에 묶어야 해요.
+- mutable state를 여러 task에서 공유해 actor isolation이 필요해요.
+- UI 실행 요구를 `@MainActor`로 API contract에 남기고 싶어요.
+- Swift 6 strict concurrency에서 `Sendable`과 isolation 검사를 활용하려고 해요.
+
+GCD를 유지하거나 함께 사용하기 좋은 경우예요.
+
+- DispatchSource, source handler, target queue 같은 GCD 고유 기능을 사용해요.
+- C·Objective-C API가 dispatch queue를 명시적인 callback contract로 사용해요.
+- 아주 작은 동기 critical section을 async API로 바꾸지 않고 보호해야 해요. 이때는 lock이나 Swift Synchronization의 `Mutex`도 비교해요.
+- 검증된 legacy code를 한 번에 다시 작성하는 위험이 점진적 adapter보다 커요.
+
+`Task.detached`나 global concurrent queue에 넣었다는 이유만으로 CPU 작업이 빨라지지는 않아요. 작업을 나눌 가치가 있는지, actor hop과 scheduling 비용보다 계산량이 큰지 측정해야 해요.
+
+## 적용 순서를 정리해요
+
+1. 현재 queue가 **작업 실행**, **mutable state 보호**, **main UI 이동** 중 어떤 역할을 하는지 표시해요.
+2. completion 기반 API에 공식 async overload가 있는지 먼저 확인해요.
+3. 없으면 가장 바깥 경계 하나만 checked continuation으로 감싸요.
+4. 순차 dependency는 `await`, 고정된 독립 작업은 `async let`, 동적인 child는 task group으로 표현해요.
+5. unstructured `Task`가 필요하면 handle 소유자와 취소 시점을 정해요.
+6. serial queue가 보호하던 state를 actor로 옮길 때 모든 `await` 전후 invariant를 다시 검사해요.
+7. UI state의 소유 타입을 `@MainActor`로 격리하고 무거운 동기 작업은 밖으로 분리해요.
+8. Swift 6 strict concurrency와 target의 Default Actor Isolation 설정에서 compile해요.
+9. Instruments의 Swift Concurrency template과 실제 latency를 측정한 뒤 GCD 경계를 더 옮길지 결정해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `async` 함수는 자동으로 background thread에서 실행되나요?
+
+아니요. `async`는 함수가 suspension할 수 있다는 뜻이며 새 task나 background thread를 자동 생성하지 않아요. 함수는 현재 task와 isolation에서 시작할 수 있고 suspension 뒤에는 같은 thread가 아니라 자신이 속한 actor의 executor 규칙에 따라 재개돼요.
+
+### `await`와 `DispatchQueue.sync`는 둘 다 기다리는데 무엇이 다른가요?
+
+`DispatchQueue.sync`는 제출한 block이 끝날 때까지 호출 thread를 막아요. `await`는 async 작업을 기다리는 동안 현재 task를 suspend해 thread가 다른 job을 실행할 수 있게 해요. 단, awaited 함수가 blocking 작업을 수행하면 async 문법을 사용해도 thread는 여전히 막혀요.
+
+### `Task {}`는 structured concurrency인가요?
+
+아니요. `Task {}`는 actor context, priority와 task-local 값을 상속할 수 있지만 creator scope에 lifetime이 묶이지 않는 unstructured task예요. 구조화된 child가 필요하면 `async let`이나 task group을 사용하고, `Task`를 사용하면 handle과 cancellation을 직접 관리해요.
+
+### Swift task cancellation은 즉시 함수를 종료하나요?
+
+아니요. cancellation은 상태와 요청을 전파하는 협력적 기능이에요. 작업이 `Task.checkCancellation()`, `Task.isCancelled` 또는 cancellation을 지원하는 API를 사용해 적절한 지점에서 종료해야 해요.
+
+### actor는 serial DispatchQueue와 같은가요?
+
+둘 다 mutable state에 mutual exclusion을 제공할 수 있지만 같지는 않아요. actor isolation은 compiler가 접근을 검사하고 suspension 시 다른 actor 작업이 끼어들 수 있으며 실행 순서도 FIFO가 아니에요. 자세한 차이는 [Actor와 데이터 격리](./actors)에서 이어서 설명해요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/)
+- [Swift Evolution SE-0296 — Async/await](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0296-async-await.md)
+- [Swift Evolution SE-0304 — Structured Concurrency](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0304-structured-concurrency.md)
+- [Swift Evolution SE-0302 — Sendable and @Sendable closures](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md)
+- [Swift Evolution SE-0461 — Run nonisolated async functions on the caller's actor by default](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md)
+- [Swift Evolution SE-0466 — Control default actor isolation inference](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0466-control-default-actor-isolation.md)
+- [Swift.org — Swift 6.2 Released](https://www.swift.org/blog/swift-6.2-released/)
+- [Apple Developer — DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue)
+- [Apple Developer — Task](https://developer.apple.com/documentation/swift/task)
+- [Apple Developer — Concurrency](https://developer.apple.com/documentation/swift/concurrency)
+- [WWDC21 — Explore structured concurrency in Swift](https://developer.apple.com/videos/play/wwdc2021/10134/)
+- [WWDC21 — Swift concurrency: Behind the scenes](https://developer.apple.com/videos/play/wwdc2021/10254/)
+- [WWDC22 — Visualize and optimize Swift concurrency](https://developer.apple.com/videos/play/wwdc2022/110350/)
+- [iOYES — Swift Concurrency: Actor](https://green1229.tistory.com/341)
+- [iOYES — Swift Concurrency: @MainActor 사용하기](https://green1229.tistory.com/343)

--- a/docs/guide/swift/concurrency/main-actor.md
+++ b/docs/guide/swift/concurrency/main-actor.md
@@ -1,0 +1,617 @@
+---
+title: Swift로 이해하는 MainActor와 UI 격리
+description: MainActor가 UI state를 main executor에 격리하는 원리와 선언 위치, MainActor.run, Task·DispatchQueue.main 차이와 테스트 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 MainActor와 UI 격리
+
+> **면접 답변 한 줄 요약:** `@MainActor`는 UI state와 관련 동작을 main actor라는 하나의 global actor에 격리해 compiler가 잘못된 concurrency domain의 접근을 막고 필요한 async 호출에서 main executor로 전환하게 하는 선언이며, 무거운 작업을 background로 보내는 annotation은 아니에요.
+
+UIKit과 AppKit의 UI 객체는 main thread에서 다뤄야 해요. GCD에서는 callback이 어느 queue에서 오는지 확인하고 필요할 때마다 `DispatchQueue.main.async`를 호출했어요. 이 방식은 실행 시점에 main queue로 보내지만, 함수 선언만 보고 main 실행 요구를 알기 어렵고 한 호출 지점에서 빼먹어도 compiler가 전체 규칙을 검사하기 어려워요.
+
+`@MainActor`는 “이 code와 state는 main actor에 속한다”는 요구를 type system에 기록해요. 호출자는 같은 actor에 있으면 동기적으로 사용하고, 다른 isolation에 있으면 async 경계를 통해 main actor로 전환해요.
+
+Queue와 task의 실행 모델부터 비교하려면 [GCD와 Swift Concurrency](./gcd-vs-swift-concurrency)를, 일반 actor instance의 격리와 reentrancy를 먼저 확인하려면 [Actor와 데이터 격리](./actors)를 참고해요.
+
+이 문서에서는 다음 내용을 설명해요.
+
+- global actor와 MainActor의 의미
+- `DispatchQueue.main.async`와 `@MainActor`의 차이
+- type, method, property와 closure에 isolation을 선언하는 기준
+- 같은 actor 호출과 cross-actor 호출 규칙
+- `MainActor.run`, `Task { @MainActor in }`, `Task {}`의 차이
+- main actor를 막는 CPU·blocking 작업을 분리하는 방법
+- UIKit·SwiftUI 상태 모델과 MainActor 테스트 방법
+- Swift 6.2 Default Actor Isolation의 영향
+
+## 먼저 알아둘 MainActor 용어
+
+| 용어                 | 쉬운 뜻                                                                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| global actor         | 서로 다른 type과 함수에 흩어진 선언을 하나의 singleton actor isolation에 묶는 기능이에요.                                          |
+| MainActor            | main dispatch queue와 동등한 executor를 사용하는 Swift 표준 global actor예요. UI code와 state를 main 실행 문맥에 묶을 때 사용해요. |
+| main thread          | app event와 UI framework 작업을 처리하는 process의 특별한 thread예요.                                                              |
+| main executor        | MainActor에 제출된 job을 main thread에서 실행하도록 scheduling하는 executor예요.                                                   |
+| isolation annotation | `@MainActor`처럼 선언이 어느 actor에 속하는지 type system에 표시하는 attribute예요.                                                |
+| actor hop            | 현재 executor와 다른 actor-isolated 함수를 실행하기 위해 target actor의 executor로 전환하는 일이에요.                              |
+| inherited isolation  | type이나 enclosing context의 global actor annotation이 member나 closure에 전파되는 규칙이에요.                                     |
+| `MainActor.run`      | async context에서 main actor로 전환해 synchronous closure를 실행하고 결과를 기다리는 API예요.                                      |
+| default isolation    | annotation이 없는 선언을 `nonisolated` 또는 `MainActor` 중 어디에 둘지 target 단위로 정하는 Swift 6.2 이상의 compiler 설정이에요.  |
+
+## MainActor는 여러 선언이 공유하는 singleton actor예요
+
+일반 actor는 instance마다 독립적인 isolation domain을 만들어요.
+
+```swift
+actor ReadingStore {}
+
+let personal = ReadingStore()
+let shared = ReadingStore()
+```
+
+`personal`과 `shared`는 서로 다른 actor예요. 반면 global actor는 하나의 `shared` actor instance를 기준으로 여러 선언을 같은 isolation에 모아요. 표준 library가 제공하는 `MainActor`를 단순화하면 다음 모양이에요.
+
+Global actor가 가지는 형태를 custom actor로 단순화하면 다음과 같아요.
+
+```swift
+@globalActor
+actor ExampleGlobalActor {
+  static let shared = ExampleGlobalActor()
+}
+```
+
+`MainActor`도 `GlobalActor` 요구사항을 만족하는 singleton actor를 표준 library가 제공한 것이에요. 앱에서는 `shared`를 직접 생성하거나 교체하지 않고 `@MainActor` attribute로 사용해요.
+
+```swift
+@MainActor
+func updateReadingProgressLabel() {
+  // main actor-isolated UI 작업
+}
+```
+
+Apple의 [`MainActor` 문서](https://developer.apple.com/documentation/swift/mainactor)는 MainActor의 executor가 main dispatch queue와 동등하다고 설명해요. 일반 actor가 특정 고정 thread를 뜻하지 않는 것과 달리 MainActor는 Apple platform의 main thread UI model과 연결된 특별한 global actor예요.
+
+## `DispatchQueue.main.async`는 호출이고 `@MainActor`는 계약이에요
+
+Legacy callback에서 UI를 갱신하는 코드를 볼게요.
+
+```swift
+func loadSummary() {
+  client.loadSummary { result in
+    DispatchQueue.main.async {
+      self.render(result)
+    }
+  }
+}
+```
+
+이 방식은 closure를 main queue에 비동기로 제출해요. `render`의 선언에는 main thread 요구가 보이지 않으므로 다른 호출자가 queue 이동을 빠뜨릴 수 있어요.
+
+MainActor를 사용하면 요구를 UI state의 소유자에 선언해요.
+
+```swift
+@MainActor
+final class ReadingHeaderViewModel {
+  private(set) var title = ""
+
+  func render(_ summary: ReadingSummary) {
+    title = "오늘 \(summary.completedMinutes)분 읽었어요"
+  }
+}
+```
+
+Type 전체를 `@MainActor`로 표시하면 instance property, method와 subscript가 기본적으로 main actor-isolated돼요. 다른 isolation에서 동기적으로 접근하려 하면 Swift 6 compiler가 오류를 내고, async context에서는 `await`를 통해 actor hop해야 해요.
+
+| 기준           | `DispatchQueue.main.async`                                        | `@MainActor`                                                                        |
+| -------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| 표현 위치      | 각 호출 지점                                                      | type·method·property·closure 선언                                                   |
+| compiler 정보  | block 제출은 알지만 대상 API의 전체 isolation 계약은 아니에요.    | declaration type에 main actor isolation이 들어가 cross-actor 접근을 검사해요.       |
+| 실행 흐름      | block을 enqueue하고 caller는 즉시 반환해요.                       | async 호출자는 hop한 작업의 결과와 오류를 `await`하며 구조적으로 이어 갈 수 있어요. |
+| 같은 main 문맥 | `async`를 호출하면 불필요하게 다음 queue turn으로 미룰 수 있어요. | 이미 MainActor라면 synchronous member를 바로 실행할 수 있어요.                      |
+| 누락 방지      | 모든 호출자가 직접 기억해야 해요.                                 | 격리된 API를 잘못 호출하면 compiler가 진단해요.                                     |
+
+제공된 [MainActor 참고 글](https://green1229.tistory.com/343)은 `DispatchQueue.main.async`를 호출마다 넣던 code를 `@MainActor` ViewModel로 옮기는 흐름을 보여 줘요. 현재 Swift에서는 annotation을 단순한 “자동 dispatch”로만 보기보다 state ownership과 cross-actor compile-time contract로 이해해야 해요.
+
+## UI state의 소유 type 전체를 격리해요
+
+화면 상태가 서로 하나의 invariant를 이룬다면 property마다 붙이기보다 type 전체를 격리하는 편이 읽기 쉬워요.
+
+```swift
+struct ReadingSummary: Sendable, Equatable {
+  let completedMinutes: Int
+}
+
+enum ReadingViewState: Equatable {
+  case idle
+  case loading
+  case loaded(ReadingSummary)
+  case failed(String)
+}
+
+protocol ReadingSummaryLoading: Sendable {
+  func loadSummary() async throws -> ReadingSummary
+}
+
+@MainActor
+final class ReadingViewModel {
+  private let loader: any ReadingSummaryLoading
+  private(set) var state: ReadingViewState = .idle
+
+  init(loader: any ReadingSummaryLoading) {
+    self.loader = loader
+  }
+
+  func load() async {
+    state = .loading
+
+    do {
+      let summary = try await loader.loadSummary()
+      state = .loaded(summary)
+    } catch is CancellationError {
+      state = .idle
+    } catch {
+      state = .failed(error.localizedDescription)
+    }
+  }
+}
+```
+
+`load()`는 MainActor에 isolated되어 있지만 `await loader.loadSummary()`에서 task가 suspend하므로 main thread를 점유한 채 network 응답을 기다리지 않아요. 응답 뒤에는 main actor로 돌아와 `state`를 안전하게 바꿔요.
+
+`await` 동안에는 main actor의 다른 event가 실행될 수 있어요. 사용자가 새 load를 시작하거나 화면을 닫을 수 있으므로 일반 actor와 마찬가지로 stale response, cancellation과 reentrancy를 고려해야 해요.
+
+### UIKit type도 MainActor annotation을 사용해요
+
+현대 SDK의 `UIView`, `UIViewController` 같은 UIKit API는 MainActor isolation을 포함해요.
+
+```swift
+@MainActor
+final class ReadingViewController: UIViewController {
+  private let viewModel: ReadingViewModel
+
+  init(viewModel: ReadingViewModel) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func refresh() {
+    Task {
+      await viewModel.load()
+      render(viewModel.state)
+    }
+  }
+
+  private func render(_ state: ReadingViewState) {
+    // 실제 앱에서는 state에 맞게 label과 loading view를 갱신해요.
+  }
+}
+```
+
+`refresh()`가 이미 MainActor에 있으므로 여기서 만든 `Task {}` closure도 actor context를 상속해요. `viewModel.load()`는 같은 actor에 isolated되어 있어 runtime hop이 필요 없는 경우 compiler가 최적화할 수 있어요. `load()`가 async이므로 potential suspension을 표시하는 `await`는 여전히 사용해요.
+
+다만 이 `Task`는 unstructured예요. View Controller가 사라질 때 취소해야 한다면 handle을 property에 저장하고 lifecycle에서 취소하거나, SwiftUI에서는 view lifecycle과 연동되는 `.task`를 검토해요.
+
+## 필요한 범위에만 MainActor를 선언할 수도 있어요
+
+Type 전체 state가 UI와 관련되지 않으면 특정 member만 격리할 수 있어요.
+
+```swift
+import Foundation
+
+final class ReadingExporter: Sendable {
+  func makeArchive() async throws -> URL {
+    URL(fileURLWithPath: "/tmp/reading.zip")
+  }
+
+  @MainActor
+  func presentShareSheet(for archiveURL: URL) {
+    // UIKit 화면 표시
+  }
+}
+```
+
+MainActor declaration을 붙일 수 있는 대표 위치예요.
+
+```swift
+@MainActor final class ViewModel {}
+
+@MainActor func updateUI() {}
+
+@MainActor var selectedBookID: Int?
+
+let completion: @MainActor (ReadingSummary) -> Void = { summary in
+  // main actor-isolated closure
+}
+```
+
+| 선언 위치    | 알맞은 상황                                                                              |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| type 전체    | 대부분의 state와 method가 UI lifetime·main thread 요구를 공유해요.                       |
+| extension    | 기존 type에서 UI 관련 기능 묶음만 같은 isolation에 두고 싶어요.                          |
+| method       | type의 일부 operation만 UI framework를 호출해요.                                         |
+| property     | 제한된 global·static state 하나가 main actor 보호를 받아야 해요.                         |
+| closure type | 저장하거나 전달하는 callback 자체가 MainActor에서 호출되어야 한다는 contract가 필요해요. |
+
+흩어진 property에 개별 annotation을 많이 붙이면 서로 다른 state가 하나의 UI invariant라는 사실이 약해져요. UI-facing ViewModel은 type 전체 격리를 먼저 검토하고, 순수 계산이나 immutable metadata만 명확한 이유가 있을 때 분리해요.
+
+## 호출 위치에 따라 `await` 필요 여부가 달라요
+
+MainActor-isolated synchronous function을 선언해 볼게요.
+
+```swift
+import UIKit
+
+@MainActor
+func setNavigationTitle(
+  _ title: String,
+  on viewController: UIViewController
+) {
+  viewController.navigationItem.title = title
+}
+```
+
+| 호출 위치                              | 호출 형태                                          | 이유                                                                                      |
+| -------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| MainActor의 synchronous·async code     | `setNavigationTitle("독서", on: controller)`       | 이미 같은 isolation이라 synchronous access가 가능해요.                                    |
+| 다른 actor 또는 nonisolated async code | `await setNavigationTitle("독서", on: controller)` | main actor로 hop할 수 있는 potential suspension이에요.                                    |
+| nonisolated synchronous code           | 직접 호출 불가                                     | synchronous caller는 suspension할 수 없으므로 async context를 만들거나 API 경계를 바꿔요. |
+
+`@MainActor`가 붙은 synchronous 함수를 legacy callback에서 호출한다고 runtime이 모든 경우에 새 task를 자동 생성하는 것은 아니에요. Swift 6 strict concurrency에서는 안전하지 않은 cross-actor 동기 호출을 compile time에 막아요. Objective-C callback과 `@preconcurrency` API처럼 isolation 정보가 약한 경계에서는 dynamic check나 adapter가 필요할 수 있어요.
+
+callback의 threading contract가 명확하지 않다면 async adapter를 만들고 isolation 안으로 들어와요.
+
+```swift
+struct LegacyEvent: Sendable {
+  let title: String
+}
+
+@MainActor
+func apply(_ event: LegacyEvent) {
+  // UI state를 event에 맞게 갱신해요.
+}
+
+func receiveLegacyEvent(_ event: LegacyEvent) {
+  Task { @MainActor in
+    apply(event)
+  }
+}
+```
+
+이 방식은 새 unstructured task를 만드는 선택이에요. 결과를 기다려야 하는 API라면 fire-and-forget task보다 caller를 async로 바꾸고 `await`로 관계를 보존하는 편이 좋아요.
+
+## `MainActor.run`은 현재 async 흐름 안에서 결과를 기다려요
+
+Nonisolated async 함수 일부에서만 UI state를 갱신해야 할 때 `MainActor.run`을 사용할 수 있어요.
+
+```swift
+func importBooks(
+  from url: URL,
+  viewModel: ReadingViewModel
+) async throws {
+  let books = try await decodeBooks(from: url)
+
+  await MainActor.run {
+    viewModel.showImportedBooks(books)
+  }
+}
+```
+
+`MainActor.run`은 MainActor-isolated synchronous closure를 실행하고 closure 결과가 끝날 때까지 현재 task가 기다려요. 오류를 던지는 closure도 사용할 수 있어요.
+
+`Task { @MainActor in }`와 비교해 볼게요.
+
+```swift
+await MainActor.run {
+  viewModel.showLoading(false)
+}
+
+let task = Task { @MainActor in
+  viewModel.showLoading(false)
+}
+
+await task.value
+```
+
+| 방식                         | 구조와 lifetime                                                              | 사용 기준                                                                            |
+| ---------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `await MainActor.run {}`     | 현재 task가 main actor closure 완료를 기다려요.                              | 기존 async operation의 한 구간을 main actor에서 실행하고 바로 다음 흐름을 이어 가요. |
+| `Task { @MainActor in }`     | 별도 unstructured task를 만들고 handle을 반환해요.                           | 독립 lifetime이 실제로 필요하고 handle의 결과·오류·취소를 소유할 곳이 있어요.        |
+| MainActor type의 method 호출 | isolation 요구가 API 선언에 남고 caller가 `await`해요.                       | UI state owner의 장기적인 contract를 표현할 때 가장 먼저 선택해요.                   |
+| `DispatchQueue.main.async`   | main queue에 block을 제출하고 즉시 반환하며 Swift task 관계는 만들지 않아요. | GCD·Objective-C callback interop처럼 queue API 자체가 경계일 때 사용해요.            |
+
+Swift 6 Concurrency Migration Guide는 `MainActor.run`을 migration 도구로 사용할 수 있지만 system의 isolation 요구를 정적으로 표현하는 대신 남용하지 말라고 안내해요. 반복해서 `MainActor.run`으로 같은 object를 감싼다면 그 object나 method가 `@MainActor`여야 하는지 먼저 검토해요.
+
+## MainActor는 순서 보장용 fire-and-forget queue가 아니에요
+
+다음 코드는 세 개의 독립 task를 만들어요.
+
+```swift
+@MainActor
+final class FireAndForgetState {
+  private(set) var state: ReadingViewState = .idle
+
+  func update(with summary: ReadingSummary) {
+    Task { @MainActor in self.state = .loading }
+    Task { @MainActor in self.state = .loaded(summary) }
+    Task { @MainActor in self.logCompletion() }
+  }
+
+  private func logCompletion() {
+    // analytics event를 기록해요.
+  }
+}
+```
+
+Actor executor는 submission FIFO를 보장하지 않고 task priority도 고려할 수 있어요. 더 중요한 문제는 creator가 어느 task의 완료나 오류도 기다리지 않는다는 점이에요.
+
+관련 state transition은 하나의 MainActor-isolated async function에 모아요.
+
+```swift
+@MainActor
+final class StructuredReadingState {
+  private let loader: any ReadingSummaryLoading
+  private(set) var state: ReadingViewState = .idle
+
+  init(loader: any ReadingSummaryLoading) {
+    self.loader = loader
+  }
+
+  func load() async {
+    state = .loading
+
+    do {
+      let summary = try await loader.loadSummary()
+      state = .loaded(summary)
+      logCompletion()
+    } catch {
+      state = .failed(error.localizedDescription)
+    }
+  }
+
+  private func logCompletion() {
+    // analytics event를 기록해요.
+  }
+}
+```
+
+`await` 동안 다른 main actor job이 들어올 수 있으므로 request ID나 task cancellation이 필요할 수 있지만, 적어도 한 operation의 lifetime과 오류 흐름이 함수에 보존돼요.
+
+## MainActor에서 network를 기다리는 것과 CPU를 점유하는 것은 달라요
+
+MainActor-isolated 함수 안에서 `URLSession` async API를 호출하는 것은 일반적으로 응답을 기다리는 동안 task를 suspend해 main thread를 양보해요.
+
+```swift
+@MainActor
+final class CoverViewModel {
+  private let coverURL: URL
+  private(set) var image: UIImage?
+
+  init(coverURL: URL) {
+    self.coverURL = coverURL
+  }
+
+  func loadCover() async throws {
+    let (data, _) = try await URLSession.shared.data(from: coverURL)
+    image = UIImage(data: data)
+  }
+}
+```
+
+하지만 응답 뒤의 image decoding이나 큰 JSON decoding이 동기적으로 오래 걸리면 MainActor가 그 계산을 실행하는 동안 UI event를 처리하지 못해요. `async` 함수 안에 있다는 이유만으로 synchronous CPU 작업이 background로 이동하지 않아요.
+
+```swift
+struct Library: Codable, Sendable {}
+
+protocol LibraryClient: Sendable {
+  func fetchLibraryData() async throws -> Data
+}
+
+@concurrent
+func decodeLibrary(from data: Data) async throws -> Library {
+  try JSONDecoder().decode(Library.self, from: data)
+}
+
+@MainActor
+final class LibraryViewModel {
+  private let client: any LibraryClient
+  private(set) var library: Library?
+
+  init(client: any LibraryClient) {
+    self.client = client
+  }
+
+  func refreshLibrary() async throws {
+    let data = try await client.fetchLibraryData()
+    library = try await decodeLibrary(from: data)
+  }
+}
+```
+
+Swift 6.2 이상에서는 `@concurrent`로 caller actor를 떠나 concurrent executor에서 실행할 계산을 명시할 수 있어요. 입력과 결과는 isolation boundary를 안전하게 넘도록 `Sendable`이어야 해요.
+
+분리 기준은 다음과 같아요.
+
+- network·file async wait는 native async API가 thread를 block하지 않는지 확인해요.
+- image decoding, parsing, compression처럼 측정상 긴 synchronous 계산은 MainActor 밖으로 분리해요.
+- 계산 결과만 immutable `Sendable` value로 MainActor에 가져와 UI state에 적용해요.
+- 너무 작은 계산을 무조건 분리하면 executor hop과 scheduling overhead만 늘 수 있으므로 Instruments로 측정해요.
+
+## `nonisolated`로 UI와 무관한 member를 분리해요
+
+MainActor type의 모든 member가 UI state를 필요로 하는 것은 아닐 수 있어요.
+
+```swift
+@MainActor
+final class ReadingViewModel {
+  nonisolated let analyticsScreenName = "reading"
+  private(set) var state: ReadingViewState = .idle
+
+  nonisolated static func normalizedQuery(
+    _ query: String
+  ) -> String {
+    query.trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+  }
+}
+```
+
+`nonisolated` member는 MainActor state에 접근할 수 없고 어느 isolation에서도 동기적으로 호출할 수 있어요. 단지 performance를 위해 instance method에 붙인 뒤 mutable UI state를 우회하려고 하면 compiler가 막아요.
+
+큰 계산을 `nonisolated`로 바꾸는 것만으로 항상 concurrent thread pool에서 실행된다고 가정하지 마세요. Swift 6.2의 isolation behavior와 `@concurrent`를 구분하고 target build setting을 확인해요.
+
+## Swift 6.2 Default Actor Isolation은 선택 설정이에요
+
+Swift 6.2부터 target의 기본 actor isolation을 MainActor로 선택할 수 있어요. 이 mode에서는 annotation이 없는 많은 app 선언이 암시적으로 `@MainActor`가 돼요.
+
+Swift Package라면 target에 설정할 수 있어요.
+
+```swift
+.target(
+  name: "ReadingApp",
+  swiftSettings: [
+    .defaultIsolation(MainActor.self),
+  ]
+)
+```
+
+이 설정은 UI 중심 app target의 single-threaded 기본값을 단순하게 만들 수 있어요. 그러나 모든 Swift module이 자동으로 MainActor mode인 것은 아니에요.
+
+- 설정이 없으면 module 기본 isolation은 `nonisolated`예요.
+- dependency module의 default isolation은 현재 app target 설정으로 바뀌지 않아요.
+- actor type 내부처럼 별도의 isolation 규칙이 있는 선언에는 MainActor 기본값이 그대로 적용되지 않는 경우가 있어요.
+- library public API는 명시적인 annotation이 client에게 더 분명한 contract가 될 수 있어요.
+- CPU 작업을 concurrent하게 실행하려면 `@concurrent` 같은 명시적 선택이 필요할 수 있어요.
+
+문서와 code review에서는 project의 설정을 모른 채 annotation이 생략된 code의 isolation을 단정하지 말고 Xcode build setting이나 Package.swift를 함께 확인해요.
+
+## 테스트도 MainActor isolation 안에서 실행해요
+
+MainActor ViewModel의 state를 동기적으로 읽고 검증하려면 test function을 MainActor에 격리할 수 있어요.
+
+```swift
+import Testing
+
+private struct StubSummaryLoader: ReadingSummaryLoading {
+  let summary: ReadingSummary
+
+  func loadSummary() async throws -> ReadingSummary {
+    summary
+  }
+}
+
+@Test
+@MainActor
+func loadsSummaryIntoViewState() async {
+  let summary = ReadingSummary(completedMinutes: 30)
+  let viewModel = ReadingViewModel(
+    loader: StubSummaryLoader(summary: summary)
+  )
+
+  await viewModel.load()
+
+  #expect(viewModel.state == .loaded(summary))
+}
+```
+
+`@MainActor` test는 ViewModel initializer와 property를 같은 isolation에서 사용하게 해요. 테스트를 통과시키려고 모든 test suite를 MainActor에 두면 병렬 실행 기회를 줄이고 production isolation 설계 오류를 감출 수 있어요. 실제로 UI-facing API를 검증하는 test만 격리해요.
+
+Nonisolated caller가 actor hop을 제대로 요구하는지 확인하고 싶다면 test 자체는 nonisolated로 두고 async helper를 통해 `await`해도 돼요.
+
+```swift
+@Test
+func readsStateAcrossMainActorBoundary() async {
+  let state = await makeLoadedStateForTesting()
+  #expect(state == .loaded(.init(completedMinutes: 30)))
+}
+
+@MainActor
+private func makeLoadedStateForTesting() async -> ReadingViewState {
+  let summary = ReadingSummary(completedMinutes: 30)
+  let viewModel = ReadingViewModel(
+    loader: StubSummaryLoader(summary: summary)
+  )
+
+  await viewModel.load()
+  return viewModel.state
+}
+```
+
+UI thread를 확인하는 `Thread.isMainThread` assertion만 반복하기보다 compiler isolation, 최종 state, cancellation과 stale response 처리 결과를 검증해요.
+
+## MainActor를 선택할 범위를 정해요
+
+MainActor가 잘 맞는 경우예요.
+
+- UIKit·AppKit object를 읽거나 변경해요.
+- SwiftUI에 표시되는 mutable presentation state를 하나의 owner가 관리해요.
+- UI 관련 protocol이나 callback이 main actor에서 호출되어야 해요.
+- global·static UI state를 하나의 isolation domain으로 보호해야 해요.
+- 선언만 보고도 main execution 요구를 알 수 있어야 해요.
+
+다른 isolation이 더 알맞은 경우예요.
+
+- cache, database state처럼 UI와 무관한 shared mutable state는 일반 actor를 검토해요.
+- immutable `Sendable` value transformation은 MainActor에 둘 이유가 없어요.
+- CPU-intensive parsing, image processing과 compression은 concurrent function이나 별도 worker로 분리해요.
+- 짧은 synchronous critical section은 `Mutex`나 lock이 API 요구에 더 자연스러울 수 있어요.
+- queue 자체가 외부 system API의 contract인 DispatchSource handler는 GCD interop을 유지해요.
+
+MainActor는 “data race warning을 없애는 곳”이 아니에요. UI state ownership과 main thread 요구가 없는 domain model까지 올리면 모든 caller가 main actor로 몰리고 UI responsiveness가 나빠질 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. UIKit·AppKit 접근과 화면에 표시되는 mutable state의 owner를 찾아요.
+2. 같은 UI invariant를 이루는 state와 method는 type 전체 `@MainActor`를 먼저 검토해요.
+3. 외부 async dependency의 입력과 결과를 `Sendable` value로 설계해요.
+4. 반복되는 `DispatchQueue.main.async` 호출을 지우기 전에 target API에 MainActor contract를 선언해요.
+5. nonisolated async caller에서는 MainActor method를 `await`해 structured flow를 유지해요.
+6. 일부 구간 migration에만 `MainActor.run`을 사용하고 반복되면 type isolation으로 올려요.
+7. `Task { @MainActor in }`를 사용하면 handle, 오류, cancellation과 lifetime owner를 정해요.
+8. MainActor method의 synchronous CPU·blocking 구간을 Instruments로 찾고 sendable snapshot을 사용해 밖으로 분리해요.
+9. Xcode의 Default Actor Isolation과 Swift language mode를 확인하고 strict concurrency에서 compile해요.
+10. MainActor test와 nonisolated boundary test를 나눠 state transition, cancellation과 stale result를 검증해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### `@MainActor`는 항상 새 작업을 main queue에 dispatch하나요?
+
+아니요. 이미 MainActor에서 실행 중이면 같은 isolation의 synchronous member를 바로 호출할 수 있고 불필요한 hop을 피할 수 있어요. 다른 isolation의 async caller가 접근할 때는 main actor로 전환하며, 안전하지 않은 synchronous cross-actor 호출은 Swift 6 compiler가 막아요.
+
+### MainActor와 main thread는 같은 개념인가요?
+
+Main thread는 운영체제 thread이고 MainActor는 Swift의 global actor isolation이에요. Apple platform에서 MainActor executor는 main dispatch queue와 연결되어 job을 main thread에서 실행하지만, API 설계에서는 thread를 직접 추적하기보다 `@MainActor` isolation contract를 사용해요.
+
+### MainActor 함수에서 network 요청을 하면 UI가 멈추나요?
+
+Native async network API가 응답을 기다리는 동안 task를 suspend하므로 그 기다림 자체는 main thread를 막지 않아요. 하지만 응답 뒤 큰 JSON decoding이나 image processing을 synchronous하게 실행하면 MainActor를 점유하므로 무거운 계산은 밖으로 분리해야 해요.
+
+### `MainActor.run`과 `Task { @MainActor in }`은 무엇이 다른가요?
+
+`MainActor.run`은 현재 task가 main actor closure의 완료를 기다려 기존 control flow를 유지해요. `Task { @MainActor in }`은 별도 unstructured task를 만들기 때문에 독립 lifetime이 필요하고 handle의 결과·취소를 관리할 때 사용해요.
+
+### ViewModel에는 항상 `@MainActor`를 붙여야 하나요?
+
+아니요. ViewModel이 UI presentation state를 소유하고 framework와 상호작용한다면 좋은 기본 선택이지만, 순수 계산이나 UI와 무관한 repository state까지 main actor에 둘 필요는 없어요. type의 state owner와 실행 요구를 기준으로 결정해요.
+
+## 참고 자료
+
+- [The Swift Programming Language — Concurrency: Global Actors](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#Global-Actors)
+- [Apple Developer — MainActor](https://developer.apple.com/documentation/swift/mainactor)
+- [Apple Developer — MainActor.run](<https://developer.apple.com/documentation/swift/mainactor/run(resulttype:body:)>)
+- [Swift Evolution SE-0316 — Global Actors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0316-global-actors.md)
+- [Swift Evolution SE-0313 — Improved control over actor isolation](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md)
+- [Swift Evolution SE-0461 — Run nonisolated async functions on the caller's actor by default](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md)
+- [Swift Evolution SE-0466 — Control default actor isolation inference](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0466-control-default-actor-isolation.md)
+- [Swift.org — Swift 6.2 Released](https://www.swift.org/blog/swift-6.2-released/)
+- [WWDC21 — Protect mutable state with Swift actors](https://developer.apple.com/videos/play/wwdc2021/10133/)
+- [WWDC22 — Eliminate data races using Swift Concurrency](https://developer.apple.com/videos/play/wwdc2022/110351/)
+- [WWDC25 — Embracing Swift concurrency](https://developer.apple.com/videos/play/wwdc2025/268/)
+- [Swift 6 Concurrency Migration Guide — Incremental Adoption](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/incrementaladoption/)
+- [iOYES — Swift Concurrency: @MainActor 사용하기](https://green1229.tistory.com/343)

--- a/docs/guide/uikit/collection-views/differencekit.md
+++ b/docs/guide/uikit/collection-views/differencekit.md
@@ -1,6 +1,6 @@
 ---
 title: Swift로 이해하는 DifferenceKit
-description: DifferenceKit의 Differentiable과 StagedChangeset을 이해하고 CollectionDifference·difference(from:)의 기능과 시간 복잡도, UIKit 갱신 방식을 비교합니다.
+description: DifferenceKit의 Differentiable과 StagedChangeset을 이해하고, 적용 전후의 전체 UICollectionView 예제로 수동 갱신과 staged diff 흐름을 비교합니다.
 ---
 
 # Swift로 이해하는 DifferenceKit
@@ -17,6 +17,7 @@ description: DifferenceKit의 Differentiable과 StagedChangeset을 이해하고 
 - `Differentiable`, `ContentIdentifiable`, `ContentEquatable`의 관계
 - `Equatable`, `Hashable`, `Identifiable`과 다른 점
 - `StagedChangeset`을 `UICollectionView`에 적용하는 방법
+- DifferenceKit 적용 전후를 비교하는 전체 Collection View 예제
 - Swift `difference(from:)`, DifferenceKit diff의 시간 복잡도와 차이
 - `reloadData()`와 부분 batch update를 선택하는 기준
 - UIKit diffable data source와의 차이
@@ -298,6 +299,352 @@ collectionView.reload(
 ```
 
 `100`은 라이브러리가 정한 정답이 아니에요. 셀 복잡도, 기기 성능, layout 비용을 측정해 화면별 기준을 정해야 해요. Collection View가 window에 올라가 있지 않을 때도 extension은 마지막 데이터와 `reloadData()`를 사용하는 경로를 제공해요.
+
+## 전체 예제로 DifferenceKit 적용 전후를 비교해요
+
+앞에서는 diff를 계산하고 적용하는 핵심 코드만 분리해서 살펴봤어요. 이제 같은 사진 목록 화면을 DifferenceKit 없이 구현한 코드와 DifferenceKit을 사용한 코드로 비교해 볼게요.
+
+두 예제는 다음 변경을 한 번에 화면에 반영해요.
+
+| 이전 상태                 | 목표 상태                 | 필요한 화면 변경            |
+| ------------------------- | ------------------------- | --------------------------- |
+| 서울, 부산, 대전          | 대전, 부산★, 제주         | 삭제, 이동, 삽입, 내용 갱신 |
+| 서울은 `indexPath.item 0` | 서울은 목표 배열에 없음   | 삭제                        |
+| 대전은 `indexPath.item 2` | 대전은 `indexPath.item 0` | 이동                        |
+| 부산은 즐겨찾기 아님      | 부산은 즐겨찾기           | 내용 갱신                   |
+| 제주 없음                 | 제주는 `indexPath.item 2` | 삽입                        |
+
+화면 구성 코드가 diff의 차이를 가리지 않도록 두 예제 모두 iOS 14의 list layout과 cell registration을 사용해요. DifferenceKit의 diff 원리 자체가 이 API에 의존하는 것은 아니므로 기존 custom cell과 flow layout에서도 데이터 갱신 부분만 같은 방식으로 적용할 수 있어요.
+
+### DifferenceKit 없이 수동으로 부분 갱신해요
+
+먼저 외부 diff 라이브러리를 사용하지 않고 `performBatchUpdates`에 필요한 위치를 직접 전달해 볼게요. 아래 코드는 한 파일에 넣어 실행할 수 있는 전체 View Controller예요.
+
+```swift
+import UIKit
+
+private struct Photo: Equatable {
+  let id: UUID
+  let title: String
+  let isFavorite: Bool
+}
+
+private enum PhotoSamples {
+  static let seoulID = UUID()
+  static let busanID = UUID()
+  static let daejeonID = UUID()
+  static let jejuID = UUID()
+
+  static let before = [
+    Photo(
+      id: seoulID,
+      title: "서울",
+      isFavorite: false
+    ),
+    Photo(
+      id: busanID,
+      title: "부산",
+      isFavorite: false
+    ),
+    Photo(
+      id: daejeonID,
+      title: "대전",
+      isFavorite: false
+    ),
+  ]
+
+  static let after = [
+    Photo(
+      id: daejeonID,
+      title: "대전",
+      isFavorite: false
+    ),
+    Photo(
+      id: busanID,
+      title: "부산",
+      isFavorite: true
+    ),
+    Photo(
+      id: jejuID,
+      title: "제주",
+      isFavorite: false
+    ),
+  ]
+}
+
+@MainActor
+final class ManualPhotoGridViewController:
+  UICollectionViewController
+{
+  private var photos = PhotoSamples.before
+
+  private lazy var cellRegistration =
+    UICollectionView.CellRegistration<
+      UICollectionViewListCell,
+      Photo
+    > { cell, _, photo in
+      var content = cell.defaultContentConfiguration()
+      content.text = photo.isFavorite
+        ? "★ \(photo.title)"
+        : photo.title
+      cell.contentConfiguration = content
+    }
+
+  init() {
+    let configuration = UICollectionLayoutListConfiguration(
+      appearance: .insetGrouped
+    )
+    let layout = UICollectionViewCompositionalLayout.list(
+      using: configuration
+    )
+    super.init(collectionViewLayout: layout)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 지원하지 않아요.")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    title = "수동 부분 갱신"
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "변경",
+      style: .plain,
+      target: self,
+      action: #selector(applySampleUpdate(_:))
+    )
+  }
+
+  override func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  override func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    collectionView.dequeueConfiguredReusableCell(
+      using: cellRegistration,
+      for: indexPath,
+      item: photos[indexPath.item]
+    )
+  }
+
+  @objc
+  private func applySampleUpdate(
+    _ sender: UIBarButtonItem
+  ) {
+    // 이 IndexPath들은 before에서 after로 바뀌는 경우에만 맞아요.
+    let deleted = [IndexPath(item: 0, section: 0)]
+    let inserted = [IndexPath(item: 2, section: 0)]
+    let movedFrom = IndexPath(item: 2, section: 0)
+    let movedTo = IndexPath(item: 0, section: 0)
+    let updated = [IndexPath(item: 1, section: 0)]
+
+    sender.isEnabled = false
+
+    collectionView.performBatchUpdates {
+      // Collection View가 새 개수를 물을 때 목표 데이터를 반환해요.
+      self.photos = PhotoSamples.after
+      self.collectionView.deleteItems(at: deleted)
+      self.collectionView.insertItems(at: inserted)
+      self.collectionView.moveItem(at: movedFrom, to: movedTo)
+    } completion: { [weak self] finished in
+      guard let self else { return }
+
+      // 이동과 내용 갱신을 직접 다른 단계로 나눠요.
+      if finished {
+        self.collectionView.reloadItems(at: updated)
+      } else {
+        self.collectionView.reloadData()
+      }
+    }
+  }
+}
+```
+
+이 코드에서 개발자가 직접 책임지는 부분을 순서대로 짚어 볼게요.
+
+1. 삭제와 이동의 출발지는 이전 배열의 위치로 계산해요.
+2. 삽입과 이동의 도착지는 목표 배열의 위치로 계산해요.
+3. batch update 중 data source가 목표 item 개수를 반환하도록 `photos`를 동기적으로 바꿔요.
+4. 이동과 내용 갱신을 한 번에 적용하면서 생길 수 있는 충돌을 피하려고 부산 셀의 reload를 다음 단계로 나눠요.
+5. 이 예제의 `IndexPath`는 정확히 `before → after` 변경에만 맞으므로 다른 배열을 받으려면 위치 계산과 안전한 단계 분리 로직을 새로 만들어야 해요.
+
+전체 재로딩으로 바꾸면 `photos = newPhotos`와 `reloadData()`만으로 단순해져요. 대신 삭제, 삽입, 이동의 의미와 각각의 애니메이션을 잃고 현재 보이는 셀을 다시 구성할 수 있어요. 부분 갱신을 유지하려면 위와 같은 bookkeeping을 직접 감당해야 해요. 여기서 bookkeeping은 이전 위치, 목표 위치, 적용 순서처럼 화면과 모델을 맞추는 기록 작업을 뜻해요.
+
+### DifferenceKit으로 같은 화면을 갱신해요
+
+이제 같은 화면에서 수동 `IndexPath` 계산을 `StagedChangeset`으로 교체해요. 앞 예제와 별개로 복사해 실행할 수 있도록 모델과 화면 코드를 모두 포함했어요.
+
+```swift
+import DifferenceKit
+import UIKit
+
+private struct Photo: Differentiable {
+  let id: UUID
+  let title: String
+  let isFavorite: Bool
+
+  var differenceIdentifier: UUID { id }
+
+  func isContentEqual(to source: Photo) -> Bool {
+    title == source.title
+      && isFavorite == source.isFavorite
+  }
+}
+
+private enum PhotoSamples {
+  static let seoulID = UUID()
+  static let busanID = UUID()
+  static let daejeonID = UUID()
+  static let jejuID = UUID()
+
+  static let before = [
+    Photo(
+      id: seoulID,
+      title: "서울",
+      isFavorite: false
+    ),
+    Photo(
+      id: busanID,
+      title: "부산",
+      isFavorite: false
+    ),
+    Photo(
+      id: daejeonID,
+      title: "대전",
+      isFavorite: false
+    ),
+  ]
+
+  static let after = [
+    Photo(
+      id: daejeonID,
+      title: "대전",
+      isFavorite: false
+    ),
+    Photo(
+      id: busanID,
+      title: "부산",
+      isFavorite: true
+    ),
+    Photo(
+      id: jejuID,
+      title: "제주",
+      isFavorite: false
+    ),
+  ]
+}
+
+@MainActor
+final class DifferenceKitPhotoGridViewController:
+  UICollectionViewController
+{
+  private var photos = PhotoSamples.before
+
+  private lazy var cellRegistration =
+    UICollectionView.CellRegistration<
+      UICollectionViewListCell,
+      Photo
+    > { cell, _, photo in
+      var content = cell.defaultContentConfiguration()
+      content.text = photo.isFavorite
+        ? "★ \(photo.title)"
+        : photo.title
+      cell.contentConfiguration = content
+    }
+
+  init() {
+    let configuration = UICollectionLayoutListConfiguration(
+      appearance: .insetGrouped
+    )
+    let layout = UICollectionViewCompositionalLayout.list(
+      using: configuration
+    )
+    super.init(collectionViewLayout: layout)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:)는 지원하지 않아요.")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    title = "DifferenceKit 갱신"
+    navigationItem.rightBarButtonItem = UIBarButtonItem(
+      title: "변경",
+      style: .plain,
+      target: self,
+      action: #selector(applySampleUpdate(_:))
+    )
+  }
+
+  override func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    photos.count
+  }
+
+  override func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    collectionView.dequeueConfiguredReusableCell(
+      using: cellRegistration,
+      for: indexPath,
+      item: photos[indexPath.item]
+    )
+  }
+
+  @objc
+  private func applySampleUpdate(
+    _ sender: UIBarButtonItem
+  ) {
+    sender.isEnabled = false
+    apply(PhotoSamples.after)
+  }
+
+  private func apply(_ newPhotos: [Photo]) {
+    let changeset = StagedChangeset(
+      source: photos,
+      target: newPhotos
+    )
+
+    collectionView.reload(
+      using: changeset,
+      interrupt: { $0.changeCount > 100 }
+    ) { [weak self] stagePhotos in
+      // 각 stage의 performBatchUpdates 안에서 동기적으로 호출돼요.
+      self?.photos = stagePhotos
+    }
+  }
+}
+```
+
+셀과 화면 구성은 수동 예제와 같아요. 달라진 핵심은 다음 두 곳이에요.
+
+- `Photo`가 안정적인 `id`를 `differenceIdentifier`로 제공하고, 화면 내용인 `title`과 `isFavorite`을 `isContentEqual`에서 비교해요.
+- `apply(_:)`는 고정된 `IndexPath` 대신 현재 `photos`와 임의의 `newPhotos`로 `StagedChangeset`을 만들어요. DifferenceKit이 삭제, 삽입, 이동, 갱신 위치를 계산하고 안전한 stage로 나눠 적용해요.
+
+`setData`에서 받는 값의 이름을 `stagePhotos`로 지은 이유도 중요해요. 이 값은 항상 최종 `newPhotos`인 것이 아니라 현재 batch update가 끝났을 때 data source가 가져야 할 중간 배열일 수 있어요. 따라서 `self?.photos = newPhotos`로 바꾸지 말고 전달받은 값을 그대로 저장해야 해요.
+
+두 구현의 책임을 비교하면 DifferenceKit이 줄이는 코드의 범위가 선명해져요.
+
+| 확인할 점          | 수동 부분 갱신                         | DifferenceKit 사용                          |
+| ------------------ | -------------------------------------- | ------------------------------------------- |
+| 변경 위치 계산     | 이전·목표 `IndexPath`를 직접 계산해요. | 두 컬렉션에서 changeset을 계산해요.         |
+| 내용 변경 판별     | 갱신할 item을 직접 찾아요.             | `isContentEqual` 결과로 판별해요.           |
+| 위험한 변경 조합   | 개발자가 적용 단계를 나눠요.           | `StagedChangeset`이 최소 stage로 나눠요.    |
+| data source 동기화 | 각 단계의 올바른 배열을 직접 만들어요. | `setData`가 각 stage의 배열을 전달해요.     |
+| 다른 목표 배열     | diff와 단계 구성 로직을 다시 계산해요. | 같은 `apply(_:)`에 새 배열을 전달하면 돼요. |
+| 추가 비용          | 라이브러리는 없지만 구현 부담이 커요.  | 외부 의존성과 모델 conformance가 생겨요.    |
 
 ## section과 item의 diff를 함께 계산해요
 
@@ -710,6 +1057,7 @@ Swift `difference(from:)`의 공개된 최악 시간 복잡도는 `O(N × M)`이
 - [DifferenceKit — Differentiable.swift](https://github.com/ra1028/DifferenceKit/blob/1.3.0/Sources/Differentiable.swift)
 - [DifferenceKit — StagedChangeset](https://ra1028.github.io/DifferenceKit/Structs/StagedChangeset.html)
 - [DifferenceKit — UICollectionView extension](https://ra1028.github.io/DifferenceKit/Extensions/UICollectionView.html)
+- [DifferenceKit — UIKitExtension.swift](https://github.com/ra1028/DifferenceKit/blob/1.3.0/Sources/Extensions/UIKitExtension.swift)
 - [Apple Developer — CollectionDifference](https://developer.apple.com/documentation/swift/collectiondifference)
 - [Apple Developer — difference(from:)](https://developer.apple.com/documentation/swift/array/difference%28from%3A%29)
 - [Apple Developer — inferringMoves()](https://developer.apple.com/documentation/swift/collectiondifference/inferringmoves%28%29)


### PR DESCRIPTION
## Summary

Swift 하위에 `Swift Concurrency` 섹션을 추가하고 GCD와 Swift Concurrency의 실행 모델, Actor의 instance isolation, MainActor의 UI isolation을 입문자가 순서대로 이해할 수 있도록 세 개의 학습 문서로 정리합니다.

## Changes

- `GCD와 Swift Concurrency` 문서에서 queue·thread와 task·job·executor를 구분하고 `async`/`await`, `async let`, task group, structured·unstructured task, 협력적 cancellation과 priority를 비교했습니다.
- completion handler를 checked continuation으로 연결하는 예제와 serial queue·DispatchGroup·main queue 코드를 Swift Concurrency로 점진적으로 전환하는 기준을 추가했습니다.
- `Actor와 데이터 격리` 문서에서 actor instance isolation, cross-actor `await`, `Sendable`, serial queue와의 차이, FIFO가 아닌 scheduling 규칙을 설명했습니다.
- Actor reentrancy로 `await` 전의 invariant가 깨지는 예제와 state 선반영·rollback, revision 재검증, `nonisolated`, `isolated` parameter, protocol conformance와 결정적 테스트 방법을 추가했습니다.
- `MainActor와 UI 격리` 문서에서 global actor, main executor, type·member·closure annotation, `MainActor.run`, `Task { @MainActor in }`, `DispatchQueue.main.async`의 차이를 설명했습니다.
- MainActor에서 native async I/O를 기다리는 경우와 CPU 작업으로 UI를 막는 경우를 구분하고 Swift 6.2 이상의 Default Actor Isolation과 `@concurrent` 적용 기준을 정리했습니다.
- Swift 언어 가이드, Swift Evolution, Apple Developer와 WWDC 공식 자료를 우선하고 제공된 Actor·MainActor 참고 글의 실전 전환 흐름을 보완 자료로 반영했습니다.
- `docs/guide/swift/_meta.json`과 하위 `_meta.json`에 세 문서를 `Swift Concurrency` 사이드바 섹션으로 연결했습니다.

## Testing

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run build`
- [x] GCD·structured task·continuation 예제를 Apple Swift 6.3 complete strict concurrency와 warnings-as-errors 조건으로 타입 검사했습니다.
- [x] Actor·reentrancy·`nonisolated`·`isolated` parameter·protocol conformance 예제를 Apple Swift 6.3 complete strict concurrency와 warnings-as-errors 조건으로 타입 검사했습니다.
- [x] MainActor·UIKit·`MainActor.run`·`@concurrent` 예제를 iOS 17 simulator SDK, Apple Swift 6.3 complete strict concurrency와 warnings-as-errors 조건으로 타입 검사했습니다.
- [x] 개발 서버에서 새 문서 3개 경로의 HTTP 200 응답을 확인했습니다.
- [x] 모든 새 문서의 한국어 `description`이 50~160자 범위인지 확인했습니다.
- [x] `git diff --check`

## Related Issues

Closes #37

## Notes

- Actor와 MainActor는 격리 대상, 호출 규칙과 UI 적용 범위가 충분히 달라 각각 독립 문서로 구성했습니다.
- Swift 6.2 이후 isolation 동작은 target build setting의 영향을 받으므로 명시적 annotation과 Default Actor Isolation을 구분해 설명했습니다.
