### PR TITLE
[#41] Naver Maps iOS SDK 학습 문서 섹션을 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -36,6 +36,12 @@
     "position": "left"
   },
   {
+    "text": "Naver Maps SDK",
+    "link": "/guide/naver-maps-sdk/index",
+    "activeMatch": "/guide/naver-maps-sdk/",
+    "position": "left"
+  },
+  {
     "text": "Combine",
     "link": "/guide/combine/index",
     "activeMatch": "/guide/combine/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -31,6 +31,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "naver-maps-sdk",
+    "label": "Naver Maps SDK"
+  },
+  {
+    "type": "dir-section-header",
     "name": "combine",
     "label": "Combine"
   },

--- a/docs/guide/naver-maps-sdk/_meta.json
+++ b/docs/guide/naver-maps-sdk/_meta.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "custom-link",
+    "text": "Naver Maps SDK 시작하기",
+    "link": "/guide/naver-maps-sdk/index"
+  },
+  {
+    "type": "custom-link",
+    "text": "설치와 화면 표시",
+    "link": "/guide/naver-maps-sdk/setup-and-authentication",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "text": "설치와 인증",
+        "link": "/guide/naver-maps-sdk/setup-and-authentication"
+      },
+      {
+        "type": "custom-link",
+        "text": "SwiftUI 연동",
+        "link": "/guide/naver-maps-sdk/swiftui-integration"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "text": "지도와 데이터 표현",
+    "link": "/guide/naver-maps-sdk/map-camera-interaction",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "text": "좌표, 카메라, 상호작용",
+        "link": "/guide/naver-maps-sdk/map-camera-interaction"
+      },
+      {
+        "type": "custom-link",
+        "text": "오버레이와 클러스터링",
+        "link": "/guide/naver-maps-sdk/overlays-and-clustering"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "text": "사용자 위치와 권한",
+    "link": "/guide/naver-maps-sdk/user-location"
+  }
+]

--- a/docs/guide/naver-maps-sdk/index.md
+++ b/docs/guide/naver-maps-sdk/index.md
@@ -1,0 +1,129 @@
+---
+title: Swift로 이해하는 Naver Maps iOS SDK
+description: Naver Maps iOS SDK가 담당하는 동적 지도 렌더링과 별도 REST API의 역할을 구분하고, 설치부터 위치 표시까지의 학습 순서를 정리합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Naver Maps iOS SDK
+
+> 면접용 한 줄 요약: **Naver Maps iOS SDK는 앱 안에서 벡터 지도를 그리고 카메라·제스처·오버레이를 다루는 도구이며, 주소 검색이나 경로 탐색은 별도의 Maps REST API가 담당합니다.**
+
+## 먼저 역할부터 구분해요
+
+지도 화면을 만든다고 해서 하나의 SDK가 모든 지도 기능을 제공하는 것은 아니에요. NAVER Cloud Platform Maps는 사용 목적에 따라 기능을 나눠 제공합니다.
+
+```text
+SwiftUI / UIKit 화면
+        │
+        ▼
+NMFNaverMapView 또는 NMFMapView
+        │
+        ▼
+NMapsMap + NMapsGeometry
+        │
+        ▼
+Mobile Dynamic Map
+
+앱 ── HTTPS ── 우리 서버 ── Directions / Geocoding REST API
+```
+
+[Maps 개요](https://guide.ncloud-docs.com/docs/maps-overview)에 따르면 Mobile Dynamic Map은 지도 유형, 카메라, UI, 오버레이 같은 화면 기능을 제공합니다. 반면 Directions, Geocoding, Reverse Geocoding은 별도의 REST API예요. 따라서 지도 SDK만 설치했다고 `주소 → 좌표` 변환이나 자동차 경로 탐색까지 생기는 것은 아닙니다.
+
+| 만들 기능                     | 선택할 제품                | 호출 위치                             |
+| ----------------------------- | -------------------------- | ------------------------------------- |
+| 손가락으로 움직이는 벡터 지도 | Mobile Dynamic Map iOS SDK | iOS 앱                                |
+| 고정된 지도 이미지            | Static Map                 | 서버 또는 요구 사항에 맞는 클라이언트 |
+| 주소를 위도·경도로 변환       | Geocoding                  | 보통 우리 서버                        |
+| 위도·경도를 주소로 변환       | Reverse Geocoding          | 보통 우리 서버                        |
+| 자동차·도보 경로 계산         | Directions 계열            | 보통 우리 서버                        |
+
+:::warning REST API 비밀 키는 앱에 넣지 않아요
+모바일 지도용 `NMFNcpKeyId`는 등록한 Bundle ID로 사용 범위를 제한하지만, REST API의 Client Secret은 앱 번들에 포함하면 안 돼요. 앱은 우리 서버에 요청하고, 서버가 Secret을 보관한 채 NAVER Cloud API를 호출하도록 경계를 나누는 편이 안전합니다.
+:::
+
+## 이 문서를 읽기 전에 알아둘 용어
+
+| 용어       | 의미                                                                           |
+| ---------- | ------------------------------------------------------------------------------ |
+| 좌표       | 지구 위 위치를 나타내는 값이에요. SDK에서는 주로 `NMGLatLng`을 사용합니다.     |
+| 카메라     | 지도에서 현재 보이는 중심, 확대 수준, 기울기, 회전 상태를 묶은 개념이에요.     |
+| 오버레이   | 지도 위에 올리는 마커, 선, 원, 다각형, 정보 창 같은 객체예요.                  |
+| 프로젝션   | 지도 좌표와 화면의 점 좌표를 서로 변환하는 규칙이에요.                         |
+| 클러스터링 | 가까이 모인 여러 마커를 확대 수준에 따라 하나의 그룹 마커로 합치는 기법이에요. |
+| NCP Key ID | NAVER Cloud Platform 애플리케이션을 식별하는 모바일 지도용 값이에요.           |
+
+## 어떤 지도 뷰를 선택할까요?
+
+SDK는 두 가지 대표 진입점을 제공합니다.
+
+| 타입              | 포함하는 것                                 | 적합한 상황                                   |
+| ----------------- | ------------------------------------------- | --------------------------------------------- |
+| `NMFMapView`      | 지도 자체                                   | 모든 컨트롤을 앱 디자인에 맞게 직접 배치할 때 |
+| `NMFNaverMapView` | `mapView`와 나침반·축척·줌·현재 위치 컨트롤 | 기본 컨트롤을 빠르게 조합할 때                |
+
+`NMFNaverMapView`를 사용해도 실제 카메라와 오버레이 작업은 내부의 `mapView`에서 합니다.
+
+```swift
+import NMapsMap
+
+let naverMapView = NMFNaverMapView(frame: .zero)
+let mapView = naverMapView.mapView
+
+naverMapView.showZoomControls = true
+naverMapView.showCompass = true
+
+let seoulCityHall = NMGLatLng(lat: 37.5666102, lng: 126.9783881)
+mapView.moveCamera(NMFCameraUpdate(scrollTo: seoulCityHall))
+```
+
+## 여섯 페이지로 나눈 이유
+
+설치, 화면 수명 주기, 카메라 상태, 대량 오버레이, 위치 권한은 실패 원인과 테스트 방법이 서로 달라요. 한 페이지에 모두 넣으면 예제를 복사하기는 쉬워도 책임의 경계를 놓치기 쉽기 때문에 다음 순서로 나눴습니다.
+
+1. [설치와 인증](/guide/naver-maps-sdk/setup-and-authentication)에서 NCP 등록, SPM/CocoaPods, 오류 코드를 확인해요.
+2. [좌표, 카메라, 상호작용](/guide/naver-maps-sdk/map-camera-interaction)에서 지도 이동과 탭 이벤트를 배워요.
+3. [SwiftUI 연동](/guide/naver-maps-sdk/swiftui-integration)에서 `UIViewRepresentable`과 Coordinator의 역할을 나눠요.
+4. [오버레이와 클러스터링](/guide/naver-maps-sdk/overlays-and-clustering)에서 마커 수명 주기와 대량 데이터를 다뤄요.
+5. [사용자 위치와 권한](/guide/naver-maps-sdk/user-location)에서 Core Location 권한과 위치 표시 모드를 연결해요.
+
+## 버전 문서는 서로 다를 수 있어요
+
+공식 시작 가이드의 오래된 배포 조건과 현재 배포 패키지의 조건이 다를 수 있습니다. 예를 들어 2026년 8월에 확인한 [SPM-NMapsMap의 3.23.3 `Package.swift`](https://github.com/navermaps/SPM-NMapsMap/blob/3.23.3/Package.swift)는 iOS 12 이상을 선언해요. 실제 프로젝트에서는 블로그나 가이드의 숫자보다 **선택한 패키지 태그의 `Package.swift`와 릴리스 노트**를 기준으로 Deployment Target을 정하세요.
+
+업데이트 전에는 [iOS SDK 변경 내역](https://github.com/navermaps/ios-map-sdk/blob/master/CHANGELOG.md)에서 인증 키 이름, 지원 환경, 동작 변경을 확인하는 습관이 중요합니다.
+
+## 언제 유용한가요?
+
+- 장소 검색 결과를 지도와 목록으로 함께 보여줄 때
+- 배달, 모빌리티, 부동산처럼 카메라 영역에 따라 데이터를 다시 조회할 때
+- 여러 지점을 마커·경로·영역으로 시각화할 때
+- 사용자의 현재 위치를 기준으로 주변 정보를 보여줄 때
+
+반대로 주소 한 줄을 좌표로 바꾸거나 경로만 계산하는 서버 작업에는 iOS SDK가 아니라 해당 REST API가 맞습니다.
+
+## 시작 전 체크리스트
+
+- [ ] 화면 표시와 검색·경로 계산의 제품 경계를 구분했나요?
+- [ ] NCP 애플리케이션에 Dynamic Map과 실제 Bundle ID를 등록했나요?
+- [ ] 선택한 SDK 버전의 최소 iOS 버전을 확인했나요?
+- [ ] REST API Client Secret을 iOS 앱에 넣지 않았나요?
+- [ ] 지도 뷰, 오버레이, 위치 추적의 수명 주기를 각각 설계했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Naver Maps SDK가 Geocoding도 직접 제공하나요?
+
+아니요. iOS SDK는 동적 지도 렌더링과 상호작용을 담당하고, Geocoding은 별도 REST API입니다. 비밀 키가 필요한 REST 호출은 보통 서버를 경유하게 설계합니다.
+
+### `NMFMapView`와 `NMFNaverMapView`의 차이는 무엇인가요?
+
+`NMFMapView`는 지도 자체이고, `NMFNaverMapView`는 그 지도와 기본 UI 컨트롤을 함께 제공하는 컨테이너입니다. 커스텀 UI가 중요하면 전자를, 빠른 기본 구성이 중요하면 후자를 선택할 수 있어요.
+
+## 참고 자료
+
+- [NAVER Maps iOS SDK 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/)
+- [NAVER Maps iOS SDK API Reference](https://navermaps.github.io/ios-map-sdk/reference/)
+- [NAVER Cloud Platform Maps 개요](https://guide.ncloud-docs.com/docs/maps-overview)
+- [NAVER Maps iOS SDK 데모 저장소](https://github.com/navermaps/ios-map-sdk)
+- [SPM-NMapsMap 공식 패키지](https://github.com/navermaps/SPM-NMapsMap)

--- a/docs/guide/naver-maps-sdk/map-camera-interaction.md
+++ b/docs/guide/naver-maps-sdk/map-camera-interaction.md
@@ -1,0 +1,240 @@
+---
+title: Naver Maps 좌표, 카메라, 상호작용
+description: NMGLatLng 좌표와 지도 카메라의 중심·줌·기울기·회전을 이해하고, 카메라 이동·화면 투영·탭 이벤트를 UIKit 전체 예제로 연결합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Naver Maps 좌표, 카메라, 상호작용
+
+> 면접용 한 줄 요약: **지도 상태는 중심 좌표만이 아니라 줌·기울기·헤딩을 포함한 카메라로 표현하며, 화면 좌표 변환과 사용자 탭은 `projection`과 전용 델리게이트로 처리합니다.**
+
+## 먼저 좌표계를 구분해요
+
+| 타입              | 나타내는 것                             | 예시                    |
+| ----------------- | --------------------------------------- | ----------------------- |
+| `NMGLatLng`       | 위도와 경도로 표현한 한 지점            | 서울시청 위치           |
+| `NMGLatLngBounds` | 남서·북동 좌표로 만든 영역              | 검색 결과 전체 범위     |
+| `CGPoint`         | 지도 뷰 왼쪽 위를 원점으로 한 화면 좌표 | 말풍선이나 버튼 위치    |
+| `NMFProjection`   | 지도 좌표와 화면 좌표 사이의 변환기     | 좌표 위에 UIKit 뷰 배치 |
+
+```swift
+let cityHall = NMGLatLng(lat: 37.5666102, lng: 126.9783881)
+let gyeongbokgung = NMGLatLng(lat: 37.579617, lng: 126.977041)
+
+let bounds = NMGLatLngBounds(
+  southWest: NMGLatLng(lat: 37.55, lng: 126.96),
+  northEast: NMGLatLng(lat: 37.59, lng: 126.99)
+)
+```
+
+좌표의 숫자는 `위도, 경도` 순서예요. API 응답 모델을 만들 때 `x`, `y` 또는 `longitude`, `latitude`의 순서를 확인하지 않고 그대로 전달하면 전혀 다른 위치가 표시될 수 있습니다.
+
+## 카메라는 네 값을 가져요
+
+`NMFCameraPosition`은 다음 값을 묶은 읽기 전용 객체입니다.
+
+| 값        | 의미                               | 주의할 점                         |
+| --------- | ---------------------------------- | --------------------------------- |
+| `target`  | 카메라가 바라보는 지도 좌표        | 화면 중심과 항상 같지는 않아요.   |
+| `zoom`    | 확대 수준                          | 클수록 더 가까이 봅니다.          |
+| `tilt`    | 지면을 비스듬히 보는 각도          | 기울기 제스처로도 바뀔 수 있어요. |
+| `heading` | 정북에서 시계 방향으로 회전한 각도 | 동쪽은 90도예요.                  |
+
+```swift
+let position = NMFCameraPosition(
+  NMGLatLng(lat: 37.5666102, lng: 126.9783881),
+  zoom: 15,
+  tilt: 0,
+  heading: 0
+)
+
+mapView.moveCamera(NMFCameraUpdate(position: position))
+```
+
+## UIKit에서 하나의 흐름으로 연결해요
+
+다음 예제는 지도 생성, 제약 조건, 카메라 이동, 탭 좌표, 카메라 완료 이벤트를 한 화면에 연결합니다.
+
+```swift
+import NMapsMap
+import UIKit
+
+final class PlaceMapViewController: UIViewController {
+  private let naverMapView = NMFNaverMapView(frame: .zero)
+
+  private var mapView: NMFMapView {
+    naverMapView.mapView
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    configureLayout()
+    configureMap()
+    moveToCityHall()
+  }
+
+  deinit {
+    mapView.removeCameraDelegate(delegate: self)
+  }
+
+  private func configureLayout() {
+    naverMapView.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(naverMapView)
+
+    NSLayoutConstraint.activate([
+      naverMapView.topAnchor.constraint(equalTo: view.topAnchor),
+      naverMapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      naverMapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      naverMapView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    ])
+  }
+
+  private func configureMap() {
+    naverMapView.showCompass = true
+    naverMapView.showScaleBar = true
+    naverMapView.showZoomControls = false
+
+    mapView.touchDelegate = self
+    mapView.addCameraDelegate(delegate: self)
+    mapView.minZoomLevel = 8
+    mapView.maxZoomLevel = 19
+  }
+
+  private func moveToCityHall() {
+    let target = NMGLatLng(lat: 37.5666102, lng: 126.9783881)
+    let update = NMFCameraUpdate(scrollTo: target)
+    update.animation = .easeIn
+    update.animationDuration = 0.5
+    mapView.moveCamera(update)
+  }
+}
+
+extension PlaceMapViewController: NMFMapViewTouchDelegate {
+  func mapView(
+    _ mapView: NMFMapView,
+    didTapMap latlng: NMGLatLng,
+    point: CGPoint
+  ) {
+    print("지도 좌표: \(latlng.lat), \(latlng.lng)")
+    print("화면 좌표: \(point.x), \(point.y)")
+  }
+}
+
+extension PlaceMapViewController: NMFMapViewCameraDelegate {
+  func mapViewCameraIdle(_ mapView: NMFMapView) {
+    let camera = mapView.cameraPosition
+    print("조회할 중심: \(camera.target.lat), \(camera.target.lng)")
+  }
+}
+```
+
+`NMFMapView`의 예전 통합 `delegate`는 사용이 권장되지 않아요. [API Reference](https://navermaps.github.io/ios-map-sdk/reference/Classes/NMFMapView.html)는 탭에는 `touchDelegate`, 카메라에는 `addCameraDelegate`/`removeCameraDelegate`를 사용하라고 안내합니다. 역할별로 등록하면 콜백의 책임과 해제 시점도 명확해져요.
+
+## 카메라 이동 방법을 선택해요
+
+| 요구 사항                    | 시작점                          | 설명                                   |
+| ---------------------------- | ------------------------------- | -------------------------------------- |
+| 특정 위치로 이동             | `NMFCameraUpdate(scrollTo:)`    | 중심 좌표만 바꿔요.                    |
+| 줌만 변경                    | `NMFCameraUpdate(zoomTo:)`      | 현재 중심을 유지해요.                  |
+| 중심·줌·기울기·회전 지정     | `NMFCameraUpdate(position:)`    | 전체 카메라 상태를 한 번에 정해요.     |
+| 여러 장소가 모두 보이게 이동 | 영역을 사용하는 카메라 업데이트 | 마커 범위와 화면 여백을 함께 고려해요. |
+| 복합 변화                    | `NMFCameraUpdateParams`         | scroll, zoom, tilt, rotate를 조합해요. |
+
+카메라 애니메이션 중 새 이동이 시작되면 이전 작업이 취소될 수 있습니다. 후속 작업이 꼭 필요하면 완료 클로저의 `isCancelled`를 확인하세요.
+
+```swift
+let update = NMFCameraUpdate(scrollTo: cityHall)
+update.animation = .fly
+update.animationDuration = 1
+
+mapView.moveCamera(update) { isCancelled in
+  guard !isCancelled else { return }
+  print("카메라 이동 완료")
+}
+```
+
+검색 API를 카메라 이동 중 매 프레임 호출하지 마세요. `cameraIsChangingByReason`은 매우 자주 호출될 수 있으므로 화면 표시용 값에 적합하고, 네트워크 재조회는 `mapViewCameraIdle` 이후 디바운스하는 편이 안정적입니다.
+
+## 아래 패널이 지도를 가리면 `contentInset`을 써요
+
+바텀 시트가 지도 아래 240pt를 덮으면 뷰의 물리적 중앙과 사용자가 실제로 보는 영역의 중앙이 달라집니다.
+
+```swift
+func updateMapInsets(bottomSheetHeight: CGFloat) {
+  mapView.contentInset = UIEdgeInsets(
+    top: 0,
+    left: 0,
+    bottom: bottomSheetHeight,
+    right: 0
+  )
+}
+```
+
+공식 [카메라와 투영 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/3-1.html)는 `contentInset`을 제외한 영역의 중심에 카메라가 위치한다고 설명합니다. 오토레이아웃으로 지도 프레임만 억지로 줄이는 것과 목적이 달라요.
+
+## 화면 좌표와 지도 좌표를 변환해요
+
+```swift
+let mapCoordinate = mapView.projection.latlng(
+  from: CGPoint(x: 120, y: 240)
+)
+
+let screenPoint = mapView.projection.point(
+  from: NMGLatLng(lat: 37.5666102, lng: 126.9783881)
+)
+
+let metersPerPoint = mapView.projection.metersPerPixel()
+```
+
+- `latlng(from:)`은 사용자가 누른 화면 지점을 지도 좌표로 바꿀 때 유용해요.
+- `point(from:)`은 UIKit 말풍선을 특정 지도 좌표 위에 배치할 때 유용해요.
+- 축척은 위도와 줌 레벨에 따라 달라지므로 고정된 `pt → m` 비율을 가정하면 안 돼요.
+
+## 이벤트 전파를 이해해요
+
+지도 심벌과 오버레이의 탭 핸들러는 `Bool`을 반환합니다.
+
+```swift
+func mapView(_ mapView: NMFMapView, didTap symbol: NMFSymbol) -> Bool {
+  guard symbol.caption == "서울특별시청" else {
+    return false // 지도 탭 이벤트로 전파
+  }
+
+  print("서울시청 심벌 탭")
+  return true // 이벤트 소비
+}
+```
+
+`true`는 해당 객체가 이벤트를 소비한다는 뜻이고, `false`는 지도 탭으로 전달한다는 뜻이에요. 선택 해제 로직을 지도 탭에 두었다면 오버레이가 `true`를 반환할 때 선택이 유지된다는 점까지 의도해야 합니다.
+
+## NAVER 로고를 가리지 않아요
+
+[사용자 인터페이스 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/4-1.html)에 따르면 NAVER 로고는 비활성화할 수 없고 앱 UI에 가려져서도 안 됩니다. `logoAlign`과 `logoMargin`으로 위치를 조정하세요. `logoInteractionEnabled`를 끈다면 앱 안에서 `showLegalNotice`와 `showOpenSourceLicense`를 열 수 있는 메뉴를 별도로 제공해야 합니다.
+
+## 체크리스트
+
+- [ ] 위도와 경도의 입력 순서를 확인했나요?
+- [ ] 중심뿐 아니라 줌·기울기·헤딩까지 화면 상태로 정의했나요?
+- [ ] 네트워크 재조회는 카메라가 멈춘 뒤 실행하나요?
+- [ ] 델리게이트를 등록한 수명 주기에서 해제하나요?
+- [ ] 바텀 시트 높이를 `contentInset`에 반영했나요?
+- [ ] NAVER 로고와 법적 고지를 가리지 않았나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### 카메라 이동 콜백마다 서버를 호출하면 왜 문제가 되나요?
+
+사용자의 한 번의 드래그에도 이동 중 콜백이 여러 번 발생해 요청 폭주, 순서 역전, 화면 깜빡임이 생길 수 있습니다. idle 시점에 디바운스하고, 이전 요청 취소나 요청 식별자를 함께 사용해야 해요.
+
+### `contentInset`과 지도 뷰 프레임 축소는 무엇이 다른가요?
+
+프레임 축소는 지도 자체의 크기를 바꾸지만 `contentInset`은 지도 렌더링 영역을 유지한 채 카메라가 기준으로 삼는 가시 영역을 조정합니다. 지도 위에 겹치는 패널이 있을 때 후자가 자연스럽습니다.
+
+## 참고 자료
+
+- [좌표 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/2-2.html)
+- [카메라와 투영 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/3-1.html)
+- [카메라 이동 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/3-2.html)
+- [사용자 인터페이스 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/4-1.html)
+- [`NMFMapViewCameraDelegate` API Reference](https://navermaps.github.io/ios-map-sdk/reference/Protocols/NMFMapViewCameraDelegate.html)

--- a/docs/guide/naver-maps-sdk/overlays-and-clustering.md
+++ b/docs/guide/naver-maps-sdk/overlays-and-clustering.md
@@ -1,0 +1,280 @@
+---
+title: Naver Maps 오버레이와 클러스터링
+description: 마커·정보 창·경로·도형의 공통 수명 주기와 스레드 규칙을 익히고, 대량 마커를 NMCClusterer로 묶어 성능과 가독성을 개선합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Naver Maps 오버레이와 클러스터링
+
+> 면접용 한 줄 요약: **오버레이는 `mapView` 연결 여부로 표시 수명을 관리하고, 대량 마커는 같은 이미지를 재사용하며 안정적인 키를 가진 클러스터러로 묶어야 합니다.**
+
+## 오버레이란 무엇인가요?
+
+기본 지도 위에 앱의 데이터를 표현하는 객체를 오버레이라고 해요.
+
+| 요구 사항               | 대표 타입                                           | 예시                     |
+| ----------------------- | --------------------------------------------------- | ------------------------ |
+| 한 지점 표시            | `NMFMarker`                                         | 매장, 정류장, 사고 지점  |
+| 선택한 지점의 부가 정보 | `NMFInfoWindow`                                     | 장소명 말풍선            |
+| 경로 표시               | `NMFPath`, `NMFMultipartPath`, `NMFPolylineOverlay` | 이동 경로, 단순 선       |
+| 영역 표시               | `NMFPolygonOverlay`, `NMFCircleOverlay`             | 배달 가능 구역, 반경     |
+| 지도 위 이미지          | `NMFGroundOverlay`                                  | 행사장 도면, 이미지 영역 |
+| 사용자 위치             | `NMFLocationOverlay`                                | 현재 위치와 방향         |
+
+타입은 달라도 표시와 제거 방식은 같습니다.
+
+```swift
+let marker = NMFMarker(
+  position: NMGLatLng(lat: 37.5666102, lng: 126.9783881)
+)
+
+marker.mapView = mapView // 지도에 표시
+marker.mapView = nil     // 지도에서 제거
+```
+
+[오버레이 공통 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-1.html)에 따르면 한 오버레이는 동시에 하나의 지도에만 추가할 수 있어요. 화면 전환이나 데이터 삭제 시 `mapView = nil`로 연결을 끊는 수명 주기를 명시적으로 가져야 합니다.
+
+## 마커와 정보 창을 하나의 선택 흐름으로 만들어요
+
+여러 장소마다 정보 창을 만들 필요는 없어요. 정보 창 하나의 데이터 소스를 갱신해 선택된 마커 위로 옮기면 됩니다.
+
+```swift
+import NMapsMap
+
+final class PlaceMarkerController {
+  private let infoWindow = NMFInfoWindow()
+  private let infoSource = NMFInfoWindowDefaultTextSource.data()
+  private var markers: [NMFMarker] = []
+
+  init() {
+    infoWindow.dataSource = infoSource
+  }
+
+  func showPlaces(_ places: [Place], on mapView: NMFMapView) {
+    removeAll()
+
+    markers = places.map { place in
+      let marker = NMFMarker(
+        position: NMGLatLng(
+          lat: place.latitude,
+          lng: place.longitude
+        )
+      )
+      marker.captionText = place.name
+      marker.userInfo = ["placeName": place.name]
+      marker.touchHandler = { [weak self] overlay in
+        guard let self,
+              let marker = overlay as? NMFMarker,
+              let title = marker.userInfo["placeName"] as? String else {
+          return false
+        }
+
+        self.infoSource.title = title
+        self.infoWindow.open(with: marker)
+        return true
+      }
+      marker.mapView = mapView
+      return marker
+    }
+  }
+
+  func closeInfoWindow() {
+    infoWindow.close()
+  }
+
+  func removeAll() {
+    infoWindow.close()
+    markers.forEach { $0.mapView = nil }
+    markers.removeAll()
+  }
+}
+
+struct Place {
+  let name: String
+  let latitude: Double
+  let longitude: Double
+}
+```
+
+`dataSource`는 `open(with:)`보다 먼저 지정해야 합니다. 마커의 `touchHandler`가 `true`를 반환했으므로 이벤트는 소비되고 지도 탭까지 전파되지 않아요. 지도를 탭했을 때 정보 창을 닫고 싶다면 지도 `touchDelegate`에서 `closeInfoWindow()`를 호출합니다.
+
+:::tip 전체 삭제보다 차이 반영이 좋아요
+위 코드는 수명 주기를 한눈에 보여주기 위해 전체를 교체합니다. 실제 SwiftUI나 실시간 검색 화면에서는 [SwiftUI 연동 문서의 `MarkerStore`](/guide/naver-maps-sdk/swiftui-integration)처럼 안정적인 ID를 기준으로 추가·변경·삭제만 반영하세요.
+:::
+
+## 표시 순서와 확대 수준을 조절해요
+
+오버레이가 겹치면 `globalZIndex`로 타입 사이의 큰 순서를, `zIndex`로 같은 타입 안의 상대 순서를 조절할 수 있어요. 선택된 마커를 위로 올리기 위해 모든 마커의 값을 반복해서 바꾸기보다 선택된 하나의 `zIndex`만 변경하세요.
+
+```swift
+marker.minZoom = 12
+marker.maxZoom = 19
+marker.zIndex = isSelected ? 10 : 0
+marker.hidden = !isVisible
+```
+
+`minZoom`, `maxZoom`으로 상세 데이터가 너무 축소된 지도에 노출되지 않게 하면 가독성과 렌더링 부담을 함께 줄일 수 있습니다.
+
+## 비트맵 이미지를 재사용해요
+
+`NMFOverlayImage`는 같은 이미지를 쓰는 여러 오버레이가 공유해야 해요. 공식 가이드는 같은 비트맵 인스턴스를 중복 생성하면 텍스처 아틀라스가 넘치거나 메모리 문제가 생길 수 있다고 경고합니다.
+
+```swift
+final class MapImageCatalog {
+  static let shared = MapImageCatalog()
+
+  let store = NMFOverlayImage(name: "marker_store")
+  let selectedStore = NMFOverlayImage(name: "marker_store_selected")
+
+  private init() {}
+}
+
+marker.iconImage = MapImageCatalog.shared.store
+```
+
+네트워크 이미지가 필요하다면 다운로드 결과를 캐시하고 `NMFOverlayImage` 생성도 재사용하는 계층을 두세요. 스크롤이나 카메라 이동 때마다 같은 이미지를 다시 디코딩하면 안 됩니다.
+
+## 지도에 붙은 오버레이는 메인 스레드에서 다뤄요
+
+[오버레이 공통 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-1.html)는 오버레이가 지도에 추가된 뒤 속성을 메인 스레드에서만 접근해야 하며, 그렇지 않으면 `NSObjectInaccessibleException`이 발생할 수 있다고 설명합니다.
+
+```swift
+Task.detached {
+  let models = await loadPlaceModels()
+
+  await MainActor.run {
+    markerController.showPlaces(models, on: mapView)
+  }
+}
+```
+
+백그라운드에서 서버 응답을 파싱하고 표시 모델을 계산하는 것은 좋지만, `mapView`에 연결된 마커의 위치·캡션·이미지를 바꾸는 구간은 `MainActor`로 넘기세요.
+
+## 마커가 많아지면 클러스터링해요
+
+마커가 수천 개면 두 문제가 동시에 생겨요.
+
+- 모든 마커가 겹쳐 사용자가 개별 장소를 읽기 어려워요.
+- 화면에 많은 오버레이를 유지하면서 렌더링과 업데이트 비용이 커져요.
+
+클러스터링은 확대 수준과 화면상 거리에 따라 가까운 항목을 하나의 그룹 마커로 묶습니다. 고정된 “몇 개부터”라는 정답은 없어요. 아이콘 복잡도, 기기, 카메라 범위가 다르므로 Instruments와 실제 기기에서 프레임, 메모리, 상호작용 지연을 측정해 결정합니다.
+
+## 안정적인 클러스터 키를 만들어요
+
+`NMCClusteringKey`는 위치뿐 아니라 항목 정체성을 표현해야 해요. 공식 데모처럼 `NSObject`를 상속하고 동등성, 해시, 복사를 일관되게 구현합니다.
+
+```swift
+import NMapsMap
+
+final class PlaceKey: NSObject, NMCClusteringKey {
+  let identifier: Int
+  let position: NMGLatLng
+
+  init(identifier: Int, position: NMGLatLng) {
+    self.identifier = identifier
+    self.position = position
+  }
+
+  override func isEqual(_ object: Any?) -> Bool {
+    guard let other = object as? PlaceKey else {
+      return false
+    }
+    return identifier == other.identifier
+  }
+
+  override var hash: Int {
+    identifier
+  }
+
+  func copy(with zone: NSZone? = nil) -> Any {
+    PlaceKey(identifier: identifier, position: position)
+  }
+}
+```
+
+같은 `identifier`인데 `hash`가 달라지거나, 화면 업데이트마다 새 임의 ID를 만들면 기존 항목을 안정적으로 찾을 수 없어요. 서버의 장소 ID처럼 변하지 않는 값을 사용합니다.
+
+## `NMCClusterer`에 데이터를 연결해요
+
+```swift
+final class PlaceClusterController {
+  private var clusterer: NMCClusterer<PlaceKey>?
+
+  func show(_ places: [ClusterPlace], on mapView: NMFMapView) {
+    let builder = NMCBuilder<PlaceKey>()
+    let clusterer = builder.build()
+
+    var items: [PlaceKey: NSObject] = [:]
+    for place in places {
+      let key = PlaceKey(
+        identifier: place.id,
+        position: NMGLatLng(
+          lat: place.latitude,
+          lng: place.longitude
+        )
+      )
+      items[key] = place.name as NSString
+    }
+
+    clusterer.addAll(items)
+    clusterer.mapView = mapView
+    self.clusterer = clusterer
+  }
+
+  func removeAll() {
+    clusterer?.clear()
+    clusterer?.mapView = nil
+    clusterer = nil
+  }
+}
+
+struct ClusterPlace {
+  let id: Int
+  let name: String
+  let latitude: Double
+  let longitude: Double
+}
+```
+
+공식 [클러스터링 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-8.html)는 항목을 하나씩 여러 번 추가하기보다 `addAll`을 한 번 호출하는 편이 성능에 유리하다고 안내합니다. 화면이 사라지거나 데이터 세트가 교체되면 `clear()`로 정리하세요.
+
+기본 전략으로 부족하면 `NMCComplexBuilder`에서 거리, 임계값, 태그 병합, 마커 업데이트 전략을 바꿀 수 있어요. 먼저 기본 클러스터러를 측정하고, 실제 UX 요구가 확인된 뒤 복잡한 전략으로 확장하는 편이 좋습니다.
+
+## 일반 마커와 클러스터링을 비교해요
+
+| 기준          | 일반 `NMFMarker`              | `NMCClusterer`                              |
+| ------------- | ----------------------------- | ------------------------------------------- |
+| 소량 장소     | 구현이 단순해요               | 오히려 설정이 늘 수 있어요                  |
+| 대량 장소     | 겹침과 업데이트 비용이 커져요 | 화면 가독성과 표시 수를 줄여요              |
+| 개별 커스텀   | 마커마다 직접 설정하기 쉬워요 | Leaf/Cluster updater 전략을 사용해요        |
+| 데이터 정체성 | 앱의 ID 저장소가 관리해요     | `NMCClusteringKey` 동등성·해시가 핵심이에요 |
+| 제거          | `mapView = nil`               | 개별 remove 또는 `clear()`                  |
+
+## 체크리스트
+
+- [ ] 오버레이를 제거할 때 `mapView = nil` 또는 `clear()`를 호출하나요?
+- [ ] 지도에 연결된 오버레이는 메인 스레드에서 변경하나요?
+- [ ] 같은 `NMFOverlayImage` 인스턴스를 재사용하나요?
+- [ ] 정보 창의 `dataSource`를 열기 전에 지정했나요?
+- [ ] 대량 마커의 안정적인 ID와 클러스터 키를 정의했나요?
+- [ ] 클러스터링 전후를 실제 기기와 Instruments에서 비교했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `NMCClusteringKey`의 `isEqual`과 `hash`가 중요한 이유는 무엇인가요?
+
+클러스터러가 데이터의 추가·변경·삭제를 같은 항목으로 식별하는 기준이기 때문입니다. 동등한 두 키는 반드시 같은 해시를 가져야 하며, 위치가 바뀌어도 항목 정체성이 같다면 식별자는 유지해야 해요.
+
+### 마커 이미지를 매번 새로 만들면 어떤 문제가 생기나요?
+
+같은 비트맵의 디코딩과 GPU 텍스처 사용이 중복됩니다. 공식 가이드가 권장하듯 `NMFOverlayImage` 인스턴스를 캐시해 여러 마커가 공유하도록 설계해야 해요.
+
+## 참고 자료
+
+- [오버레이 공통 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-1.html)
+- [마커 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-2.html)
+- [정보 창 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-3.html)
+- [경로선 오버레이 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-7.html)
+- [마커 클러스터링 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-8.html)
+- [NAVER Maps iOS SDK 공식 데모](https://github.com/navermaps/ios-map-sdk)

--- a/docs/guide/naver-maps-sdk/setup-and-authentication.md
+++ b/docs/guide/naver-maps-sdk/setup-and-authentication.md
@@ -1,0 +1,214 @@
+---
+title: Naver Maps iOS SDK 설치와 인증
+description: NAVER Cloud Platform 애플리케이션 등록부터 SPM·CocoaPods 설치, NCP Key ID 설정과 401·429·800 인증 오류 진단까지 단계별로 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Naver Maps iOS SDK 설치와 인증
+
+> 면접용 한 줄 요약: **SDK 설치만으로 지도 인증이 끝나는 것은 아니며, NCP에서 Dynamic Map과 Bundle ID를 등록하고 `NMFNcpKeyId`를 앱 시작 시점에 설정해야 합니다.**
+
+## 준비물과 용어
+
+| 용어             | 역할                                                                                  |
+| ---------------- | ------------------------------------------------------------------------------------- |
+| NCP 애플리케이션 | Maps 상품과 인증 정보를 묶어 관리하는 단위예요.                                       |
+| Dynamic Map      | iOS 앱 안에 동적 벡터 지도를 표시하는 상품이에요.                                     |
+| Bundle ID        | `com.example.MyApp`처럼 앱을 식별하며, 등록된 앱의 요청인지 확인하는 제한 조건이에요. |
+| `NMFNcpKeyId`    | iOS SDK가 인증에 사용할 NCP Key ID를 읽는 `Info.plist` 키예요.                        |
+
+## 1단계: NCP 애플리케이션을 등록해요
+
+[공식 시작 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/1.html)의 순서는 다음과 같아요.
+
+1. NAVER Cloud Platform 콘솔에서 **Services → Application Services → Maps**로 이동해요.
+2. 새 Application을 등록하고 **Dynamic Map**을 선택해요.
+3. iOS 앱의 실제 Bundle ID를 등록해요.
+4. 인증 정보에서 NCP Key ID를 확인해요.
+
+개발·스테이징·운영 앱의 Bundle ID가 다르면 모두 등록 여부를 확인해야 합니다. `PRODUCT_BUNDLE_IDENTIFIER`가 빌드 구성마다 바뀌는데 운영 Bundle ID 하나만 등록하면 디버그 빌드에서 401 오류가 날 수 있어요.
+
+## 2단계: SDK를 설치해요
+
+### Swift Package Manager
+
+Xcode에서 **File → Add Package Dependencies**를 선택하고 다음 공식 패키지 URL을 입력해요.
+
+```text
+https://github.com/navermaps/SPM-NMapsMap
+```
+
+버전 규칙은 무조건 최신을 선택하기보다 팀의 업데이트 정책에 맞춰 정하세요. 버전을 올릴 때는 [SDK 변경 내역](https://github.com/navermaps/ios-map-sdk/blob/master/CHANGELOG.md)을 확인합니다.
+
+:::warning 최소 iOS 버전은 선택한 태그에서 확인해요
+2026년 8월에 확인한 3.23.3 태그의 `Package.swift`는 iOS 12 이상을 선언합니다. 공식 웹 가이드의 오래된 설치 조건과 다를 수 있으므로, 프로젝트가 실제로 선택한 태그의 [`Package.swift`](https://github.com/navermaps/SPM-NMapsMap/blob/3.23.3/Package.swift)를 기준으로 판단하세요.
+:::
+
+### CocoaPods
+
+공식 가이드의 Pod 이름은 `NMapsMap`이에요.
+
+```ruby
+platform :ios, '12.0'
+
+target 'MapSample' do
+  use_frameworks!
+  pod 'NMapsMap'
+end
+```
+
+```bash
+pod install
+```
+
+CocoaPods를 사용했다면 `.xcodeproj`가 아니라 생성된 `.xcworkspace`를 열어야 해요. 최소 버전은 위 예시의 값을 그대로 복사하지 말고, 설치할 SDK 버전과 앱 정책을 함께 확인해 결정합니다.
+
+## 3단계: NCP Key ID를 설정해요
+
+### 방법 A: `Info.plist`
+
+```xml
+<key>NMFNcpKeyId</key>
+<string>YOUR_NCP_KEY_ID</string>
+```
+
+SDK가 지도 뷰를 초기화할 때 이 값을 읽으므로 가장 단순한 방법이에요. 값이 환경마다 다르면 `.xcconfig` 변수를 `Info.plist`에 주입할 수 있습니다.
+
+```text
+// Debug.xcconfig
+NAVER_MAP_NCP_KEY_ID = your_debug_key_id
+```
+
+```xml
+<key>NMFNcpKeyId</key>
+<string>$(NAVER_MAP_NCP_KEY_ID)</string>
+```
+
+`.xcconfig`로 옮겨도 빌드된 앱 안에서 값 자체가 사라지는 것은 아니에요. 이 값은 등록한 Bundle ID로 사용 범위를 제한하고, 저장소에는 실제 운영 값을 커밋하지 않는 방식으로 관리하세요.
+
+### 방법 B: 앱 시작 시점에 코드로 설정해요
+
+```swift
+import NMapsMap
+import UIKit
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    NMFAuthManager.shared().ncpKeyId = "YOUR_NCP_KEY_ID"
+    return true
+  }
+}
+```
+
+SwiftUI 생명 주기에서는 `UIApplicationDelegateAdaptor`로 연결할 수 있어요.
+
+```swift
+import SwiftUI
+
+@main
+struct MapSampleApp: App {
+  @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}
+```
+
+중요한 것은 **첫 지도 뷰가 만들어지기 전에** 설정하는 것입니다. `ContentView.onAppear`처럼 지도 생성보다 늦을 수 있는 위치는 피하세요.
+
+## 인증 결과를 관찰해요
+
+`NMFAuthManager.delegate`는 약한 참조이므로, 델리게이트 객체를 강하게 보관해야 합니다.
+
+```swift
+import NMapsMap
+
+final class MapAuthenticationObserver: NSObject, NMFAuthManagerDelegate {
+  func authorized(_ state: NMFAuthState, error: (any Error)?) {
+    if let error {
+      print("지도 인증 실패: \(error.localizedDescription)")
+      return
+    }
+
+    print("지도 인증 상태: \(state)")
+  }
+}
+
+final class MapBootstrap {
+  private let observer = MapAuthenticationObserver()
+
+  func configure(keyID: String) {
+    let manager = NMFAuthManager.shared()
+    manager.ncpKeyId = keyID
+    manager.delegate = observer
+  }
+}
+```
+
+운영 앱에서는 콘솔 로그만 남기기보다 오류 코드, 앱 버전, Bundle ID, 네트워크 상태를 개인정보 없이 수집해 진단 가능하게 만드는 편이 좋아요. 실제 NCP Key ID 전체 값은 로그에 기록하지 않습니다.
+
+## 오류 코드로 원인을 좁혀요
+
+[공식 시작 가이드의 인증 오류 표](https://navermaps.github.io/ios-map-sdk/guide-ko/1.html)를 기준으로 먼저 다음 항목을 확인하세요.
+
+| 상태 코드 | 대표 원인                                  | 확인 순서                                                             |
+| --------- | ------------------------------------------ | --------------------------------------------------------------------- |
+| 800       | NCP Key ID가 지정되지 않음                 | `NMFNcpKeyId` 철자, Target Membership, 앱 시작 시 설정 순서           |
+| 401       | 잘못된 Key ID 또는 등록되지 않은 Bundle ID | 실행 중인 `Bundle.main.bundleIdentifier`, NCP 등록 값, 개발·운영 환경 |
+| 429       | Dynamic Map 미선택 또는 사용량 한도 초과   | Maps 상품 선택, 이용량·쿼터, 결제 상태                                |
+
+```swift
+let actualBundleID = Bundle.main.bundleIdentifier ?? "unknown"
+print("실행 중인 Bundle ID: \(actualBundleID)")
+```
+
+오류가 날 때는 코드를 계속 바꾸기보다 다음 순서로 진단해요.
+
+1. 현재 Target이 SDK를 링크하고 `import NMapsMap`이 되는지 확인해요.
+2. 실행 중인 Bundle ID와 NCP 콘솔 등록 값을 문자 단위로 비교해요.
+3. `NMFNcpKeyId`가 지도 생성 전에 설정됐는지 확인해요.
+4. Dynamic Map 선택과 쿼터를 확인해요.
+5. 프록시·VPN을 끈 네트워크와 실제 기기에서도 재현되는지 확인해요.
+
+## Client Secret과 혼동하지 않아요
+
+| 값                          | 사용 위치                        | 앱 번들 포함                         |
+| --------------------------- | -------------------------------- | ------------------------------------ |
+| 모바일 지도용 NCP Key ID    | `NMFNcpKeyId` 또는 `ncpKeyId`    | 필요하지만 Bundle ID 제한을 설정해요 |
+| Maps REST API Client Secret | 우리 서버가 REST API를 호출할 때 | 포함하지 않아요                      |
+
+앱에 들어간 문자열은 결국 추출될 수 있습니다. Client Secret이 필요한 Geocoding이나 Directions 요청은 서버로 옮기고, 서버에 인증·호출 제한·레이트 리밋을 적용하세요.
+
+## 체크리스트
+
+- [ ] NCP 애플리케이션에서 Dynamic Map을 선택했나요?
+- [ ] 현재 빌드 구성의 Bundle ID를 등록했나요?
+- [ ] SDK 버전의 최소 iOS 조건을 확인했나요?
+- [ ] 첫 지도 뷰 생성 전에 NCP Key ID를 설정했나요?
+- [ ] 인증 델리게이트 객체를 강하게 보관했나요?
+- [ ] 실제 Key ID와 Client Secret을 로그나 저장소에 남기지 않았나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### 왜 `Info.plist`의 Key ID를 완전한 비밀로 볼 수 없나요?
+
+앱 번들은 사용자 기기에 배포되므로 내부 문자열을 추출할 수 있기 때문입니다. 모바일 지도 키는 Bundle ID 제한으로 오용 범위를 줄이고, 진짜 비밀인 REST API Client Secret은 서버에만 보관해야 합니다.
+
+### 인증 델리게이트가 호출되지 않는 원인은 무엇일 수 있나요?
+
+델리게이트 속성이 약한 참조인데 관찰자 객체를 지역 변수로만 만들면 즉시 해제될 수 있습니다. 강한 프로퍼티로 보관하고, 지도 인증이 시작되기 전에 등록했는지 확인해야 해요.
+
+## 참고 자료
+
+- [NAVER Maps iOS SDK 시작하기](https://navermaps.github.io/ios-map-sdk/guide-ko/1.html)
+- [`NMFAuthManager` API Reference](https://navermaps.github.io/ios-map-sdk/reference/Classes/NMFAuthManager.html)
+- [`NMFAuthManagerDelegate` API Reference](https://navermaps.github.io/ios-map-sdk/reference/Protocols/NMFAuthManagerDelegate.html)
+- [SPM-NMapsMap 공식 패키지](https://github.com/navermaps/SPM-NMapsMap)
+- [NAVER Maps 애플리케이션 사용 가이드](https://guide.ncloud-docs.com/docs/en/maps-app/)

--- a/docs/guide/naver-maps-sdk/swiftui-integration.md
+++ b/docs/guide/naver-maps-sdk/swiftui-integration.md
@@ -1,0 +1,295 @@
+---
+title: SwiftUI에서 Naver Maps SDK 연동하기
+description: UIViewRepresentable과 Coordinator로 NMFNaverMapView를 감싸고, 카메라 양방향 상태 동기화와 Identifiable 기반 마커 재조정을 안전하게 구현합니다.
+pageType: doc-wide
+outline: false
+---
+
+# SwiftUI에서 Naver Maps SDK 연동하기
+
+> 면접용 한 줄 요약: **UIKit 지도 뷰의 생성은 `makeUIView`, SwiftUI 상태 반영은 `updateUIView`, 델리게이트와 명령형 객체 보관은 Coordinator가 맡도록 수명 주기를 나눕니다.**
+
+:::info 예제의 근거
+Naver Maps iOS SDK는 UIKit 뷰를 제공하고, Apple은 UIKit 뷰를 SwiftUI에 연결할 때 `UIViewRepresentable`을 사용하도록 안내합니다. 아래 코드는 [Naver Maps 지도·카메라 계약](https://navermaps.github.io/ios-map-sdk/guide-ko/3-2.html)과 Apple의 [`UIViewRepresentable`](https://developer.apple.com/documentation/swiftui/uiviewrepresentable) 수명 주기를 조합한 구현 예시예요.
+:::
+
+## 세 수명 주기를 먼저 나눠요
+
+| 구성 요소         | 수명 주기                         | 맡길 책임                              |
+| ----------------- | --------------------------------- | -------------------------------------- |
+| SwiftUI `View` 값 | 상태가 바뀔 때 자주 다시 생성     | 선언적 입력과 화면 조합                |
+| `NMFNaverMapView` | Representable이 관리하는 UIKit 뷰 | 지도 렌더링과 제스처                   |
+| `Coordinator`     | Representable의 UIKit 연결 수명   | 델리게이트, 마커 저장소, 양방향 이벤트 |
+
+가장 흔한 실수는 `updateUIView`에서 지도 뷰나 모든 마커를 매번 새로 만드는 것입니다. SwiftUI 업데이트는 매우 자주 일어날 수 있으므로, 이 메서드는 **현재 UIKit 상태와 새 입력의 차이만 반영**해야 해요.
+
+## 1단계: SwiftUI가 이해할 카메라 모델을 만들어요
+
+SDK 객체를 앱의 화면 상태로 그대로 노출하기보다 필요한 값만 담은 Swift 모델을 두면 테스트와 비교가 쉬워집니다.
+
+```swift
+struct MapViewport: Equatable {
+  var latitude: Double
+  var longitude: Double
+  var zoom: Double
+
+  static let seoul = MapViewport(
+    latitude: 37.5666102,
+    longitude: 126.9783881,
+    zoom: 15
+  )
+
+  func isApproximatelyEqual(to other: MapViewport) -> Bool {
+    abs(latitude - other.latitude) < 0.000_001
+      && abs(longitude - other.longitude) < 0.000_001
+      && abs(zoom - other.zoom) < 0.001
+  }
+}
+```
+
+부동소수점 카메라 값을 `==`로만 비교하면 아주 작은 오차 때문에 같은 이동을 반복할 수 있어요. 화면 요구 사항에 맞는 허용 오차를 사용합니다.
+
+## 2단계: 지도 뷰와 카메라를 양방향으로 연결해요
+
+```swift
+import NMapsMap
+import SwiftUI
+
+struct NaverMapContainer: UIViewRepresentable {
+  @Binding var viewport: MapViewport
+  var onMapTap: (NMGLatLng) -> Void = { _ in }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(viewport: $viewport, onMapTap: onMapTap)
+  }
+
+  func makeUIView(context: Context) -> NMFNaverMapView {
+    let naverMapView = NMFNaverMapView(frame: .zero)
+    let mapView = naverMapView.mapView
+
+    naverMapView.showCompass = true
+    naverMapView.showScaleBar = true
+    naverMapView.showZoomControls = false
+
+    mapView.touchDelegate = context.coordinator
+    mapView.addCameraDelegate(delegate: context.coordinator)
+    return naverMapView
+  }
+
+  func updateUIView(_ uiView: NMFNaverMapView, context: Context) {
+    context.coordinator.viewport = $viewport
+    context.coordinator.onMapTap = onMapTap
+    context.coordinator.apply(viewport, to: uiView.mapView)
+  }
+
+  static func dismantleUIView(
+    _ uiView: NMFNaverMapView,
+    coordinator: Coordinator
+  ) {
+    coordinator.detach(from: uiView.mapView)
+  }
+
+  final class Coordinator: NSObject {
+    var viewport: Binding<MapViewport>
+    var onMapTap: (NMGLatLng) -> Void
+    private var lastAppliedViewport: MapViewport?
+
+    init(
+      viewport: Binding<MapViewport>,
+      onMapTap: @escaping (NMGLatLng) -> Void
+    ) {
+      self.viewport = viewport
+      self.onMapTap = onMapTap
+    }
+
+    func apply(_ newViewport: MapViewport, to mapView: NMFMapView) {
+      if let lastAppliedViewport,
+         newViewport.isApproximatelyEqual(to: lastAppliedViewport) {
+        return
+      }
+
+      lastAppliedViewport = newViewport
+      let target = NMGLatLng(
+        lat: newViewport.latitude,
+        lng: newViewport.longitude
+      )
+      let position = NMFCameraPosition(target, zoom: newViewport.zoom)
+      let update = NMFCameraUpdate(position: position)
+      update.animation = .easeIn
+      mapView.moveCamera(update)
+    }
+
+    func detach(from mapView: NMFMapView) {
+      mapView.touchDelegate = nil
+      mapView.removeCameraDelegate(delegate: self)
+    }
+    func reportCameraIdle(_ mapView: NMFMapView) {
+      let camera = mapView.cameraPosition
+      let current = MapViewport(
+        latitude: camera.target.lat,
+        longitude: camera.target.lng,
+        zoom: camera.zoom
+      )
+
+      lastAppliedViewport = current
+      guard !current.isApproximatelyEqual(to: viewport.wrappedValue) else {
+        return
+      }
+
+      DispatchQueue.main.async { [weak self] in
+        self?.viewport.wrappedValue = current
+      }
+    }
+  }
+}
+
+extension NaverMapContainer.Coordinator: NMFMapViewCameraDelegate {
+  func mapViewCameraIdle(_ mapView: NMFMapView) {
+    reportCameraIdle(mapView)
+  }
+}
+
+extension NaverMapContainer.Coordinator: NMFMapViewTouchDelegate {
+  func mapView(
+    _ mapView: NMFMapView,
+    didTapMap latlng: NMGLatLng,
+    point: CGPoint
+  ) {
+    onMapTap(latlng)
+  }
+}
+```
+
+`lastAppliedViewport`가 중요한 이유는 다음 순환을 끊기 위해서예요.
+
+```text
+사용자 제스처 → 카메라 idle → Binding 변경 → updateUIView
+      ▲                                      │
+      └──── 같은 카메라 이동을 다시 실행 ────┘
+```
+
+Coordinator가 방금 보고한 카메라와 SwiftUI 입력을 비교하면 같은 이동을 되풀이하지 않습니다.
+
+## 3단계: SwiftUI 화면에서 사용해요
+
+```swift
+struct PlaceMapScreen: View {
+  @State private var viewport = MapViewport.seoul
+  @State private var selectedCoordinate: String?
+
+  var body: some View {
+    ZStack(alignment: .bottom) {
+      NaverMapContainer(viewport: $viewport) { coordinate in
+        selectedCoordinate = "\(coordinate.lat), \(coordinate.lng)"
+      }
+      .ignoresSafeArea()
+
+      if let selectedCoordinate {
+        Text(selectedCoordinate)
+          .padding(12)
+          .background(.regularMaterial, in: Capsule())
+          .padding(.bottom, 24)
+      }
+    }
+  }
+}
+```
+
+SwiftUI가 레이아웃을 소유하므로 `makeUIView`에서 화면 크기를 직접 읽어 프레임을 고정하지 않습니다. `ignoresSafeArea`, `frame`, `safeAreaInset` 같은 SwiftUI 수정자로 배치를 결정해요.
+
+## 마커는 안정적인 ID로 재조정해요
+
+마커 배열이 바뀔 때 기존 마커를 모두 `nil`로 떼고 다시 만들면 아이콘 생성, 터치 핸들러 등록, 렌더링이 반복됩니다. `Identifiable`의 ID를 키로 사용해 추가·변경·삭제만 반영하세요.
+
+```swift
+struct PlacePin: Identifiable, Equatable {
+  let id: String
+  var title: String
+  var latitude: Double
+  var longitude: Double
+}
+
+final class MarkerStore {
+  private var markersByID: [PlacePin.ID: NMFMarker] = [:]
+
+  func synchronize(
+    pins: [PlacePin],
+    on mapView: NMFMapView,
+    onTap: @escaping (PlacePin.ID) -> Void
+  ) {
+    let incomingIDs = Set(pins.map(\.id))
+    let removedIDs = Set(markersByID.keys).subtracting(incomingIDs)
+
+    for id in removedIDs {
+      markersByID[id]?.mapView = nil
+      markersByID[id] = nil
+    }
+
+    for pin in pins {
+      let marker = markersByID[pin.id] ?? NMFMarker()
+      marker.position = NMGLatLng(
+        lat: pin.latitude,
+        lng: pin.longitude
+      )
+      marker.captionText = pin.title
+      marker.touchHandler = { _ in
+        onTap(pin.id)
+        return true
+      }
+      marker.mapView = mapView
+      markersByID[pin.id] = marker
+    }
+  }
+
+  func removeAll() {
+    markersByID.values.forEach { $0.mapView = nil }
+    markersByID.removeAll()
+  }
+}
+```
+
+이 저장소는 Coordinator가 소유하는 것이 자연스러워요. `updateUIView`에서는 `markerStore.synchronize(...)`만 호출하고, `dismantleUIView`에서 `removeAll()`을 호출합니다.
+
+마커가 수천 개로 늘어나면 ID 기반 재조정만으로 충분하지 않을 수 있어요. 화면 가독성과 렌더링 비용을 함께 줄이려면 [클러스터링](/guide/naver-maps-sdk/overlays-and-clustering)을 적용합니다.
+
+## 비동기 검색 결과와 카메라를 연결할 때
+
+카메라가 멈출 때마다 주변 장소를 조회하는 화면은 다음 경계를 가져야 해요.
+
+```text
+카메라 idle
+  → SwiftUI viewport 갱신
+  → 이전 Task 취소
+  → 서버에 현재 영역 조회
+  → 최신 요청의 결과만 pins에 반영
+  → MarkerStore가 차이만 지도에 반영
+```
+
+Coordinator 안에서 네트워크를 직접 호출하면 UIKit 수명 주기와 비즈니스 로직이 강하게 결합됩니다. Coordinator는 카메라 이벤트를 SwiftUI 상태로 전달하고, 검색 Task는 ViewModel이나 화면 모델이 소유하도록 나누세요.
+
+## 체크리스트
+
+- [ ] 지도 뷰는 `makeUIView`에서 한 번 만들고 있나요?
+- [ ] `updateUIView`는 입력 차이만 반영하나요?
+- [ ] 카메라 양방향 바인딩의 되먹임을 차단했나요?
+- [ ] 델리게이트 등록과 해제를 같은 수명 주기로 묶었나요?
+- [ ] 마커를 안정적인 ID로 추가·변경·삭제하나요?
+- [ ] 네트워크 검색을 Coordinator 밖의 화면 모델이 소유하나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Coordinator가 필요한 이유는 무엇인가요?
+
+SwiftUI `View`는 값 타입이고 자주 다시 만들어지지만 UIKit 델리게이트와 오버레이 저장소는 참조 수명과 정체성이 필요합니다. Coordinator가 두 세계 사이에서 이벤트와 명령형 객체를 안정적으로 보관해요.
+
+### `updateUIView`에서 지도를 매번 새로 만들면 왜 안 되나요?
+
+카메라와 제스처 상태가 초기화되고, 네트워크 타일 로딩과 오버레이 생성이 반복되며, SwiftUI 상태 변경 때 화면이 깜빡일 수 있습니다. UIKit 인스턴스는 유지하고 바뀐 속성만 업데이트해야 해요.
+
+## 참고 자료
+
+- [Apple `UIViewRepresentable`](https://developer.apple.com/documentation/swiftui/uiviewrepresentable)
+- [Apple SwiftUI의 UIKit 통합](https://developer.apple.com/documentation/swiftui/uikit-integration)
+- [NAVER 지도 객체 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/2-1.html)
+- [NAVER 카메라 이동 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/3-2.html)
+- [`NMFMapView` API Reference](https://navermaps.github.io/ios-map-sdk/reference/Classes/NMFMapView.html)

--- a/docs/guide/naver-maps-sdk/user-location.md
+++ b/docs/guide/naver-maps-sdk/user-location.md
@@ -1,0 +1,262 @@
+---
+title: Naver Maps 사용자 위치와 권한
+description: 최신 Core Location 권한 정책에 맞춰 When In Use 권한을 요청하고, 내장 위치 추적 모드와 NMFLocationOverlay 직접 갱신 방식을 비교해 구현합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Naver Maps 사용자 위치와 권한
+
+> 면접용 한 줄 요약: **Naver Maps SDK는 기본적으로 위치를 사용하지 않으며, 기능을 실행하는 순간 최소 권한을 요청한 뒤 내장 추적 모드 또는 단일 위치 오버레이를 선택해 표시합니다.**
+
+## 세 가지 책임을 구분해요
+
+```text
+Core Location 권한
+  └─ 사용자가 위치 접근을 허용했는가?
+
+위치 제공자
+  └─ 현재 좌표·정확도·방향을 누가 갱신하는가?
+
+Naver Maps 표현
+  └─ 위치 오버레이와 카메라를 어떻게 보여주는가?
+```
+
+지도 SDK를 설치했다고 위치 권한이 자동으로 생기지는 않아요. [NAVER 위치 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/4-2.html)도 SDK가 기본적으로 위치 정보를 사용하지 않는다고 설명합니다.
+
+## 현재 사용 중에만 필요하면 When In Use를 선택해요
+
+지도를 보는 동안 주변 장소를 보여주는 기능이라면 `Info.plist`에 목적 문자열을 추가합니다.
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>현재 위치 주변의 장소를 지도에 표시하기 위해 위치가 필요합니다.</string>
+```
+
+목적 문자열은 “서비스 제공을 위해 필요합니다”처럼 추상적으로 쓰기보다 **어떤 기능에서 어떤 이점을 주는지** 사용자가 이해할 수 있게 적으세요.
+
+:::warning 오래된 Always 키 예제를 그대로 복사하지 않아요
+NAVER 위치 가이드에는 과거의 `NSLocationAlwaysUsageDescription` 예제가 남아 있지만, 이 키는 현재 Apple SDK에서 폐기된 키예요. Apple의 [위치 서비스 권한 요청 가이드](https://developer.apple.com/documentation/corelocation/requesting-authorization-to-use-location-services)에 따라 화면 사용 중 기능은 `NSLocationWhenInUseUsageDescription`을 우선 사용하세요. 실제 백그라운드 위치가 제품의 핵심일 때만 더 강한 권한과 Background Modes를 별도로 설계합니다.
+:::
+
+Always 권한이 정말 필요하다면 현재는 `NSLocationWhenInUseUsageDescription`과 `NSLocationAlwaysAndWhenInUseUsageDescription`을 요구 사항에 맞게 구성해야 해요. 단순 지도 화면을 위해 Always를 요청하면 권한 거부 가능성과 개인정보 부담만 커집니다.
+
+## 권한은 기능을 누른 시점에 요청해요
+
+앱 시작 직후 설명 없이 권한 팝업을 띄우기보다 “내 위치” 버튼처럼 맥락이 생긴 순간 요청하세요.
+
+```swift
+import CoreLocation
+
+final class LocationPermissionController: NSObject, CLLocationManagerDelegate {
+  private let manager = CLLocationManager()
+  var onAuthorized: (() -> Void)?
+  var onDenied: (() -> Void)?
+
+  override init() {
+    super.init()
+    manager.delegate = self
+  }
+
+  func requestWhenInUse() {
+    switch manager.authorizationStatus {
+    case .notDetermined:
+      manager.requestWhenInUseAuthorization()
+    case .authorizedWhenInUse, .authorizedAlways:
+      onAuthorized?()
+    case .denied, .restricted:
+      onDenied?()
+    @unknown default:
+      onDenied?()
+    }
+  }
+
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    switch manager.authorizationStatus {
+    case .authorizedWhenInUse, .authorizedAlways:
+      onAuthorized?()
+    case .denied, .restricted:
+      onDenied?()
+    case .notDetermined:
+      break
+    @unknown default:
+      onDenied?()
+    }
+  }
+}
+```
+
+거부 상태에서는 권한 요청 팝업을 반복해서 띄울 수 없어요. 기능이 왜 필요한지 설명하고 사용자가 원할 때 설정 앱으로 이동할 수 있는 선택지를 제공하되, 권한 없이도 지도를 탐색하거나 주소를 검색할 수 있게 대체 흐름을 남겨두세요.
+
+## 방법 A: 내장 위치 추적 모드를 사용해요
+
+SDK가 제공하는 현재 위치 버튼과 카메라 추적을 빠르게 연결할 때 적합합니다.
+
+```swift
+naverMapView.showLocationButton = true
+naverMapView.positionMode = .direction
+```
+
+| 모드         | 위치 오버레이    | 카메라 중심               | 카메라 방향             |
+| ------------ | ---------------- | ------------------------- | ----------------------- |
+| `.disabled`  | 추적하지 않음    | 유지                      | 유지                    |
+| `.normal`    | 현재 위치로 이동 | 사용자가 움직인 상태 유지 | 유지                    |
+| `.direction` | 현재 위치로 이동 | 현재 위치를 따라감        | 사용자의 지도 회전 유지 |
+| `.compass`   | 현재 위치로 이동 | 현재 위치를 따라감        | 기기 방향을 따라감      |
+
+`.direction`이나 `.compass` 상태에서 사용자가 제스처로 지도를 움직이면 `.normal`로 바뀔 수 있어요. 이는 사용자가 다른 지역을 탐색하려는 동작을 카메라가 즉시 되돌리지 않도록 하는 자연스러운 UX입니다.
+
+공식 데모는 `NMFLocationManager.sharedInstance()`에 `NMFLocationManagerDelegate`를 등록하고 화면이 사라질 때 제거합니다.
+
+```swift
+final class TrackingViewController: UIViewController, NMFLocationManagerDelegate {
+  private let locationManager = NMFLocationManager.sharedInstance()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    locationManager?.add(self)
+  }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    locationManager?.remove(self)
+  }
+}
+```
+
+등록과 해제를 같은 화면 수명에 묶어 중복 콜백과 불필요한 참조를 피하세요.
+
+## 방법 B: Core Location 결과를 직접 표시해요
+
+위치 필터링, 정확도 정책, 자체 상태 모델, 서버 업로드가 필요하다면 `CLLocationManager`를 직접 소유하고 지도에는 결과만 전달하는 편이 명확합니다.
+
+```swift
+import CoreLocation
+import NMapsMap
+
+final class MapLocationController: NSObject, CLLocationManagerDelegate {
+  private let manager = CLLocationManager()
+  private weak var mapView: NMFMapView?
+
+  init(mapView: NMFMapView) {
+    self.mapView = mapView
+    super.init()
+    manager.delegate = self
+    manager.desiredAccuracy = kCLLocationAccuracyBest
+  }
+
+  func start() {
+    switch manager.authorizationStatus {
+    case .authorizedWhenInUse, .authorizedAlways:
+      manager.startUpdatingLocation()
+      manager.startUpdatingHeading()
+    case .notDetermined:
+      manager.requestWhenInUseAuthorization()
+    case .denied, .restricted:
+      hideLocation()
+    @unknown default:
+      hideLocation()
+    }
+  }
+
+  func stop() {
+    manager.stopUpdatingLocation()
+    manager.stopUpdatingHeading()
+  }
+
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    start()
+  }
+
+  func locationManager(
+    _ manager: CLLocationManager,
+    didUpdateLocations locations: [CLLocation]
+  ) {
+    guard let latest = locations.last,
+          latest.horizontalAccuracy >= 0,
+          let overlay = mapView?.locationOverlay else {
+      return
+    }
+
+    overlay.location = NMGLatLng(
+      lat: latest.coordinate.latitude,
+      lng: latest.coordinate.longitude
+    )
+    overlay.hidden = false
+  }
+
+  func locationManager(
+    _ manager: CLLocationManager,
+    didUpdateHeading newHeading: CLHeading
+  ) {
+    let heading = newHeading.trueHeading >= 0
+      ? newHeading.trueHeading
+      : newHeading.magneticHeading
+    mapView?.locationOverlay.heading = heading
+  }
+
+  private func hideLocation() {
+    mapView?.locationOverlay.hidden = true
+  }
+}
+```
+
+`NMFLocationOverlay`는 지도마다 하나만 존재하며 `mapView.locationOverlay`로 가져옵니다. 일반 마커처럼 `mapView = nil`로 제거하는 객체가 아니므로 `hidden`으로 표시를 제어해야 해요.
+
+`locationOverlay.circleRadius`의 단위는 미터가 아니라 화면의 pt입니다. `CLLocation.horizontalAccuracy`처럼 실제 지리적 반경을 보여주려면 `NMFCircleOverlay`를 별도로 만들고 위치와 반경을 갱신하세요.
+
+## 두 방법을 비교해요
+
+| 기준                    | 내장 위치 추적     | 직접 Core Location 연동          |
+| ----------------------- | ------------------ | -------------------------------- |
+| 구현 속도               | 빠름               | 상태와 권한 코드를 직접 작성     |
+| 현재 위치 버튼          | 바로 연결하기 쉬움 | 앱 버튼과 직접 연결              |
+| 카메라 추적             | 모드로 제공        | 카메라 업데이트를 직접 구현      |
+| 위치 필터·정확도 정책   | 제한적             | 제품 요구에 맞게 제어            |
+| 서버 업로드·도메인 모델 | 별도 연결 필요     | 같은 파이프라인에서 구성 가능    |
+| 테스트 대역             | SDK 추적에 의존    | 위치 제공자 프로토콜로 분리 가능 |
+
+주변 장소 화면처럼 단순히 현 위치를 보여주고 따라가면 내장 모드가 편해요. 운동 기록이나 배달 추적처럼 위치 품질을 검사하고 도메인 이벤트로 처리해야 하면 직접 연동이 적합합니다.
+
+## 배터리와 개인정보를 함께 설계해요
+
+- 화면이 사라지거나 기능이 끝나면 위치와 방향 업데이트를 중지해요.
+- 제품이 허용하는 가장 낮은 `desiredAccuracy`를 선택해요.
+- 서버 전송이 필요하다면 보관 기간, 전송 주기, 사용 목적을 명확히 해요.
+- 원본 위치를 로그·분석 이벤트에 무심코 남기지 않아요.
+- 권한 거부, 위치 서비스 꺼짐, 정확한 위치 비활성화 상태의 UI를 준비해요.
+
+## 테스트 방법
+
+1. 시뮬레이터의 **Features → Location**에서 고정 위치와 이동 경로를 바꿔요.
+2. 권한을 허용, 거부, 다시 설정한 각 상태에서 버튼 동작을 확인해요.
+3. 사용자가 지도를 드래그했을 때 `.direction`에서 `.normal`로 바뀌는지 확인해요.
+4. 화면 전환 후에도 위치 업데이트가 계속되는지 Instruments의 Energy Log와 로그로 확인해요.
+5. 실제 기기에서 나침반 방향과 위치 정확도 변화도 확인해요.
+
+## 체크리스트
+
+- [ ] 위치 기능을 사용자가 요청한 순간에 권한을 묻나요?
+- [ ] 단순 지도 화면에 Always 권한을 요구하지 않나요?
+- [ ] 거부·제한 상태에서도 사용할 대체 흐름이 있나요?
+- [ ] 내장 추적과 직접 연동 중 책임에 맞는 방식을 선택했나요?
+- [ ] 화면이 사라질 때 추적과 델리게이트를 정리하나요?
+- [ ] 위치 정확도와 원본 위치의 로그·보관 정책을 검토했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### 지도 SDK를 설치하면 위치 권한 문구가 반드시 필요한가요?
+
+아니요. Naver Maps SDK는 기본적으로 사용자 위치를 사용하지 않습니다. 현재 위치 기능이나 직접 Core Location 추적을 실제로 사용할 때 목적에 맞는 권한 문구를 추가해야 해요.
+
+### 위치 정확도 원을 `locationOverlay.circleRadius`로 표현해도 되나요?
+
+정확도 값은 미터인데 `circleRadius`는 화면의 pt 단위라서 의미가 맞지 않습니다. 지리적 반경은 `NMFCircleOverlay`의 미터 단위 반경으로 표현해야 해요.
+
+## 참고 자료
+
+- [NAVER 위치 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/4-2.html)
+- [NAVER 위치 오버레이 공식 가이드](https://navermaps.github.io/ios-map-sdk/guide-ko/5-5.html)
+- [NAVER Maps iOS SDK 위치 추적 데모](https://github.com/navermaps/ios-map-sdk/blob/master/NaverMapDemo/LocationTrackingViewController.swift)
+- [Apple 위치 서비스 권한 요청](https://developer.apple.com/documentation/corelocation/requesting-authorization-to-use-location-services)
+- [Apple `CLLocationManager`](https://developer.apple.com/documentation/corelocation/cllocationmanager)


### PR DESCRIPTION
## 요약

- Naver Maps iOS SDK 전용 학습 섹션과 상단 내비게이션을 추가했습니다.
- 공식 NAVER Maps iOS SDK·NAVER Cloud Platform·Apple Core Location 문서를 기준으로 6개 학습 문서를 구성했습니다.
- UIKit과 SwiftUI의 전체 흐름, 인증 오류 진단, 대량 마커 클러스터링, 최신 위치 권한 정책을 단계별 Swift 예제로 설명했습니다.

## 문서 구성

- SDK와 Maps REST API의 역할 경계 및 학습 순서
- SPM·CocoaPods 설치, NCP Key ID 설정, 401·429·800 오류 진단
- 좌표, 카메라, 투영, 탭 이벤트, NAVER 로고 정책
- `UIViewRepresentable`과 Coordinator를 이용한 SwiftUI 연동 및 마커 재조정
- 마커·정보 창·도형의 수명 주기, 이미지 재사용, `NMCClusterer`
- When In Use 권한, 내장 위치 추적 모드, Core Location 직접 연동

## 검증

- `npm run format`
- `npm run lint`
- `npm run build`
- 모든 Swift 코드 블록 `swiftc -parse`
- 로컬 Rspress 경로 `/Swift-KR/guide/naver-maps-sdk/index` HTTP 200 확인
- `git diff --check`

Closes #41
