### PR TITLE
[#45] 네이버 지도와 Firebase 목차에 문서 경로가 표시되는 문제를 수정한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -42,7 +42,7 @@
     "position": "left"
   },
   {
-    "text": "Firebase iOS SDK",
+    "text": "파이어베이스 iOS SDK",
     "link": "/guide/firebase-ios-sdk/index",
     "activeMatch": "/guide/firebase-ios-sdk/",
     "position": "left"

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -37,7 +37,7 @@
   {
     "type": "dir-section-header",
     "name": "firebase-ios-sdk",
-    "label": "Firebase iOS SDK"
+    "label": "파이어베이스 iOS SDK"
   },
   {
     "type": "dir-section-header",

--- a/docs/guide/firebase-ios-sdk/_meta.json
+++ b/docs/guide/firebase-ios-sdk/_meta.json
@@ -1,53 +1,53 @@
 [
   {
     "type": "custom-link",
-    "text": "Firebase iOS SDK 시작하기",
+    "label": "파이어베이스 iOS SDK 시작하기",
     "link": "/guide/firebase-ios-sdk/index"
   },
   {
     "type": "custom-link",
-    "text": "인증",
+    "label": "인증",
     "link": "/guide/firebase-ios-sdk/authentication"
   },
   {
     "type": "custom-link",
-    "text": "데이터와 파일",
+    "label": "데이터와 파일",
     "link": "/guide/firebase-ios-sdk/realtime-database",
     "collapsible": true,
     "collapsed": true,
     "items": [
       {
         "type": "custom-link",
-        "text": "Realtime Database",
+        "label": "실시간 데이터베이스",
         "link": "/guide/firebase-ios-sdk/realtime-database"
       },
       {
         "type": "custom-link",
-        "text": "Cloud Firestore",
+        "label": "클라우드 파이어스토어",
         "link": "/guide/firebase-ios-sdk/cloud-firestore"
       },
       {
         "type": "custom-link",
-        "text": "Cloud Storage",
+        "label": "클라우드 스토리지",
         "link": "/guide/firebase-ios-sdk/cloud-storage"
       }
     ]
   },
   {
     "type": "custom-link",
-    "text": "상태와 보안",
+    "label": "상태와 보안",
     "link": "/guide/firebase-ios-sdk/snapshots-and-listeners",
     "collapsible": true,
     "collapsed": true,
     "items": [
       {
         "type": "custom-link",
-        "text": "Snapshot과 Listener",
+        "label": "스냅샷과 리스너",
         "link": "/guide/firebase-ios-sdk/snapshots-and-listeners"
       },
       {
         "type": "custom-link",
-        "text": "Security Rules와 Emulator",
+        "label": "보안 규칙과 에뮬레이터",
         "link": "/guide/firebase-ios-sdk/security-rules-and-emulators"
       }
     ]

--- a/docs/guide/naver-maps-sdk/_meta.json
+++ b/docs/guide/naver-maps-sdk/_meta.json
@@ -1,50 +1,50 @@
 [
   {
     "type": "custom-link",
-    "text": "네이버 지도 SDK 시작하기",
+    "label": "네이버 지도 SDK 시작하기",
     "link": "/guide/naver-maps-sdk/index"
   },
   {
     "type": "custom-link",
-    "text": "설치와 지도 표시",
+    "label": "설치와 지도 표시",
     "link": "/guide/naver-maps-sdk/setup-and-authentication",
     "collapsible": true,
     "collapsed": true,
     "items": [
       {
         "type": "custom-link",
-        "text": "설치와 인증",
+        "label": "설치와 인증",
         "link": "/guide/naver-maps-sdk/setup-and-authentication"
       },
       {
         "type": "custom-link",
-        "text": "SwiftUI 화면 연동",
+        "label": "SwiftUI 화면 연동",
         "link": "/guide/naver-maps-sdk/swiftui-integration"
       }
     ]
   },
   {
     "type": "custom-link",
-    "text": "지도 조작과 정보 표현",
+    "label": "지도 조작과 정보 표현",
     "link": "/guide/naver-maps-sdk/map-camera-interaction",
     "collapsible": true,
     "collapsed": true,
     "items": [
       {
         "type": "custom-link",
-        "text": "좌표와 카메라 조작",
+        "label": "좌표와 카메라 조작",
         "link": "/guide/naver-maps-sdk/map-camera-interaction"
       },
       {
         "type": "custom-link",
-        "text": "지도 요소와 마커 묶기",
+        "label": "지도 요소와 마커 묶기",
         "link": "/guide/naver-maps-sdk/overlays-and-clustering"
       }
     ]
   },
   {
     "type": "custom-link",
-    "text": "사용자 위치와 권한",
+    "label": "사용자 위치와 권한",
     "link": "/guide/naver-maps-sdk/user-location"
   }
 ]


### PR DESCRIPTION
## Summary

네이버 지도 SDK와 파이어베이스 iOS SDK 사이드바에서 문서 제목 대신 `/guide/...` 경로가 표시되던 문제를 수정합니다.

## Changes

- `custom-link.text`를 Rspress 스키마에 맞는 `custom-link.label`로 교체
- 네이버 지도와 파이어베이스 사이드바 표시 이름을 한글로 정리
- 기존 URL과 문서 slug는 그대로 유지

## Testing

- `npm run format`
- `npm run lint`
- `npm run build`
- `git diff --check`
- 생성된 정적 HTML에서 사이드바 링크의 한글 표시 이름 확인

## Related Issues

Closes #45
