### PR TITLE
[#47] Mapbox Maps SDK for iOS 학습 문서 섹션을 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -42,6 +42,12 @@
     "position": "left"
   },
   {
+    "text": "Mapbox Maps SDK",
+    "link": "/guide/mapbox-maps-sdk/index",
+    "activeMatch": "/guide/mapbox-maps-sdk/",
+    "position": "left"
+  },
+  {
     "text": "파이어베이스 iOS SDK",
     "link": "/guide/firebase-ios-sdk/index",
     "activeMatch": "/guide/firebase-ios-sdk/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -36,6 +36,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "mapbox-maps-sdk",
+    "label": "Mapbox Maps SDK"
+  },
+  {
+    "type": "dir-section-header",
     "name": "firebase-ios-sdk",
     "label": "파이어베이스 iOS SDK"
   },

--- a/docs/guide/mapbox-maps-sdk/_meta.json
+++ b/docs/guide/mapbox-maps-sdk/_meta.json
@@ -1,0 +1,55 @@
+[
+  {
+    "type": "custom-link",
+    "label": "Mapbox Maps SDK 시작하기",
+    "link": "/guide/mapbox-maps-sdk/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "설치와 화면 구성",
+    "link": "/guide/mapbox-maps-sdk/installation-and-access-token",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "설치와 Access Token",
+        "link": "/guide/mapbox-maps-sdk/installation-and-access-token"
+      },
+      {
+        "type": "custom-link",
+        "label": "SwiftUI 지도와 카메라",
+        "link": "/guide/mapbox-maps-sdk/swiftui-map-and-camera"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "지도 데이터와 표현",
+    "link": "/guide/mapbox-maps-sdk/styles-sources-and-layers",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "스타일·Source·Layer",
+        "link": "/guide/mapbox-maps-sdk/styles-sources-and-layers"
+      },
+      {
+        "type": "custom-link",
+        "label": "Annotation과 클러스터링",
+        "link": "/guide/mapbox-maps-sdk/annotations-and-clustering"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "사용자 위치와 권한",
+    "link": "/guide/mapbox-maps-sdk/user-location"
+  },
+  {
+    "type": "custom-link",
+    "label": "오프라인 지도",
+    "link": "/guide/mapbox-maps-sdk/offline-maps"
+  }
+]

--- a/docs/guide/mapbox-maps-sdk/annotations-and-clustering.md
+++ b/docs/guide/mapbox-maps-sdk/annotations-and-clustering.md
@@ -1,0 +1,285 @@
+---
+title: Mapbox Annotation과 클러스터링
+description: Marker·View Annotation·Layer Annotation의 차이를 비교하고 PointAnnotationGroup과 GeoJSON Source로 많은 지점을 클러스터링하는 기준을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Mapbox Annotation과 클러스터링
+
+> 면접용 한 줄 요약: **소수의 개별 지점은 Annotation으로 빠르게 표현하고, 지점이 많아지면 Layer 기반 그룹이나 GeoJSON Source 클러스터링으로 draw call과 화면 겹침을 줄입니다.**
+
+## 먼저 알아둘 표현 용어
+
+| 용어             | 쉬운 뜻                                                                 |
+| ---------------- | ----------------------------------------------------------------------- |
+| Marker           | SwiftUI에서 기본 핀 모양을 빠르게 만드는 편의 API예요.                  |
+| View Annotation  | 지도 좌표 위에 실제 SwiftUI View나 UIKit View를 배치해요.               |
+| Layer Annotation | `PointAnnotation`, `CircleAnnotation`처럼 지도 Layer로 렌더링해요.      |
+| Annotation Group | 여러 Annotation을 하나의 Layer 구성으로 묶어 효율과 공통 설정을 높여요. |
+| 클러스터링       | 가까운 여러 점을 zoom 수준에 따라 하나의 그룹 점으로 합쳐요.            |
+| cluster radius   | 화면상 어느 거리 안의 점을 같은 cluster로 볼지 정하는 반경이에요.       |
+
+## 세 가지 표현 방법은 비용이 달라요
+
+| 방식             | 장점                                          | 비용·제약                                              | 적합한 상황                           |
+| ---------------- | --------------------------------------------- | ------------------------------------------------------ | ------------------------------------- |
+| Marker           | 기본 핀 자산 없이 가장 빠르게 시작            | SwiftUI 전용이며 현재 experimental, 큰 데이터에 부적합 | 프로토타입과 적은 기본 핀             |
+| View Annotation  | 임의의 SwiftUI View, 복잡한 상호작용          | 지도 Layer보다 무겁고 항상 지도 콘텐츠 위에 표시       | 선택 카드, 가격표, 소수의 복잡한 UI   |
+| Layer Annotation | 지도 renderer가 처리하고 Layer 사이 배치 가능 | 이미지 자산과 지도 스타일 개념이 필요                  | 일반 핀, 선·면, 그룹·클러스터링       |
+| Source + Layer   | 대량 데이터와 표현을 가장 세밀하게 제어       | 설정 코드와 ID 관리가 늘어남                           | 많은 지점, zoom별 집계, 데이터 시각화 |
+
+[공식 SwiftUI 가이드](https://docs.mapbox.com/ios/maps/guides/swift-ui/)는 Layer Annotation이 보통 View Annotation보다 성능에 유리하고, `PointAnnotation`에 한해 클러스터링을 지원한다고 설명합니다.
+
+## 한 개의 지점은 `PointAnnotation`으로 시작해요
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct OnePlaceMap: View {
+  private let cityHall = CLLocationCoordinate2D(
+    latitude: 37.5666,
+    longitude: 126.9784
+  )
+
+  var body: some View {
+    Map(initialViewport: .camera(center: cityHall, zoom: 15)) {
+      PointAnnotation(coordinate: cityHall)
+        .image(named: "place-pin")
+        .iconAnchor(.bottom)
+        .onTapGesture { context in
+          print("선택: \(context.coordinate)")
+          return true
+        }
+    }
+  }
+}
+```
+
+`place-pin`은 Asset Catalog에 있는 이미지 이름이에요. 공식 Annotation 가이드는 `PointAnnotation`이 기본 핀 이미지를 제공하지 않으므로 앱이 자산을 준비해야 한다고 안내합니다.
+
+## SwiftUI View가 꼭 필요할 때만 View Annotation을 사용해요
+
+가격과 선택 상태를 SwiftUI로 꾸미고 싶다면 `MapViewAnnotation`을 사용할 수 있어요.
+
+```swift
+struct PriceTag: View {
+  let price: Int
+
+  var body: some View {
+    Text("\(price.formatted())원")
+      .font(.caption.bold())
+      .padding(.horizontal, 8)
+      .padding(.vertical, 5)
+      .background(.white)
+      .foregroundStyle(.black)
+      .clipShape(Capsule())
+      .shadow(radius: 2)
+  }
+}
+
+Map {
+  MapViewAnnotation(coordinate: cityHall) {
+    PriceTag(price: 12_000)
+  }
+  .allowOverlap(false)
+}
+```
+
+View Annotation은 UIKit/SwiftUI View 계층의 비용을 가져요. 지도에 가격표 수백 개를 항상 띄우기보다 화면 안의 선택 항목이나 제한된 수만 표시하고, 나머지는 Layer Annotation이나 cluster로 표현하는 방식을 검토합니다.
+
+## 배열은 `PointAnnotationGroup`으로 묶어요
+
+같은 종류의 장소를 안정적인 ID로 그룹에 전달합니다.
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct Place: Identifiable {
+  let id: UUID
+  let name: String
+  let coordinate: CLLocationCoordinate2D
+}
+
+struct PlacesMap: View {
+  let places: [Place]
+
+  var body: some View {
+    Map {
+      PointAnnotationGroup(places, id: \.id) { place in
+        PointAnnotation(coordinate: place.coordinate)
+          .image(named: "place-pin")
+          .iconAnchor(.bottom)
+      }
+      .iconAllowOverlap(false)
+    }
+  }
+}
+```
+
+Group은 여러 Annotation을 하나의 Layer로 렌더링하고 group 공통 설정을 적용할 수 있어요. 배열 index보다 서버 ID나 UUID처럼 삽입·삭제 후에도 같은 장소를 가리키는 식별자를 사용하세요.
+
+## 기본 클러스터링은 `ClusterOptions`로 켜요
+
+`PointAnnotationGroup`에 cluster 설정을 추가하면 가까운 지점을 묶을 수 있습니다.
+
+```swift
+Map {
+  PointAnnotationGroup(places, id: \.id) { place in
+    PointAnnotation(coordinate: place.coordinate)
+      .image(named: "place-pin")
+      .iconAnchor(.bottom)
+  }
+  .clusterOptions(
+    ClusterOptions(
+      circleRadius: .constant(22),
+      circleColor: .constant(StyleColor(.systemBlue)),
+      textColor: .constant(StyleColor(.white)),
+      textSize: .constant(13),
+      clusterRadius: 60,
+      clusterMaxZoom: 14,
+      clusterMinPoints: 2
+    )
+  )
+}
+```
+
+- `clusterRadius`는 가까운 점을 어느 화면 반경까지 묶을지 정해요.
+- `clusterMaxZoom`보다 더 확대하면 cluster를 풀어 개별 점을 보여줘요.
+- `clusterMinPoints`는 몇 개부터 cluster로 만들지 정해요.
+- 원 크기와 색은 Expression으로 `point_count`에 따라 바꿀 수 있어요.
+
+cluster 옵션과 Layer 위치는 Group이 생성된 뒤 자유롭게 바꾸는 일반 View 상태와 다를 수 있어요. SDK 버전의 API Reference를 확인하고, 설정 자체가 바뀌어야 한다면 명시적인 identity 변경이나 Source·Layer 방식으로 수명 주기를 설계합니다.
+
+## cluster를 누르면 확장 zoom으로 이동해요
+
+사용자가 cluster를 눌렀을 때 무조건 `zoom + 1`을 적용하면 일부 점이 계속 겹칠 수 있어요. 지도 엔진이 계산한 cluster expansion zoom을 조회하는 편이 정확합니다.
+
+```swift
+MapReader { proxy in
+  Map(viewport: $viewport) {
+    TapInteraction(.layer("cluster-circle-layer")) { feature, context in
+      proxy.map?.getGeoJsonClusterExpansionZoom(
+        forSourceId: "places-source",
+        feature: feature.originalFeature
+      ) { result in
+        guard
+          case let .success(value) = result,
+          let zoom = value.value as? Double
+        else { return }
+
+        withViewportAnimation(.easeIn(duration: 0.4)) {
+          viewport = .camera(
+            center: context.coordinate,
+            zoom: zoom
+          )
+        }
+      }
+
+      return true
+    }
+  }
+}
+```
+
+이 예제는 `places-source`와 `cluster-circle-layer`를 Source·Layer로 구성한 고급 방식의 interaction 부분이에요. `MapReader`로 내부 map에 cluster 질의를 보내고 결과로 카메라를 이동합니다.
+
+## 고급 클러스터링은 Source와 세 Layer로 구성해요
+
+색, 집계 속성, 탭 대상, 아이콘을 완전히 제어하려면 `GeoJSONSource`의 cluster를 켜고 보통 다음 Layer를 둡니다.
+
+```text
+GeoJSONSource(cluster = true)
+  ├─ CircleLayer: point_count가 있는 cluster 원
+  ├─ SymbolLayer: cluster 안의 point_count 글자
+  └─ SymbolLayer: point_count가 없는 개별 지점 아이콘
+```
+
+핵심 설정은 다음과 같아요.
+
+```swift
+var source = GeoJSONSource(id: "places-source")
+source.data = .featureCollection(placeFeatures)
+source.cluster = true
+source.clusterRadius = 60
+source.clusterMaxZoom = 14
+
+var clusters = CircleLayer(
+  id: "cluster-circle-layer",
+  source: "places-source"
+)
+clusters.filter = Exp(.has) { "point_count" }
+clusters.circleRadius = .constant(22)
+clusters.circleColor = .constant(StyleColor(.systemBlue))
+
+var individualPlaces = CircleLayer(
+  id: "individual-place-layer",
+  source: "places-source"
+)
+individualPlaces.filter = Exp(.not) {
+  Exp(.has) { "point_count" }
+}
+individualPlaces.circleRadius = .constant(7)
+individualPlaces.circleColor = .constant(StyleColor(.systemOrange))
+```
+
+실제 지도에는 Source를 먼저 추가한 뒤 cluster 원, 개수 글자, 개별 지점 Layer를 순서대로 추가해야 해요. SwiftUI에서는 선언형 Map Styling으로 같은 구조를 표현할 수 있고, 명령형 API를 사용한다면 Style reload와 중복 ID를 직접 관리합니다.
+
+## 클러스터링이 성능 문제를 모두 해결하지는 않아요
+
+클러스터링은 화면에 그릴 점 수와 겹침을 줄이지만 원본 데이터 다운로드와 GeoJSON 해석 비용까지 없애지는 않습니다.
+
+- 도시 전체 데이터를 하나의 거대한 GeoJSON으로 받는다면 network와 decoding 비용은 남아요.
+- cluster Source를 매 프레임 새로 만들면 갱신 비용이 커져요.
+- 이미지가 크고 다양하면 texture와 메모리 비용이 늘어요.
+- 화면 밖 데이터까지 앱 메모리에 모두 유지하면 초기 로딩이 느려질 수 있어요.
+
+데이터가 매우 크면 서버 측 Tileset이나 Vector Tile로 공간 분할하고, 현재 카메라 영역에 필요한 데이터만 읽는 구조를 검토하세요. 숫자 하나를 절대 기준으로 정하기보다 Instruments에서 로딩 시간, 메모리, 프레임 드롭과 실제 기기 성능을 측정합니다.
+
+## 삭제와 선택 상태도 데이터로 표현해요
+
+SwiftUI에서는 배열에서 `Place`가 사라지면 Group의 해당 Annotation도 사라져요. 지도 객체를 별도 Dictionary에 중복 저장하기보다 장소 배열을 single source of truth로 두는 편이 단순합니다.
+
+선택 상태는 다음 중 하나로 표현할 수 있어요.
+
+- 선택된 한 항목만 `MapViewAnnotation` 카드로 추가해요.
+- 선택 여부를 Feature 속성으로 넣고 Expression에서 색을 바꿔요.
+- 선택 Layer를 별도로 두어 일반 Layer 위에 그려요.
+
+모든 핀을 View Annotation으로 바꾸는 방식은 선택 하나 때문에 전체 렌더링 비용을 높일 수 있습니다.
+
+## 적용 기준을 정리해요
+
+1. 소수의 단순 핀은 `PointAnnotation`으로 시작해요.
+2. 같은 종류의 배열은 안정적인 ID를 가진 Group으로 묶어요.
+3. 복잡한 SwiftUI UI는 화면에 필요한 소수만 View Annotation으로 올려요.
+4. 점이 겹치기 시작하면 `ClusterOptions`로 기본 cluster를 적용해요.
+5. cluster 색·집계·탭 동작이 복잡하면 GeoJSON Source와 Layer로 내려가요.
+6. 원본 데이터가 크면 Vector Tile과 영역 단위 조회를 검토해요.
+7. 실제 기기에서 프레임 시간과 메모리를 측정해 선택을 검증해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### View Annotation이 Layer Annotation보다 느릴 수 있는 이유는 무엇인가요?
+
+View Annotation은 각 항목이 UIKit·SwiftUI View 계층과 layout 비용을 가져요. Layer Annotation은 지도 renderer가 하나의 Layer에서 처리할 수 있어 많은 항목에 일반적으로 더 적합합니다.
+
+### 클러스터링과 필터링은 어떤 차이가 있나요?
+
+클러스터링은 가까운 여러 점을 zoom에 따라 집계 Feature로 바꾸고 `point_count` 같은 속성을 만듭니다. 필터링은 조건에 맞는 Feature만 특정 Layer가 그리게 할 뿐 여러 점을 하나로 합치지는 않아요.
+
+### `PointAnnotationGroup`과 GeoJSON Source 방식 중 무엇을 선택하나요?
+
+기본 cluster와 개별 Annotation 스타일이면 Group이 단순합니다. cluster별 Expression, 집계 속성, Layer 순서와 탭 동작을 세밀하게 제어하거나 데이터가 커지면 GeoJSON Source와 Layer 구성이 더 적합해요.
+
+## 참고 자료
+
+- [Mapbox Annotations 가이드](https://docs.mapbox.com/ios/maps/guides/add-your-data/annotations/)
+- [Mapbox SwiftUI Annotation 가이드](https://docs.mapbox.com/ios/maps/guides/swift-ui/#annotations)
+- [Mapbox SwiftUI 클러스터링 공식 예제](https://docs.mapbox.com/ios/maps/examples/swiftui-clustering/)
+- [Map Content Gestures](https://docs.mapbox.com/ios/maps/guides/user-interaction/map-content-gestures/)
+- [`PointAnnotationGroup` API Reference](https://docs.mapbox.com/ios/maps/api/latest/documentation/mapboxmaps/pointannotationgroup/)
+- [`ClusterOptions` API Reference](https://docs.mapbox.com/ios/maps/api/latest/documentation/mapboxmaps/clusteroptions/)
+- [Source와 Layer 다루기](https://docs.mapbox.com/ios/maps/guides/styles/work-with-layers/)

--- a/docs/guide/mapbox-maps-sdk/index.md
+++ b/docs/guide/mapbox-maps-sdk/index.md
@@ -1,0 +1,162 @@
+---
+title: Swift로 이해하는 Mapbox Maps SDK for iOS
+description: Mapbox Maps SDK의 지도 렌더링 구조와 Navigation·Search SDK의 경계를 구분하고 설치부터 오프라인 지도까지의 학습 순서를 정리합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Mapbox Maps SDK for iOS
+
+> 면접용 한 줄 요약: **Mapbox Maps SDK는 Style이 참조하는 지리 데이터를 Source에서 읽어 Layer 규칙대로 Metal로 그리며, SwiftUI에서는 `Map`과 `Viewport`로 화면과 카메라를 선언적으로 구성하는 지도 렌더링 SDK입니다.**
+
+## 먼저 제품의 역할부터 구분해요
+
+Mapbox에는 지도 화면 외에도 검색, 길 안내, 지도 디자인을 담당하는 제품이 있어요. Maps SDK 하나를 설치했다고 장소 검색이나 턴 바이 턴 내비게이션까지 자동으로 생기지는 않습니다.
+
+| 만들 기능               | 선택할 제품                | 핵심 역할                                  |
+| ----------------------- | -------------------------- | ------------------------------------------ |
+| 앱 안의 대화형 지도     | Maps SDK for iOS           | 지도 렌더링, 카메라, 제스처, 데이터 표현   |
+| 주소·장소 검색          | Search SDK 또는 Search API | 검색어와 주변 위치를 장소 결과로 변환      |
+| 경로 계산과 길 안내     | Navigation SDK             | 경로, 진행 상태, 음성 안내와 내비게이션 UI |
+| 지도의 색·데이터 디자인 | Mapbox Studio              | Style과 Tileset을 웹에서 제작·게시         |
+| 고정된 지도 이미지      | Static Images API          | 상호작용 없는 지도 이미지를 생성           |
+
+앱의 전체 흐름을 단순화하면 다음과 같아요.
+
+```text
+SwiftUI Map / UIKit MapView
+          │
+          ▼
+       Map Style
+          │
+    ┌─────┴─────┐
+    ▼           ▼
+  Source      Layer
+(어디의 어떤 데이터)  (어떻게 그릴지)
+    └─────┬─────┘
+          ▼
+      Metal 렌더링
+
+검색어 ──> Search SDK/API ──> 좌표·장소 ──> Maps SDK에 표현
+목적지 ──> Navigation SDK ──> 경로·안내 ──> 지도 위에 표현
+```
+
+[공식 Maps SDK 저장소](https://github.com/mapbox/mapbox-maps-ios)는 SDK가 Mapbox Style Specification에 맞는 스타일과 Vector Tile 데이터를 받아 Metal로 렌더링한다고 설명합니다. 지도 화면은 Maps SDK가 맡고, 검색이나 경로 계산 결과를 지도에 어떻게 보여줄지는 앱이 연결해요.
+
+## 먼저 알아둘 용어
+
+| 용어         | 쉬운 뜻                                                                                |
+| ------------ | -------------------------------------------------------------------------------------- |
+| Style        | 배경 지도와 데이터의 색, 글꼴, 배치, 표시 규칙을 묶은 지도 설계도예요.                 |
+| Source       | GeoJSON, Vector Tile, Raster처럼 지도에 그릴 원본 데이터를 제공해요.                   |
+| Layer        | Source의 점·선·면을 어떤 색과 크기, 순서로 그릴지 정해요.                              |
+| Feature      | 위치와 속성을 함께 가진 지리 데이터 한 건이에요.                                       |
+| Annotation   | 좌표에 핀, 원, 선, 다각형이나 SwiftUI View를 비교적 간단히 올리는 API예요.             |
+| Camera       | 지도에서 바라보는 중심 좌표, 확대 수준, 회전, 기울기, 여백을 묶은 상태예요.            |
+| Viewport     | 고정 카메라, 사용자 위치 추적, 영역 전체 보기처럼 카메라의 목적을 나타내는 추상화예요. |
+| Access Token | Mapbox 리소스를 어떤 권한으로 요청할 수 있는지 나타내는 문자열이에요.                  |
+
+## Mapbox의 강점은 데이터와 표현을 분리하는 데 있어요
+
+장소 세 곳을 지도에 표시한다고 생각해 볼게요. 작은 데이터라면 `PointAnnotation`으로 빠르게 시작할 수 있습니다. 데이터가 커지거나 줌 수준에 따라 모양을 바꾸려면 Source와 Layer를 사용해요.
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct StoreMap: View {
+  private let cityHall = CLLocationCoordinate2D(
+    latitude: 37.5666,
+    longitude: 126.9784
+  )
+
+  var body: some View {
+    Map(initialViewport: .camera(center: cityHall, zoom: 13)) {
+      PointAnnotation(coordinate: cityHall)
+        .image(named: "store-pin")
+        .iconAnchor(.bottom)
+    }
+    .mapStyle(.standard)
+  }
+}
+```
+
+이 예제에서 좌표와 이미지가 바뀌어도 배경 지도 Style은 그대로 둘 수 있어요. 반대로 같은 데이터에 `CircleLayer`, `SymbolLayer`, `HeatmapLayer`를 적용하면 앱 모델을 다시 설계하지 않고 표현 방식을 바꿀 수 있습니다.
+
+## Maps SDK와 Apple MapKit은 같은 타입이 아니에요
+
+두 프레임워크 모두 지도를 표시하지만 타입과 데이터 생태계가 다릅니다. Mapbox의 `Map`, `Viewport`, `PointAnnotation`은 SwiftUI MapKit의 같은 이름과 호환되지 않아요. 한 파일에서 두 프레임워크를 함께 import하면 `Map` 같은 이름이 모호해질 수 있으므로 모듈 접두어를 사용하거나 지도 화면의 import 범위를 좁히세요.
+
+선택할 때는 다음 질문부터 확인합니다.
+
+- Mapbox Studio로 만든 Style과 Tileset이 필요한가요?
+- Source·Layer·Expression을 사용한 데이터 시각화가 중요한가요?
+- 오프라인 영역을 앱이 직접 내려받아 관리해야 하나요?
+- Search와 Navigation을 포함한 Mapbox 제품군을 함께 사용할 계획인가요?
+- 외부 서비스 비용과 attribution·telemetry 운영 조건을 감당할 수 있나요?
+
+플랫폼 기본 지도만으로 요구 사항을 충족한다면 외부 의존성과 토큰 관리가 없는 MapKit이 더 단순할 수 있어요. 반대로 브랜드 전용 지도 스타일과 복잡한 지리 데이터 표현이 핵심이면 Mapbox의 Source·Layer 구조가 잘 맞습니다.
+
+## 일곱 페이지로 나눈 이유
+
+토큰, SwiftUI 상태, 렌더링 데이터, 위치 권한, 오프라인 저장은 실패 원인과 수명 주기가 달라요. 다음 순서로 학습하면 각 책임을 분리하기 쉽습니다.
+
+1. [설치와 Access Token](/guide/mapbox-maps-sdk/installation-and-access-token)에서 SPM과 공개·비밀 Token의 경계를 확인해요.
+2. [SwiftUI 지도와 카메라](/guide/mapbox-maps-sdk/swiftui-map-and-camera)에서 `Map`, `Viewport`, 이벤트를 연결해요.
+3. [스타일·Source·Layer](/guide/mapbox-maps-sdk/styles-sources-and-layers)에서 지도 데이터와 표현 규칙을 나눠요.
+4. [Annotation과 클러스터링](/guide/mapbox-maps-sdk/annotations-and-clustering)에서 적은 핀과 대량 지점을 다르게 다뤄요.
+5. [사용자 위치와 권한](/guide/mapbox-maps-sdk/user-location)에서 `Puck2D`와 위치 추적을 연결해요.
+6. [오프라인 지도](/guide/mapbox-maps-sdk/offline-maps)에서 Style Pack과 Tile Region의 다운로드 수명 주기를 배워요.
+
+첫 페이지를 포함해 총 7개 문서예요.
+
+## 버전 숫자는 선택한 패키지와 함께 확인해요
+
+2026년 8월에 확인한 [공식 시작 페이지](https://docs.mapbox.com/ios/maps/guides/)는 Maps SDK `11.28.2`, iOS 14 이상, Swift 5.9 이상을 안내합니다. 이 숫자를 영구적인 최신 버전으로 외우기보다 프로젝트가 실제로 선택한 패키지 버전의 릴리스 노트와 요구 사항을 확인하세요.
+
+v6의 `MGLMapView` 예제와 v10·v11의 `MapView` 예제는 API가 크게 달라요. 검색으로 찾은 코드에 `MGL` 접두어가 보이면 현재 v11 문서인지 먼저 확인합니다.
+
+## 출시 전에 법적·운영 조건을 확인해요
+
+[공식 조건 안내](https://docs.mapbox.com/ios/maps/guides/#conditions)에 따르면 Mapbox 지도를 사용할 때 wordmark와 attribution을 표시해야 하며, Mapbox 데이터가 전혀 없는 예외를 제외하면 attribution을 임의로 없애면 안 됩니다. 기본 attribution control은 telemetry opt-out 경로도 제공합니다.
+
+기본 control을 숨기거나 커스텀 UI로 바꾼다면 다음을 제품·법무 체크리스트에 포함하세요.
+
+- Mapbox wordmark와 데이터 출처를 읽을 수 있게 유지했나요?
+- attribution에 필요한 링크와 현재 카메라 정보를 제공하나요?
+- 사용자가 telemetry를 개별적으로 끌 수 있는 경로가 있나요?
+- 예상 월간 사용자와 지도 로드, 오프라인 사용량을 현재 가격 정책으로 계산했나요?
+
+가격과 약관은 바뀔 수 있으므로 출시 시점의 [Mapbox 계정·가격 문서](https://docs.mapbox.com/accounts/)와 계약을 다시 확인합니다.
+
+## 시작 전 체크리스트
+
+- [ ] Maps, Search, Navigation SDK의 책임을 구분했나요?
+- [ ] 실제 비밀 Token을 앱 번들이나 저장소에 넣지 않았나요?
+- [ ] Style, Source, Layer와 Annotation 중 데이터 규모에 맞는 표현을 골랐나요?
+- [ ] 카메라 변경 이벤트를 매 프레임 SwiftUI 상태로 복사하지 않나요?
+- [ ] 위치 권한과 오프라인 저장의 사용자 가치를 설명할 수 있나요?
+- [ ] attribution, telemetry와 비용 정책을 출시 전에 검토했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Source와 Layer는 왜 분리하나요?
+
+Source는 데이터가 어디에 있고 어떤 지리 정보인지 정의하며, Layer는 그 데이터를 어떻게 그릴지 정합니다. 하나의 Source를 여러 Layer가 공유할 수 있어 같은 데이터를 점, 라벨, 열 지도처럼 서로 다른 방식으로 표현할 수 있어요.
+
+### Maps SDK만으로 장소 검색과 길 안내가 가능한가요?
+
+Maps SDK의 주 역할은 지도 렌더링과 상호작용입니다. 장소 검색은 Search 제품, 경로와 턴 바이 턴 안내는 Navigation 제품이 담당하며 앱이 결과를 Maps SDK 화면에 연결합니다.
+
+### 공개 Access Token도 숨겨야 하나요?
+
+공개 `pk` Token은 모바일 클라이언트에서 사용하는 제한된 권한의 값이라 최종 앱에서 추출될 수 있습니다. 저장소 노출은 피하고 환경별 최소 권한 Token을 사용하되, 쓰기 권한이 있는 비밀 `sk` Token은 절대 앱에 포함하지 않아야 해요.
+
+## 참고 자료
+
+- [Mapbox Maps SDK for iOS 공식 가이드](https://docs.mapbox.com/ios/maps/guides/)
+- [Mapbox Maps SDK for iOS 공식 저장소](https://github.com/mapbox/mapbox-maps-ios)
+- [Mapbox Maps SDK SwiftUI 가이드](https://docs.mapbox.com/ios/maps/guides/swift-ui/)
+- [Mapbox Style Specification](https://docs.mapbox.com/style-spec/)
+- [Mapbox attribution 안내](https://docs.mapbox.com/help/dive-deeper/attribution/)
+- [Mapbox 모바일 앱과 telemetry 안내](https://docs.mapbox.com/help/dive-deeper/mobile-apps/)

--- a/docs/guide/mapbox-maps-sdk/installation-and-access-token.md
+++ b/docs/guide/mapbox-maps-sdk/installation-and-access-token.md
@@ -1,0 +1,212 @@
+---
+title: Mapbox Maps SDK 설치와 Access Token
+description: Swift Package Manager로 Mapbox Maps SDK를 설치하고 공개·비밀 Access Token을 구분해 Info.plist와 빌드 환경에 안전하게 연결하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Mapbox Maps SDK 설치와 Access Token
+
+> 면접용 한 줄 요약: **Mapbox 지도는 앱 시작 전에 읽기 권한의 공개 `pk` Token이 필요하며, 계정 변경 권한이 있는 비밀 `sk` Token은 서버·CI 같은 보호된 환경에만 두어야 합니다.**
+
+## 먼저 알아둘 설치 용어
+
+| 용어                       | 쉬운 뜻                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| Swift Package Manager(SPM) | Xcode가 Swift 패키지의 버전과 의존성을 내려받아 프로젝트에 연결하는 도구예요. |
+| Access Token               | Mapbox 리소스 요청의 계정과 허용 동작을 식별하는 문자열이에요.                |
+| Scope                      | `styles:read`, `downloads:read`처럼 Token에 허용한 작업 범위예요.             |
+| `Info.plist`               | 앱의 설정과 권한 설명을 번들에 담는 속성 목록 파일이에요.                     |
+| `.xcconfig`                | 빌드 구성별 값을 Xcode Build Setting으로 주입하는 텍스트 설정 파일이에요.     |
+
+## 1단계: 지원 환경을 확인해요
+
+2026년 8월에 확인한 [공식 Maps SDK 페이지](https://docs.mapbox.com/ios/maps/guides/)는 다음 요구 사항을 안내합니다.
+
+- iOS 14 이상
+- Swift 5.9 이상
+- Maps SDK v11에는 Xcode 16 이상
+
+현재 공식 문서의 버전은 `11.28.2`지만, 새 버전이 배포되면 달라질 수 있어요. 프로젝트가 선택한 버전의 [changelog](https://github.com/mapbox/mapbox-maps-ios/blob/main/CHANGELOG.md)와 Package Resolution을 기준으로 실제 지원 범위를 확인합니다.
+
+## 2단계: SPM으로 패키지를 추가해요
+
+Xcode에서 **File → Add Package Dependencies…**를 열고 공식 저장소 URL을 입력합니다.
+
+```text
+https://github.com/mapbox/mapbox-maps-ios.git
+```
+
+[공식 설치 가이드](https://docs.mapbox.com/ios/maps/guides/install/)는 `11.0.0`부터 **Up to Next Major Version** 규칙을 사용하는 방법을 예로 듭니다. 팀이 업데이트 전에 회귀 테스트를 거쳐야 한다면 Exact Version이나 별도 버전 고정 정책을 선택할 수 있어요.
+
+소스 빌드 시간이 부담되면 공식 pre-built XCFramework 패키지도 검토할 수 있습니다.
+
+```text
+https://github.com/mapbox/mapbox-maps-ios-binary.git
+```
+
+공식 안내에 따르면 binary 배포는 `11.20.0`부터 제공되며 소스 저장소와 같은 버전 번호를 사용해요. 어느 배포 방식을 선택하든 앱 Target에 `MapboxMaps` 제품이 연결되었는지 확인합니다.
+
+:::warning CocoaPods 신규 도입은 피하는 편이 좋아요
+Mapbox는 2026년 12월에 Maps SDK for iOS의 CocoaPods 배포 지원을 종료할 예정이라고 안내합니다. 기존 프로젝트라면 마이그레이션 일정을 세우고, 새 프로젝트는 SPM을 우선 검토하세요.
+:::
+
+## 3단계: 앱 전용 공개 Token을 만들어요
+
+Mapbox 계정의 Access Tokens 화면에서 앱과 환경을 구분한 공개 Token을 만들어요. 지도 Style과 글꼴을 읽으려면 보통 `styles:read`, `fonts:read` 같은 공개 scope가 필요합니다.
+
+Token은 접두어와 권한에 따라 역할이 달라요.
+
+| 종류      | 접두어 | 두는 위치                    | 대표 용도                                         |
+| --------- | ------ | ---------------------------- | ------------------------------------------------- |
+| Public    | `pk`   | 모바일 앱·웹 클라이언트      | Style, 글꼴, 공개 리소스 읽기                     |
+| Secret    | `sk`   | 서버, 비밀 저장소, 보호된 CI | Style 쓰기, 업로드, Token 관리, 일부 SDK 다운로드 |
+| Temporary | `tk`   | 짧은 서버 작업               | 최대 1시간처럼 제한된 임시 권한                   |
+
+[공식 Token 관리 문서](https://docs.mapbox.com/accounts/guides/tokens/)는 비밀 scope가 있는 Token을 클라이언트에 노출하지 말고 서버에서만 사용하라고 설명합니다. 모바일 앱에 필요한 것은 공개 Token이에요.
+
+:::danger `sk` Token은 `Info.plist`에 넣지 않아요
+앱 번들과 설치된 바이너리는 사용자가 분석할 수 있습니다. `.xcconfig`나 난독화 문자열로 옮겨도 비밀 `sk` Token을 안전하게 숨길 수 없어요. 쓰기·관리 권한이 필요한 요청은 서버에서 수행하세요.
+:::
+
+## 4단계: `MBXAccessToken`을 설정해요
+
+가장 단순한 방법은 앱 Target의 `Info.plist`에 공개 Token을 넣는 것입니다.
+
+```xml
+<key>MBXAccessToken</key>
+<string>$(MAPBOX_PUBLIC_TOKEN)</string>
+```
+
+실제 값은 빌드 구성에서 주입할 수 있어요.
+
+```text
+// Config/Debug.xcconfig — 저장소에는 실제 값 대신 예시 파일만 둬요.
+MAPBOX_PUBLIC_TOKEN = YOUR_PUBLIC_MAPBOX_ACCESS_TOKEN
+```
+
+`.xcconfig`를 사용하면 개발·스테이징·운영 값을 나누고 Git 실수를 줄일 수 있지만, 최종 앱에서 공개 Token 자체를 숨기는 보안 장치는 아니에요. 공개 Token은 최소 scope와 환경 분리, 사용량 모니터링, 교체 절차로 관리합니다.
+
+오픈 소스 프로젝트라면 [모바일 Token 보관 공식 가이드](https://docs.mapbox.com/help/dive-deeper/private-access-token-android-and-ios/)처럼 실제 값을 버전 관리 밖의 파일에 두고 `.gitignore`로 제외하세요. 저장소에는 `Config.example.xcconfig`처럼 키 이름만 있는 예시를 남길 수 있습니다.
+
+## 코드에서 주입할 수도 있어요
+
+서버에서 공개 Token을 받아 교체하는 고급 구성이 필요하면 첫 `Map`이나 `MapView`를 만들기 전에 설정합니다.
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+@main
+struct MapSampleApp: App {
+  init() {
+    // 예제 값이에요. 실제 앱은 안전한 구성 계층에서 공개 Token을 읽어요.
+    MapboxOptions.accessToken = "YOUR_PUBLIC_MAPBOX_ACCESS_TOKEN"
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}
+```
+
+`MapboxOptions.accessToken`은 Mapbox SDK들이 공유하는 설정이에요. 지도 생성 후에 값을 바꾸기보다 앱의 composition root에서 먼저 구성하세요.
+
+## 첫 지도를 표시해요
+
+Token과 패키지를 연결한 뒤 서울시청을 중심으로 지도를 띄워 봅니다.
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct ContentView: View {
+  private let seoulCityHall = CLLocationCoordinate2D(
+    latitude: 37.5666,
+    longitude: 126.9784
+  )
+
+  var body: some View {
+    Map(
+      initialViewport: .camera(
+        center: seoulCityHall,
+        zoom: 13,
+        bearing: 0,
+        pitch: 0
+      )
+    )
+    .mapStyle(.standard)
+    .ignoresSafeArea()
+  }
+}
+```
+
+빈 화면이 보이면 SwiftUI 레이아웃보다 먼저 Token과 Target 연결을 확인하세요.
+
+## 설치용 비밀 Token이 등장하는 경우를 구분해요
+
+과거 버전이나 특정 binary 다운로드 경로의 공식 troubleshooting은 `downloads:read` scope가 있는 비밀 Token을 `~/.netrc`나 CI secret에 두도록 안내할 수 있어요. 이 Token은 **SDK 파일을 받는 빌드 환경용**이며 지도 실행에 쓰는 공개 Token과 다릅니다.
+
+```text
+machine api.mapbox.com
+  login mapbox
+  password YOUR_SECRET_DOWNLOAD_TOKEN
+```
+
+이 예시는 위치와 형식만 보여 줍니다. 실제 `sk` 값을 저장소, PR, CI 로그에 남기면 안 돼요. 현재 공식 source SPM 저장소로 정상 설치된다면 불필요한 비밀 Token을 추가하지 않습니다.
+
+## Token을 제한할 때 모바일의 특성을 알아둬요
+
+Mapbox의 URL restriction은 웹 요청의 origin을 제한하는 기능입니다. [Tokens API 문서](https://docs.mapbox.com/api/accounts/tokens/)는 URL restriction을 추가한 Token이 native mobile SDK와 호환되지 않는다고 안내해요. iOS 앱 Token에는 웹 URL 제한을 그대로 적용하지 말고 다음 방어를 조합합니다.
+
+- 앱·환경마다 별도 공개 Token을 발급해 영향 범위를 줄여요.
+- 지도 표시와 관계없는 scope를 제거해요.
+- Statistics에서 비정상 사용량을 확인해요.
+- 문제가 생기면 새 Token 배포 후 이전 Token을 폐기해요.
+- 쓰기·관리 기능은 비밀 Token을 가진 서버로 이동해요.
+
+## 흔한 실패를 순서대로 진단해요
+
+| 증상                          | 먼저 확인할 것                                                                           |
+| ----------------------------- | ---------------------------------------------------------------------------------------- |
+| `No such module 'MapboxMaps'` | 앱 Target에 `MapboxMaps` 제품이 연결되었는지 확인해요.                                   |
+| 지도 타일이 비어 있음         | `MBXAccessToken` 이름, 공개 Token 값과 `styles:read` 권한을 확인해요.                    |
+| package 다운로드 401          | 선택한 배포 경로의 공식 설치 안내가 `downloads:read` 비밀 Token을 요구하는지 확인해요.   |
+| Simulator에서 실행되지 않음   | 실행 대상을 구체적인 iOS Simulator로 선택했는지 확인해요.                                |
+| 운영에서만 실패               | Release `.xcconfig`가 `Info.plist` 변수에 연결되는지 Archive의 build setting을 확인해요. |
+
+## 적용 순서를 정리해요
+
+1. 선택할 SDK 버전의 iOS·Swift·Xcode 조건을 확인해요.
+2. 공식 source 또는 binary SPM 패키지를 앱 Target에 연결해요.
+3. 환경별 최소 scope의 공개 `pk` Token을 만들어요.
+4. 실제 값은 버전 관리 밖에서 `MBXAccessToken`으로 주입해요.
+5. 첫 지도 생성 전에 Token이 준비되는지 확인해요.
+6. 비밀 `sk` Token은 서버·CI secret 밖으로 나오지 않게 해요.
+7. 실제 기기와 Release 구성에서도 지도 로드와 attribution을 점검해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 공개 Token을 Git에 커밋해도 괜찮나요?
+
+공개 Token은 클라이언트 사용을 전제로 하므로 최종 앱에서 완전히 숨길 수는 없지만, 저장소에 직접 커밋할 이유는 없습니다. 환경별 최소 권한 Token을 버전 관리 밖에서 주입하면 실수와 교체 범위를 줄일 수 있어요.
+
+### `Info.plist`와 `MapboxOptions.accessToken` 중 무엇을 선택하나요?
+
+고정된 앱 구성이면 `MBXAccessToken`이 가장 단순합니다. 서버에서 공개 Token을 받아 회전시키는 등 런타임 구성이 필요하면 첫 지도 생성 전에 `MapboxOptions.accessToken`을 설정하되, 초기화 실패와 오프라인 시작 정책까지 함께 설계해야 해요.
+
+### `downloads:read` Token과 지도 실행 Token은 같은가요?
+
+아니요. `downloads:read`는 일부 SDK 배포물을 내려받는 빌드 환경용 비밀 권한이고, 지도 실행에는 공개 읽기 Token을 사용합니다. 비밀 다운로드 Token을 앱에 포함하면 안 됩니다.
+
+## 참고 자료
+
+- [Mapbox Maps SDK for iOS 설치 가이드](https://docs.mapbox.com/ios/maps/guides/install/)
+- [Mapbox Maps SDK for iOS 요구 사항](https://docs.mapbox.com/ios/maps/guides/)
+- [Mapbox Token 관리](https://docs.mapbox.com/accounts/guides/tokens/)
+- [Mapbox Access Tokens 설명](https://docs.mapbox.com/help/dive-deeper/access-tokens/)
+- [오픈 소스 모바일 앱의 Token 보관](https://docs.mapbox.com/help/dive-deeper/private-access-token-android-and-ios/)
+- [iOS SDK 설치 문제 해결](https://docs.mapbox.com/help/troubleshooting/ios-sdk-installation/)
+- [Mapbox Maps SDK 공식 저장소](https://github.com/mapbox/mapbox-maps-ios)

--- a/docs/guide/mapbox-maps-sdk/offline-maps.md
+++ b/docs/guide/mapbox-maps-sdk/offline-maps.md
@@ -1,0 +1,300 @@
+---
+title: Mapbox 오프라인 지도
+description: OfflineManager의 Style Pack과 TileStore의 Tile Region을 구분하고 영역·zoom별 다운로드, 진행률, 갱신, 삭제와 저장 공간 정책을 설계하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Mapbox 오프라인 지도
+
+> 면접용 한 줄 요약: **Mapbox 오프라인 지도는 Style Pack으로 글꼴·sprite 같은 표현 리소스를, Tile Region으로 지정 영역과 zoom의 지도 타일을 내려받아 두 수명 주기를 함께 관리합니다.**
+
+## 먼저 알아둘 오프라인 용어
+
+| 용어               | 쉬운 뜻                                                                    |
+| ------------------ | -------------------------------------------------------------------------- |
+| Style Pack         | Style 정의, sprite, 글꼴 등 타일이 아닌 렌더링 리소스 묶음이에요.          |
+| Tile Pack          | 특정 Tileset의 여러 지도 tile을 저장하는 내부 묶음이에요.                  |
+| Tile Region        | 영역 geometry와 zoom 범위에 필요한 Tile Pack을 다운로드·관리하는 단위예요. |
+| `OfflineManager`   | Style Pack을 관리하고 Tile 다운로드용 descriptor를 만들어요.               |
+| `TileStore`        | Tile Region을 저장, 조회, 갱신, 삭제해요.                                  |
+| Tileset descriptor | 어떤 Style과 zoom 범위의 tile이 필요한지 설명해요.                         |
+| `acceptExpired`    | 만료된 리소스를 그대로 허용할지 정하는 옵션이에요.                         |
+
+## 캐시와 오프라인 다운로드는 달라요
+
+온라인에서 한 번 본 지도 tile이 disk cache에 남아 네트워크 없이 보일 수 있어요. 하지만 cache는 앱이 보존 범위를 약속하거나 사용자에게 진행률을 보여 주는 기능이 아닙니다.
+
+명시적인 오프라인 기능은 다음 두 부분을 준비해요.
+
+```text
+Style URI
+  └─ OfflineManager ──> Style Pack
+                        style JSON, sprite, glyph, model...
+
+영역 Geometry + Zoom Range
+  └─ TilesetDescriptor ──> TileStore ──> Tile Region
+                                      vector/raster tile packs
+
+Style Pack + Tile Region이 모두 준비됨
+  └─ 네트워크가 없어도 지정 범위 렌더링
+```
+
+Tile Region만 받고 Style Pack을 빠뜨리면 글꼴이나 sprite 같은 리소스가 없어 지도가 비거나 일부가 누락될 수 있어요.
+
+## 다운로드 범위를 먼저 작게 설계해요
+
+“서울 전체를 최대 확대까지” 같은 요구는 영역과 zoom 조합이 커져 저장 공간과 다운로드 시간이 급격히 늘어날 수 있어요. 다음 값을 제품 요구로 명시합니다.
+
+- 사용자가 선택할 수 있는 영역의 최대 크기
+- 실제 기능에 필요한 최소·최대 zoom
+- Wi-Fi 전용 다운로드 여부
+- 예상 크기와 남은 저장 공간 안내
+- 다운로드 취소·재시도 정책
+- 오래된 지역 자동 삭제와 수동 삭제 UI
+- 현재 Mapbox 가격·tile pack 제한
+
+오프라인 지도는 버튼 하나가 아니라 저장소 수명 주기 기능이에요.
+
+## 1단계: Style Pack을 준비해요
+
+```swift
+import MapboxMaps
+
+final class OfflineMapStore {
+  private let offlineManager = OfflineManager()
+  private let tileStore = TileStore.default
+
+  private var stylePackTask: Cancelable?
+  private var tileRegionTask: Cancelable?
+
+  func downloadStandardStyle(
+    progress: @escaping (UInt64, UInt64) -> Void,
+    completion: @escaping (Result<StylePack, Error>) -> Void
+  ) {
+    let options = StylePackLoadOptions(
+      glyphsRasterizationMode: .ideographsRasterizedLocally,
+      metadata: ["purpose": "offline-map"],
+      acceptExpired: false
+    )
+
+    stylePackTask = offlineManager.loadStylePack(
+      for: .standard,
+      loadOptions: options
+    ) { value in
+      DispatchQueue.main.async {
+        progress(value.completedResourceCount, value.requiredResourceCount)
+      }
+    } completion: { result in
+      DispatchQueue.main.async {
+        completion(result)
+      }
+    }
+  }
+}
+```
+
+공식 가이드는 progress와 completion closure가 main thread에서 호출된다고 보장하지 않는다고 안내합니다. SwiftUI 상태를 바꾸기 전에 MainActor나 main queue로 전환하세요.
+
+한글·한자 glyph를 기기에서 rasterize하면 원격 glyph 다운로드를 줄일 수 있지만 글꼴과 디자인 요구를 함께 확인해야 해요. 앱의 Style과 다른 Style Pack을 받으면 원하는 지도를 오프라인으로 그릴 수 없습니다.
+
+## 2단계: 영역과 zoom의 Tileset descriptor를 만들어요
+
+서울 중심의 예시를 작게 만들어 볼게요. 실제 서비스는 점 한 개보다 polygon이나 bounding box로 영역을 정의하는 경우가 많습니다.
+
+```swift
+import MapboxMaps
+import Turf
+
+extension OfflineMapStore {
+  func downloadSeoulCenter(
+    progress: @escaping (UInt64, UInt64) -> Void,
+    completion: @escaping (Result<TileRegion, Error>) -> Void
+  ) {
+    let descriptorOptions = TilesetDescriptorOptions(
+      styleURI: .standard,
+      zoomRange: 10...14
+    )
+
+    let descriptor = offlineManager.createTilesetDescriptor(
+      for: descriptorOptions
+    )
+
+    let center = CLLocationCoordinate2D(
+      latitude: 37.5666,
+      longitude: 126.9784
+    )
+
+    guard let loadOptions = TileRegionLoadOptions(
+      geometry: Geometry(coordinate: center),
+      descriptors: [descriptor],
+      metadata: [
+        "name": "seoul-center",
+        "minZoom": 10,
+        "maxZoom": 14,
+      ],
+      acceptExpired: false
+    ) else {
+      completion(.failure(OfflineMapError.invalidRegion))
+      return
+    }
+
+    tileRegionTask = tileStore.loadTileRegion(
+      forId: "seoul-center-10-14",
+      loadOptions: loadOptions
+    ) { value in
+      DispatchQueue.main.async {
+        progress(value.completedResourceCount, value.requiredResourceCount)
+      }
+    } completion: { result in
+      DispatchQueue.main.async {
+        completion(result)
+      }
+    }
+  }
+}
+
+enum OfflineMapError: Error {
+  case invalidRegion
+}
+```
+
+이 코드는 오프라인 API의 연결 관계를 보여 주는 최소 예제예요. 실제 기능에서는 polygon으로 영역을 정의하고, Style Pack 완료와 Tile Region 완료를 하나의 화면 상태로 조합하며, 오류 타입별 재시도 정책을 둡니다.
+
+`TileRegionLoadOptions`의 geometry가 점이면 그 점을 덮는 tile만 대상으로 삼아요. 사용자가 지도를 움직일 실제 범위를 제공하려면 bounding box를 닫힌 polygon으로 변환하세요.
+
+## 진행률 상태는 하나의 모델로 합쳐요
+
+Style Pack과 Tile Region은 서로 다른 작업이라 완료 시점도 다릅니다.
+
+```swift
+enum OfflineRegionState: Equatable {
+  case notDownloaded
+  case downloading(style: Double, tiles: Double)
+  case ready
+  case failed(message: String)
+}
+```
+
+화면에는 전체 상태를 보여 주되 내부에서는 두 작업의 progress, completion, cancel token을 각각 보관해요. 한쪽만 성공했을 때 `.ready`로 표시하면 비행기 모드에서 지도가 누락될 수 있습니다.
+
+## 취소와 화면 종료는 구분해요
+
+`loadStylePack`과 `loadTileRegion`은 `Cancelable`을 반환합니다.
+
+```swift
+extension OfflineMapStore {
+  func cancelCurrentDownload() {
+    stylePackTask?.cancel()
+    tileRegionTask?.cancel()
+    stylePackTask = nil
+    tileRegionTask = nil
+  }
+}
+```
+
+화면이 잠깐 사라진다고 사용자 요청 다운로드를 항상 취소할지는 제품 정책이에요. View가 작업을 소유하면 탭 전환에 취소될 수 있으므로 오래 걸리는 다운로드는 앱 수준 store나 background 정책과 함께 설계합니다.
+
+iOS background execution 시간이 무한하지 않다는 점도 고려하세요. 앱이 background로 갔을 때 중단·재개되는 동작을 실제 기기에서 검증합니다.
+
+## 기존 데이터는 같은 ID로 갱신해요
+
+공식 오프라인 가이드에 따르면 같은 Style URI와 Tile Region ID로 다시 load하고 `acceptExpired: false`를 전달하면 누락되거나 만료된 리소스를 갱신할 수 있어요.
+
+```text
+앱 시작
+  ├─ 저장된 Style Pack과 Tile Region 목록 조회
+  ├─ 만료·정책 버전 확인
+  ├─ Wi-Fi와 사용자 설정 확인
+  └─ 같은 ID로 refresh
+```
+
+`acceptExpired: true`는 오래된 데이터를 허용해 즉시 사용할 수 있게 하지만 새 리소스로 바꾸지 않을 수 있어요. “오래돼도 우선 보이기”와 “연결되면 최신화” 정책을 나누고 사용자에게 마지막 업데이트 시각을 보여 주세요.
+
+지도 화면이 `TileStore`의 오래된 pack을 온라인에서 자동 갱신하게 하려면 `MapboxMapsOptions.tileStoreUsageMode`의 `.readAndUpdate` 동작을 검토할 수 있습니다. 네트워크와 비용 정책을 확인하지 않고 전역 옵션부터 켜지는 마세요.
+
+## 목록과 삭제 수명 주기를 제공해요
+
+`OfflineManager.allStylePacks`와 `TileStore.allTileRegions`로 현재 저장 항목을 조회할 수 있어요. 사용자가 지역을 삭제하면 Tile Region을 먼저 제거하고, 다른 지역이 공유하지 않는 Style Pack과 cache 정책을 함께 정리합니다.
+
+```swift
+extension OfflineMapStore {
+  func removeSeoulCenter(
+    completion: @escaping (Result<TileRegion, Error>) -> Void
+  ) {
+    tileStore.removeTileRegion(
+      forId: "seoul-center-10-14"
+    ) { result in
+      DispatchQueue.main.async {
+        completion(result)
+      }
+    }
+  }
+}
+```
+
+삭제 API를 호출했다고 disk byte가 즉시 모두 사라진다고 가정하면 안 돼요. 공식 가이드는 region에서 resource 참조를 제거한 뒤 disk cache의 일반 정리 과정에서 실제 파일이 삭제될 수 있다고 설명합니다.
+
+## 오프라인 테스트는 cache를 통제해요
+
+온라인에서 이미 본 영역은 cache만으로 보일 수 있어 잘못된 성공 판정을 만들어요.
+
+1. 새 Simulator 또는 **Erase All Content and Settings**로 cache를 비워요.
+2. 지정 Style Pack과 Tile Region을 내려받아요.
+3. 다운로드 완료 상태를 확인해요.
+4. 네트워크를 끄고 앱을 완전히 다시 실행해요.
+5. 지정한 zoom 범위 안과 밖을 각각 확인해요.
+6. 앱 업데이트, Style 변경, 만료 데이터, 저장 공간 부족을 테스트해요.
+7. 취소 후 재시작과 일부 다운로드 실패를 테스트해요.
+
+zoom 10...14만 받았다면 zoom 15에서 상세 tile이 안 보이는 것은 오류가 아니라 다운로드 계약입니다.
+
+## 저장 공간과 비용을 함께 관리해요
+
+- zoom 한 단계가 늘 때 필요한 tile 수가 크게 증가할 수 있어요.
+- 서로 겹치는 Region이 내부 Tile Pack을 공유할 수 있지만 앱이 항상 정확한 byte 절감을 가정하면 안 돼요.
+- 오래된 Region을 자동 삭제할 때 최근 사용 시각과 사용자의 고정 여부를 보존해요.
+- 다운로드 전에 예상 크기와 네트워크 종류를 안내해요.
+- Mapbox의 offline pricing과 tile pack 한도는 변경될 수 있으므로 출시 시점 공식 정책을 확인해요.
+- Mapbox 서버에서 받은 오프라인 데이터를 다른 사용자나 앱에 재배포하지 않아요.
+
+## 언제 오프라인 지도를 사용해야 하나요?
+
+- 등산, 여행, 현장 업무처럼 연결이 자주 끊기는 제한된 지역
+- 사용자가 출발 전에 지역을 명시적으로 선택할 수 있는 기능
+- 필요한 zoom과 Style이 명확하고 저장 공간을 안내할 수 있는 기능
+
+반대로 전 세계를 항상 최대 zoom으로 저장하거나, 잠깐 네트워크가 느릴 때 cache만으로 충분한 화면이라면 명시적 offline region은 비용과 관리 복잡도가 과할 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. 사용자 시나리오에서 영역과 필요한 zoom 범위를 제한해요.
+2. 사용할 Style URI와 Style Pack 정책을 정해요.
+3. 영역 ID, geometry, descriptor와 metadata 모델을 설계해요.
+4. Style Pack과 Tile Region을 각각 다운로드하고 하나의 UI 상태로 합쳐요.
+5. progress callback을 MainActor 상태로 안전하게 전달해요.
+6. 취소, 재시도, 갱신, 목록, 삭제 수명 주기를 구현해요.
+7. 깨끗한 cache와 실제 기기에서 offline·저장 공간·앱 재실행을 검증해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Style Pack과 Tile Region은 왜 둘 다 필요한가요?
+
+Style Pack은 Style 정의, 글꼴, sprite처럼 지도를 어떻게 그릴지에 필요한 리소스를 담습니다. Tile Region은 지정 영역과 zoom의 실제 지도 tile을 담으므로 둘 중 하나가 없으면 완전한 오프라인 렌더링을 보장할 수 없어요.
+
+### cache와 offline region의 차이는 무엇인가요?
+
+cache는 최근 온라인 사용의 부산물이며 보존 범위와 완료 상태를 앱이 제어하지 못합니다. Offline region은 앱이 geometry, zoom, progress, 갱신과 삭제를 명시적으로 관리하는 사용자 기능이에요.
+
+### zoom 범위를 넓히면 왜 비용이 크게 늘 수 있나요?
+
+확대할수록 같은 영역을 더 작은 tile들로 나눠야 하므로 필요한 tile 수가 빠르게 증가합니다. 사용자가 실제로 볼 상세 수준만 선택하고 예상 저장 공간과 가격을 함께 검토해야 해요.
+
+## 참고 자료
+
+- [Mapbox 오프라인 데이터 관리](https://docs.mapbox.com/ios/maps/guides/offline/manage-offline-data/)
+- [Mapbox iOS 오프라인 지도 튜토리얼](https://docs.mapbox.com/help/tutorials/ios-offline-maps/)
+- [`OfflineManager` API Reference](https://docs.mapbox.com/ios/maps/api/latest/documentation/mapboxmaps/offlinemanager/)
+- [`TileStore` API Reference](https://docs.mapbox.com/ios/maps/api/latest/documentation/mapboxmaps/tilestore/)
+- [Mapbox Maps SDK 공식 예제](https://docs.mapbox.com/ios/maps/examples/)
+- [Mapbox 계정과 가격 문서](https://docs.mapbox.com/accounts/)

--- a/docs/guide/mapbox-maps-sdk/styles-sources-and-layers.md
+++ b/docs/guide/mapbox-maps-sdk/styles-sources-and-layers.md
@@ -1,0 +1,298 @@
+---
+title: Mapbox 스타일·Source·Layer
+description: Mapbox Style과 GeoJSON·Vector Source, Layer의 역할을 분리하고 SwiftUI 선언형 Map Styling으로 앱 데이터를 표현하고 갱신하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Mapbox 스타일·Source·Layer
+
+> 면접용 한 줄 요약: **Source는 지도에 그릴 지리 데이터를 제공하고 Layer는 그 데이터를 표현하는 규칙을 정의하며, Style은 배경 지도와 여러 Source·Layer의 전체 구성을 묶습니다.**
+
+## 먼저 알아둘 렌더링 용어
+
+| 용어        | 쉬운 뜻                                                                   |
+| ----------- | ------------------------------------------------------------------------- |
+| Style       | 배경, 도로, 건물, 글꼴과 앱이 추가한 Layer까지 지도 모양 전체를 정의해요. |
+| Source      | 좌표와 속성을 가진 원본 데이터를 지도 엔진에 공급해요.                    |
+| Layer       | Source의 Feature를 원, 선, 면, 아이콘, 글자처럼 그리는 규칙이에요.        |
+| GeoJSON     | 점·선·다각형과 속성을 JSON으로 표현하는 공개 지리 데이터 형식이에요.      |
+| Vector Tile | 큰 지리 데이터를 확대 수준과 영역별 작은 타일로 나눈 벡터 형식이에요.     |
+| Expression  | Feature 속성이나 zoom에 따라 색·크기 같은 Layer 값을 계산하는 식이에요.   |
+| Layer order | 같은 위치에 여러 Layer가 있을 때 어느 것을 위에 그릴지 정하는 순서예요.   |
+
+## 데이터와 표현을 한 타입에 섞으면 바꾸기 어려워요
+
+산책 경로 좌표를 View가 직접 반복해 선 조각으로 만든다고 생각해 볼게요. 좌표가 많아질수록 View가 데이터 변환, 렌더링 선택, 색상 정책을 모두 맡게 됩니다.
+
+Mapbox는 이를 두 책임으로 나눠요.
+
+```text
+FeatureCollection / GeoJSON / Vector Tile
+                  │
+                  ▼
+               Source
+                  │ source id
+        ┌─────────┼─────────┐
+        ▼         ▼         ▼
+    LineLayer  CircleLayer  SymbolLayer
+     경로 선     지점 원      아이콘·라벨
+```
+
+Source 하나를 여러 Layer가 공유할 수 있어요. 같은 매장 데이터에서 `CircleLayer`로 위치를 그리고 `SymbolLayer`로 이름을 올리는 식입니다.
+
+## Style은 배경 지도의 시작점이에요
+
+Maps SDK의 기본 Style은 Mapbox Standard입니다.
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct StyledMap: View {
+  @Environment(\.colorScheme) private var colorScheme
+
+  var body: some View {
+    Map()
+      .mapStyle(
+        .standard(
+          lightPreset: colorScheme == .light ? .day : .dusk
+        )
+      )
+  }
+}
+```
+
+Mapbox Studio에서 만든 Style은 Style URI로 불러올 수 있어요.
+
+```swift
+extension MapStyle {
+  static let brand = MapStyle(
+    uri: StyleURI(
+      rawValue: "mapbox://styles/example-account/example-style-id"
+    )!
+  )
+}
+
+struct BrandMap: View {
+  var body: some View {
+    Map()
+      .mapStyle(.brand)
+  }
+}
+```
+
+실제 URI는 환경 설정에서 관리하고, 해당 Style을 읽을 수 있는 공개 Token scope를 확인합니다.
+
+## SwiftUI에서는 Source와 Layer를 선언해요
+
+서울의 두 지점을 연결하는 산책 경로를 `GeoJSONSource`와 `LineLayer`로 표현해 볼게요.
+
+```swift
+import MapboxMaps
+import SwiftUI
+import Turf
+
+struct WalkingRouteMap: View {
+  private let route = LineString([
+    CLLocationCoordinate2D(latitude: 37.5666, longitude: 126.9784),
+    CLLocationCoordinate2D(latitude: 37.5700, longitude: 126.9830),
+    CLLocationCoordinate2D(latitude: 37.5729, longitude: 126.9769),
+  ])
+
+  var body: some View {
+    Map(
+      initialViewport: .overview(
+        geometry: Geometry.lineString(route)
+      )
+    ) {
+      GeoJSONSource(id: "walking-route-source")
+        .data(.geometry(.lineString(route)))
+
+      LineLayer(
+        id: "walking-route-layer",
+        source: "walking-route-source"
+      )
+      .lineColor(StyleColor(.systemBlue))
+      .lineWidth(5)
+      .lineCap(.round)
+      .lineJoin(.round)
+    }
+  }
+}
+```
+
+확인할 연결은 두 가지예요.
+
+1. `LineLayer`의 `source` 문자열이 `GeoJSONSource`의 ID와 같아야 해요.
+2. Source에는 선 geometry가 있고 이를 그릴 `LineLayer`를 선택해야 해요.
+
+`FillLayer`에 점 Source를 연결하거나 ID를 오타 내면 원하는 결과가 나오지 않습니다.
+
+## 선언형 Map Styling이 수명 주기를 관리해요
+
+Mapbox Maps SDK v11.4부터 Source, Layer, Image, Light 같은 style primitive를 선언형으로 구성할 수 있어요. SwiftUI에서는 `Map` content에 선언하면 상태가 바뀔 때 필요한 차이를 반영하고 Style을 다시 불러온 뒤에도 선언된 content를 다시 연결합니다.
+
+```swift
+struct RouteStyle: MapStyleContent {
+  let route: LineString
+  let isHighlighted: Bool
+
+  var body: some MapStyleContent {
+    GeoJSONSource(id: "route-source")
+      .data(.geometry(.lineString(route)))
+
+    LineLayer(id: "route-layer", source: "route-source")
+      .lineColor(
+        isHighlighted
+          ? StyleColor(.systemOrange)
+          : StyleColor(.systemBlue)
+      )
+      .lineWidth(isHighlighted ? 8 : 4)
+  }
+}
+
+struct RouteMap: View {
+  let route: LineString
+  @State private var isHighlighted = false
+
+  var body: some View {
+    Map {
+      RouteStyle(
+        route: route,
+        isHighlighted: isHighlighted
+      )
+    }
+    .overlay(alignment: .bottom) {
+      Toggle("경로 강조", isOn: $isHighlighted)
+        .padding()
+        .background(.regularMaterial)
+    }
+  }
+}
+```
+
+`MapStyleContent`로 관련 Source와 Layer를 묶으면 ID와 스타일 규칙을 재사용할 수 있어요. 단순한 한 화면에는 직접 선언하고, 여러 화면에서 같은 지도 표현을 쓸 때 컴포넌트로 추출합니다.
+
+## Source 종류는 데이터가 만들어지는 방식으로 골라요
+
+| Source            | 데이터 특성                            | 대표 사용                           |
+| ----------------- | -------------------------------------- | ----------------------------------- |
+| `GeoJSONSource`   | 앱 메모리, bundle 파일, URL의 점·선·면 | 실시간 장소, 경로, 작은·중간 데이터 |
+| `VectorSource`    | 서버에서 영역·zoom별 vector tile 제공  | 도시·국가 규모의 큰 데이터          |
+| `RasterSource`    | 이미 그려진 이미지 tile                | 위성, 날씨, 스캔 지도               |
+| `RasterDemSource` | 지형 높이 데이터                       | 3D terrain, hillshade               |
+| `ImageSource`     | 좌표 네 모서리에 한 이미지를 배치      | 평면도, 행사장 이미지               |
+
+큰 GeoJSON 파일 전체를 매번 앱에서 내려받는 방식은 초기 로딩과 메모리 비용이 커져요. 데이터가 넓은 지역과 여러 zoom에 걸치면 Vector Tile이나 Mapbox Tileset으로 전처리하는 방식을 검토합니다.
+
+## Layer는 geometry와 시각화 목적에 맞춰요
+
+| Layer                | 그리는 것                         |
+| -------------------- | --------------------------------- |
+| `CircleLayer`        | 점을 화면 크기의 원으로 표현      |
+| `SymbolLayer`        | 아이콘과 텍스트 라벨 표현         |
+| `LineLayer`          | 경로, 도로, 경계선 표현           |
+| `FillLayer`          | 다각형 내부 영역 표현             |
+| `FillExtrusionLayer` | 높이가 있는 3D 면 표현            |
+| `HeatmapLayer`       | 많은 점의 밀도를 연속 색으로 표현 |
+| `RasterLayer`        | Raster Source 이미지를 표현       |
+
+Layer 하나가 모든 역할을 맡게 하기보다 같은 Source를 여러 Layer가 읽게 하면 선택 상태나 라벨을 독립적으로 바꿀 수 있습니다.
+
+## Expression으로 zoom과 속성에 반응해요
+
+매장 Feature에 `isOpen` 속성이 있다면 영업 중인 매장을 다른 색으로 표시할 수 있어요.
+
+```swift
+CircleLayer(id: "stores-layer", source: "stores-source")
+  .circleColor(
+    .expression(
+      Exp(.match) {
+        Exp(.get) { "isOpen" }
+        true
+        UIColor.systemGreen
+        UIColor.systemGray
+      }
+    )
+  )
+  .circleRadius(
+    .expression(
+      Exp(.interpolate) {
+        Exp(.linear)
+        Exp(.zoom)
+        10
+        4
+        16
+        10
+      }
+    )
+  )
+```
+
+Expression은 Swift에서 Feature마다 색을 계산해 새 배열을 만드는 대신 렌더링 규칙을 지도 엔진에 전달합니다. 다만 복잡한 식은 디버깅 비용이 있으므로 속성 이름과 예상 타입을 문서화하세요.
+
+## Mapbox Standard에서는 Layer 위치를 의식해요
+
+Layer 순서는 겹침과 탭 우선순위를 결정합니다. Mapbox Standard와 Standard Satellite는 basemap을 style import로 구성하므로 앱이 만든 custom layer를 배치할 때 slot 개념을 사용합니다. 다른 Style에서 특정 layer ID 위아래에 놓는 방식과 동일하다고 가정하면 안 돼요.
+
+[Source와 Layer 공식 가이드](https://docs.mapbox.com/ios/maps/guides/styles/work-with-layers/)의 현재 Style별 위치 지정 규칙을 확인하고 다음 요구를 먼저 정합니다.
+
+- 경로가 도로 라벨 아래에 있어도 되나요?
+- 선택 핀은 모든 지도 콘텐츠보다 위에 있어야 하나요?
+- 3D 건물이나 terrain이 Layer 순서에 영향을 주나요?
+- 탭할 Layer가 다른 Layer에 가려지지 않나요?
+
+## Annotation과 Source·Layer 중 무엇을 선택하나요?
+
+| 기준        | Annotation                             | Source + Layer                              |
+| ----------- | -------------------------------------- | ------------------------------------------- |
+| 시작 난이도 | 좌표와 스타일을 바로 선언해 낮음       | 데이터·표현 ID 연결이 필요해 높음           |
+| 개별 스타일 | 각 Annotation별 설정이 편함            | 속성과 Expression으로 데이터 기반 설정      |
+| 대량 데이터 | 종류에 따라 비효율적일 수 있음         | tile·GeoJSON과 renderer를 활용하기 좋음     |
+| 클러스터링  | `PointAnnotationGroup`에서 간단히 시작 | cluster Source와 여러 Layer로 세밀하게 제어 |
+| Layer 순서  | group modifier 범위에서 조절           | 전체 Style 구조에서 정밀하게 조절           |
+
+핀 몇 개와 간단한 탭은 Annotation으로 시작해도 충분해요. 데이터가 크거나 줌별 스타일, 여러 Layer 공유, cluster 집계가 중요하면 Source·Layer 구조를 선택합니다.
+
+## 흔한 오류를 진단해요
+
+- Source와 Layer ID가 중복되거나 서로 다르지 않은지 확인해요.
+- Source의 geometry 타입과 Layer 종류가 맞는지 확인해요.
+- 앱에서 읽는 Feature 속성 이름과 실제 GeoJSON key가 같은지 확인해요.
+- Style 변경 뒤 명령형으로 추가한 Layer가 사라지지 않았는지 확인해요.
+- Mapbox Standard에서 custom Layer의 slot과 렌더링 순서를 확인해요.
+- 큰 GeoJSON을 메인 스레드에서 반복 변환하고 있지 않은지 Instruments로 측정해요.
+
+## 적용 순서를 정리해요
+
+1. 지도에 표시할 데이터를 점·선·면과 속성으로 모델링해요.
+2. 앱 크기라면 GeoJSON, 넓은 지역이라면 Vector Tile 등 Source를 골라요.
+3. 하나의 Source에 안정적이고 고유한 ID를 정해요.
+4. 원하는 표현마다 Layer를 나누고 같은 Source ID에 연결해요.
+5. 색·크기가 데이터와 zoom에 따라 바뀌면 Expression을 추가해요.
+6. Layer order와 탭 우선순위를 실제 Style에서 확인해요.
+7. 데이터 규모가 커지면 로딩·메모리·프레임 시간을 측정해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### 하나의 Source를 여러 Layer가 사용할 수 있나요?
+
+네. Source는 데이터이고 Layer는 표현이므로 같은 매장 Source를 원, 아이콘, 라벨 Layer가 공유할 수 있습니다. 데이터 갱신과 표현 규칙을 분리할 수 있다는 것이 핵심이에요.
+
+### 선언형 Styling과 명령형 `addLayer`의 차이는 무엇인가요?
+
+선언형 방식은 현재 SwiftUI 상태가 어떤 Source와 Layer를 가져야 하는지 기술하고 SDK가 갱신과 Style reload 뒤 재연결을 맡습니다. 명령형 방식은 추가 순서와 중복, Style 수명 주기를 앱이 직접 관리해야 해요.
+
+### 큰 GeoJSON을 그대로 사용하면 어떤 문제가 생기나요?
+
+파일 다운로드, JSON 해석, 메모리 점유와 Source 갱신 비용이 커질 수 있습니다. 넓은 지역과 여러 확대 수준을 다루면 Vector Tile로 전처리하고 필요한 영역만 읽는 구조를 검토해야 해요.
+
+## 참고 자료
+
+- [Mapbox Map Styles 가이드](https://docs.mapbox.com/ios/maps/guides/styles/)
+- [Source와 Layer 다루기](https://docs.mapbox.com/ios/maps/guides/styles/work-with-layers/)
+- [Declarative Map Styling](https://docs.mapbox.com/ios/maps/guides/styles/declarative-map-styling/)
+- [Mapbox Style Specification](https://docs.mapbox.com/style-spec/)
+- [Mapbox Maps SDK SwiftUI 가이드](https://docs.mapbox.com/ios/maps/guides/swift-ui/)
+- [GeoJSON Specification](https://datatracker.ietf.org/doc/html/rfc7946)

--- a/docs/guide/mapbox-maps-sdk/swiftui-map-and-camera.md
+++ b/docs/guide/mapbox-maps-sdk/swiftui-map-and-camera.md
@@ -1,0 +1,271 @@
+---
+title: Mapbox SwiftUI 지도와 카메라
+description: MapboxMaps의 SwiftUI Map과 Viewport로 초기 카메라, 양방향 상태, 애니메이션과 고빈도 카메라 이벤트를 안전하게 다루는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Mapbox SwiftUI 지도와 카메라
+
+> 면접용 한 줄 요약: **SwiftUI의 `Map`은 지도 내용을 선언하고 `Viewport`는 카메라의 목적을 표현하며, 연속 카메라 이벤트는 매번 `@State`에 복사하지 않고 필요한 시점에만 축약해야 합니다.**
+
+## 먼저 알아둘 카메라 용어
+
+| 용어     | 쉬운 뜻                                                                        |
+| -------- | ------------------------------------------------------------------------------ |
+| center   | 화면 중심이 바라보는 위도·경도예요.                                            |
+| zoom     | 지도를 얼마나 확대했는지 나타내며 값이 클수록 가까이 보여요.                   |
+| bearing  | 북쪽을 기준으로 지도를 시계 방향으로 회전한 각도예요.                          |
+| pitch    | 카메라를 수직 지도에서 얼마나 기울였는지 나타내요.                             |
+| padding  | 시트나 버튼이 지도를 가릴 때 실제로 보여 줄 영역 안쪽에 확보하는 여백이에요.   |
+| Viewport | 고정 카메라, 현재 위치 추적, geometry 전체 보기 같은 카메라 동작의 목적이에요. |
+
+## 한 번만 정할 카메라는 `initialViewport`로 시작해요
+
+화면이 처음 나타날 때 서울시청을 보여 주고 이후에는 사용자가 자유롭게 움직이게 한다면 초기 Viewport만 전달하면 됩니다.
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct SeoulMap: View {
+  private let seoulCityHall = CLLocationCoordinate2D(
+    latitude: 37.5666,
+    longitude: 126.9784
+  )
+
+  var body: some View {
+    Map(
+      initialViewport: .camera(
+        center: seoulCityHall,
+        zoom: 14,
+        bearing: 0,
+        pitch: 30
+      )
+    )
+  }
+}
+```
+
+`initialViewport`는 이름처럼 초기화에만 사용해요. 부모 View가 다시 그려져도 이 값을 바꿔 카메라를 계속 명령할 수 있는 binding은 아닙니다.
+
+## 버튼이 카메라를 움직여야 하면 binding을 사용해요
+
+검색 결과, 현재 위치 버튼, 경로 전체 보기처럼 앱이 나중에 카메라를 바꿔야 하면 `Viewport`를 상태로 보관하고 `Map(viewport:)`에 binding을 전달합니다.
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct PlaceMap: View {
+  private let cityHall = CLLocationCoordinate2D(
+    latitude: 37.5666,
+    longitude: 126.9784
+  )
+
+  private let seoulStation = CLLocationCoordinate2D(
+    latitude: 37.5547,
+    longitude: 126.9707
+  )
+
+  @State private var viewport: Viewport = .styleDefault
+
+  var body: some View {
+    ZStack(alignment: .bottomTrailing) {
+      Map(viewport: $viewport)
+
+      VStack {
+        Button("시청") {
+          move(to: cityHall)
+        }
+
+        Button("서울역") {
+          move(to: seoulStation)
+        }
+      }
+      .buttonStyle(.borderedProminent)
+      .padding()
+    }
+  }
+
+  private func move(to coordinate: CLLocationCoordinate2D) {
+    withViewportAnimation(.easeInOut(duration: 0.6)) {
+      viewport = .camera(center: coordinate, zoom: 15)
+    }
+  }
+}
+```
+
+이 예제의 상태는 좌표 숫자 모음이 아니라 “이 좌표를 줌 15로 보여 줘요”라는 카메라 목적이에요.
+
+## Viewport 모드를 역할에 맞게 골라요
+
+| Viewport               | 적합한 상황                                   |
+| ---------------------- | --------------------------------------------- |
+| `.styleDefault`        | Style에 저장된 기본 카메라로 시작할 때        |
+| `.camera(...)`         | 중심, 확대, 회전, 기울기를 직접 지정할 때     |
+| `.overview(geometry:)` | 경로나 여러 지점 전체가 화면에 들어오게 할 때 |
+| `.followPuck(...)`     | 사용자 위치 Puck을 카메라가 따라갈 때         |
+| `.idle`                | Viewport가 카메라를 더 이상 제어하지 않을 때  |
+
+사용자가 손가락으로 지도를 움직이면 Viewport는 `.idle`로 전환돼요. 이는 사용자의 제스처와 앱의 자동 추적이 동시에 카메라를 잡고 싸우지 않게 하는 중요한 규칙입니다. 다시 추적하려면 “내 위치” 버튼처럼 명시적인 동작에서 `.followPuck`을 설정하세요.
+
+## 애니메이션은 목적에 맞게 선택해요
+
+고정 장소로 이동할 때는 ease 계열 애니메이션이 자연스럽습니다.
+
+```swift
+withViewportAnimation(.easeOut(duration: 0.5)) {
+  viewport = .camera(center: cityHall, zoom: 15)
+}
+```
+
+동적으로 움직이는 사용자 Puck을 따라갈 때는 고정된 목표로 끝나는 ease보다 기본 Viewport transition을 권장해요.
+
+```swift
+withViewportAnimation(.default(maxDuration: 1.0)) {
+  viewport = .followPuck(
+    zoom: 16,
+    bearing: .heading,
+    pitch: 45
+  )
+}
+```
+
+[공식 SwiftUI 가이드](https://docs.mapbox.com/ios/maps/guides/swift-ui/)는 `followPuck`으로 전환할 때 `.default(maxDuration:)` 사용을 권장합니다. 움직이는 위치를 정적인 목표처럼 보간하면 애니메이션 끝에서 점프가 생길 수 있기 때문이에요.
+
+## 카메라 이벤트를 매 프레임 상태로 복사하지 않아요
+
+지도 영역이 바뀔 때 주변 장소를 다시 검색하려고 다음처럼 작성하기 쉬워요.
+
+```swift
+Map(viewport: $viewport)
+  .onCameraChanged { context in
+    // 나쁜 예: 카메라가 움직이는 모든 프레임에 View를 다시 그려요.
+    visibleCenter = context.cameraState.center
+  }
+```
+
+`onCameraChanged`는 제스처와 애니메이션 중 수백 번 호출될 수 있어요. 고빈도 값을 곧바로 `@State`에 넣으면 SwiftUI `body` 평가와 네트워크 요청이 과도하게 늘어날 수 있습니다.
+
+화면 요구에 따라 경계를 정하세요.
+
+```text
+카메라가 이동 중
+  └─ lightweight한 모델에 마지막 CameraState만 저장
+
+카메라가 멈춤 또는 사용자가 "이 지역 검색" 선택
+  ├─ 현재 보이는 좌표 영역 계산
+  ├─ 이전 검색 Task 취소
+  └─ 최신 영역 한 번만 요청
+```
+
+연속 이벤트가 꼭 필요하면 model에서 throttle하거나 debounce하고, UI에 필요한 축약된 값만 MainActor 상태로 전달합니다.
+
+## 지도 이벤트와 콘텐츠 제스처를 구분해요
+
+`onCameraChanged`는 카메라 상태가 변했다는 **지도 이벤트**예요. Annotation이나 Layer를 눌렀다는 **콘텐츠 제스처**와 목적이 다릅니다.
+
+```swift
+Map {
+  PointAnnotation(coordinate: cityHall)
+    .image(named: "place-pin")
+    .onTapGesture { context in
+      print("선택 좌표: \(context.coordinate)")
+      return true
+    }
+}
+```
+
+handler가 `true`를 반환하면 아래의 다른 지도 요소로 이벤트를 전파하지 않겠다는 뜻이에요. 겹친 Layer와 지도의 탭 동작을 함께 설계할 때 반환값을 명시적으로 정합니다.
+
+## `MapReader`는 필요한 API만 꺼내는 탈출구예요
+
+SwiftUI modifier로 노출되지 않은 기능이나 현재 카메라의 상세 계산이 필요하면 `MapReader`로 내부 `MapboxMap`에 접근할 수 있어요.
+
+```swift
+struct DebugMap: View {
+  var body: some View {
+    MapReader { proxy in
+      Map()
+        .onAppear {
+          guard let map = proxy.map else { return }
+          print(map.cameraState)
+        }
+    }
+  }
+}
+```
+
+`MapReader`가 있다고 모든 작업을 명령형 API로 바꿀 필요는 없습니다. Style, Source, Layer와 Annotation이 SwiftUI `Map` content로 표현된다면 선언을 single source of truth로 두세요. 내부 지도 객체는 쿼리, 고급 클러스터 확장, 아직 노출되지 않은 API처럼 필요한 곳에서만 사용합니다.
+
+## UIKit에서는 `MapView`와 `CameraOptions`를 사용해요
+
+UIKit 화면의 진입점은 `MapView`입니다.
+
+```swift
+import MapboxMaps
+import UIKit
+
+final class MapViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    let mapView = MapView(frame: view.bounds)
+    mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    view.addSubview(mapView)
+
+    mapView.mapboxMap.setCamera(
+      to: CameraOptions(
+        center: CLLocationCoordinate2D(
+          latitude: 37.5666,
+          longitude: 126.9784
+        ),
+        zoom: 14
+      )
+    )
+  }
+}
+```
+
+SwiftUI에서 지원되는 기능을 위해 `UIViewRepresentable`로 `MapView`부터 감싸기보다 공식 SwiftUI `Map`을 먼저 검토하세요. 현재 SwiftUI API는 Viewport, Annotation, Puck, 이벤트, 제스처, Style API를 직접 지원합니다.
+
+## 언제 어떤 방식을 사용하나요?
+
+- 첫 화면 위치만 필요하면 `initialViewport`를 사용해요.
+- 버튼과 검색 결과가 카메라를 바꾸면 `@State Viewport` binding을 사용해요.
+- 사용자 위치를 계속 따라가면 `followPuck`과 기본 transition을 사용해요.
+- 경로나 여러 지점을 한 번에 보여주면 `overview(geometry:)`를 사용해요.
+- 카메라 변화 중 모든 좌표가 필요하지 않다면 종료 시점이나 사용자 액션에서만 조회해요.
+- SwiftUI에 없는 고급 API가 필요할 때만 `MapReader`를 사용해요.
+
+## 체크리스트
+
+- [ ] 초기 카메라와 이후 앱 명령 카메라를 구분했나요?
+- [ ] 사용자 제스처 후 `.idle` 상태를 존중하나요?
+- [ ] `followPuck` 전환에 동적 목표에 맞는 애니메이션을 사용하나요?
+- [ ] `onCameraChanged`에서 무거운 계산이나 즉시 네트워크 요청을 하지 않나요?
+- [ ] Annotation 탭의 event propagation을 의도대로 반환하나요?
+- [ ] `MapReader`로 얻은 객체를 SwiftUI 선언과 중복 관리하지 않나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `initialViewport`와 `Map(viewport:)`의 차이는 무엇인가요?
+
+`initialViewport`는 지도가 만들어질 때 한 번 적용할 시작 상태입니다. `Map(viewport:)`는 binding을 통해 앱이 나중에도 카메라의 목적을 바꿀 수 있어 검색 결과 이동이나 위치 추적에 적합해요.
+
+### 왜 `onCameraChanged` 값을 바로 `@State`에 저장하면 안 되나요?
+
+카메라 이벤트는 한 번의 제스처에도 매우 자주 발생합니다. 매번 SwiftUI 상태를 바꾸면 `body` 재평가와 후속 작업이 폭증할 수 있으므로 model에 보관하거나 throttle한 뒤 필요한 값만 UI에 전달해야 해요.
+
+### 사용자가 지도를 드래그하면 위치 추적은 어떻게 되나요?
+
+Viewport가 `.idle`로 바뀌어 자동 카메라 제어가 멈춥니다. 앱은 사용자의 조작을 존중하고, 명시적인 “내 위치” 동작에서 `.followPuck`으로 다시 전환하는 편이 자연스러워요.
+
+## 참고 자료
+
+- [Mapbox Maps SDK SwiftUI 가이드](https://docs.mapbox.com/ios/maps/guides/swift-ui/)
+- [Mapbox Camera와 Animation 가이드](https://docs.mapbox.com/ios/maps/guides/camera-and-animation/)
+- [Mapbox Camera Animation](https://docs.mapbox.com/ios/maps/guides/camera-and-animation/animations/)
+- [`Map` API Reference](https://docs.mapbox.com/ios/maps/api/latest/documentation/mapboxmaps/map/)
+- [Map Content Gestures](https://docs.mapbox.com/ios/maps/guides/user-interaction/map-content-gestures/)

--- a/docs/guide/mapbox-maps-sdk/user-location.md
+++ b/docs/guide/mapbox-maps-sdk/user-location.md
@@ -1,0 +1,228 @@
+---
+title: Mapbox 사용자 위치와 권한
+description: Core Location 권한과 Mapbox Puck2D, heading·course, followPuck Viewport를 연결하고 정확도·Simulator·사용자 제스처를 안전하게 처리하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Mapbox 사용자 위치와 권한
+
+> 면접용 한 줄 요약: **Mapbox의 Puck은 위치를 지도에 표현하고 Viewport는 카메라 추적을 담당하지만, 위치 접근의 목적과 권한·정확도 정책은 앱이 Core Location 규칙에 맞게 설계해야 합니다.**
+
+## 먼저 알아둘 위치 용어
+
+| 용어             | 쉬운 뜻                                                                         |
+| ---------------- | ------------------------------------------------------------------------------- |
+| Core Location    | iOS에서 위치 권한과 GPS·Wi-Fi·기지국 기반 위치를 제공하는 Apple 프레임워크예요. |
+| Puck             | 지도 위에 사용자의 현재 위치와 방향을 표시하는 2D 또는 3D 표시예요.             |
+| heading          | 기기가 가리키는 나침반 방향이에요. 가만히 있어도 얻을 수 있어요.                |
+| course           | 실제 이동 경로가 향하는 방향이에요. 움직임이 있어야 의미가 생겨요.              |
+| reduced accuracy | 사용자가 정확한 위치 대신 대략적인 위치만 허용한 상태예요.                      |
+| follow-puck      | 카메라가 Puck의 위치를 계속 따라가는 Viewport 상태예요.                         |
+
+## 위치 표시와 카메라 추적은 다른 책임이에요
+
+`Puck2D`를 추가하면 사용자 위치가 지도에 그려집니다. 카메라를 사용자에게 고정하려면 별도로 `.followPuck` Viewport를 사용해요.
+
+```text
+AppleLocationProvider
+        │ Location / Heading
+        ▼
+   LocationManager
+     │        │
+     ▼        ▼
+  Puck2D    followPuck Viewport
+ 위치 표현      카메라 추적
+```
+
+Puck이 보인다고 카메라가 자동으로 따라가는 것은 아니며, 카메라가 따라간다고 위치 접근 목적 설명이 생략되는 것도 아닙니다.
+
+## 1단계: 사용 이유를 `Info.plist`에 설명해요
+
+앱을 사용하는 동안 주변 장소를 보여 주는 기능이라면 다음 키를 추가합니다.
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>현재 위치 주변의 장소를 지도에 보여드리기 위해 위치를 사용합니다.</string>
+```
+
+“서비스 제공을 위해 필요합니다”처럼 추상적인 문장보다 사용자가 보게 될 기능을 구체적으로 설명하세요. 위치를 쓰지 않는 화면에서 앱 시작 즉시 권한을 요청하기보다 사용자가 “내 위치” 기능을 선택한 맥락에서 요청하는 편이 이해하기 쉽습니다.
+
+:::warning Always 권한을 기본값으로 요청하지 않아요
+백그라운드 위치 기능이 실제 제품 요구 사항이고 사용자가 가치를 이해할 수 있을 때만 `NSLocationAlwaysAndWhenInUseUsageDescription`과 관련 capability를 검토하세요. 지도에 현재 위치를 보여 주는 일반 화면은 When In Use로 시작할 수 있습니다.
+:::
+
+## 2단계: Puck을 지도에 선언해요
+
+```swift
+import MapboxMaps
+import SwiftUI
+
+struct UserLocationMap: View {
+  var body: some View {
+    Map {
+      Puck2D(bearing: .heading)
+        .showsAccuracyRing(true)
+    }
+  }
+}
+```
+
+`Puck2D()`는 위치만 표시하고, `bearing: .heading`을 전달하면 기기의 방향을 함께 보여줘요. 정확도 ring은 현재 위치가 한 점이 아니라 오차 범위를 가진 측정값이라는 사실을 사용자에게 전달합니다.
+
+공식 User Location 가이드에 따르면 Maps SDK의 `LocationManager`는 기본 `AppleLocationProvider`를 사용합니다. custom provider가 필요하지 않다면 앱에서 별도 `CLLocationManager`를 만들어 같은 권한과 위치 흐름을 중복 관리하지 마세요.
+
+## 3단계: 카메라가 사용자를 따라가게 해요
+
+```swift
+struct FollowingMap: View {
+  @State private var viewport: Viewport = .followPuck(
+    zoom: 15,
+    bearing: .heading,
+    pitch: 45
+  )
+
+  var body: some View {
+    ZStack(alignment: .bottomTrailing) {
+      Map(viewport: $viewport) {
+        Puck2D(bearing: .heading)
+          .showsAccuracyRing(true)
+      }
+
+      Button {
+        withViewportAnimation(.default(maxDuration: 1.0)) {
+          viewport = .followPuck(
+            zoom: 15,
+            bearing: .heading,
+            pitch: 45
+          )
+        }
+      } label: {
+        Image(systemName: "location.fill")
+      }
+      .buttonStyle(.borderedProminent)
+      .padding()
+    }
+  }
+}
+```
+
+사용자가 지도를 드래그하면 Viewport가 `.idle`이 되어 추적이 멈춥니다. 위 버튼은 사용자가 원할 때만 follow-puck으로 돌아가게 해요. 드래그 직후 자동으로 추적을 재개하면 사용자가 보려던 위치를 빼앗게 됩니다.
+
+## heading과 course를 상황에 맞게 골라요
+
+| 기준      | heading                            | course                            |
+| --------- | ---------------------------------- | --------------------------------- |
+| 의미      | 기기 윗부분이 가리키는 나침반 방향 | 실제 위치 변화가 향하는 이동 방향 |
+| 정지 상태 | 사용할 수 있음                     | 신뢰하기 어려움                   |
+| 대표 화면 | 주변 탐색, AR 방향                 | 차량·자전거 이동                  |
+| 주의점    | 자력계 간섭과 calibration          | 느린 이동과 위치 오차에 민감      |
+
+사용자가 걷지 않는데 course로 Puck을 회전시키면 방향이 없거나 오래된 값이 남을 수 있어요. 주변 지도는 heading, 이동 경로 중심 화면은 course를 검토하되 품질이 낮을 때의 fallback을 정합니다.
+
+## 정확한 위치를 거부해도 앱이 동작하게 해요
+
+iOS 14 이상에서는 사용자가 정확한 위치를 끄고 reduced accuracy만 허용할 수 있어요. 주변 도시나 대략적인 지역을 보여 주는 기능이라면 그대로 동작하게 설계합니다.
+
+정확한 승하차 지점처럼 특정 기능에만 full accuracy가 꼭 필요하면 임시 정확도 요청의 목적 key를 준비할 수 있어요.
+
+```xml
+<key>NSLocationTemporaryUsageDescriptionDictionary</key>
+<dict>
+  <key>PickupLocationAccuracy</key>
+  <string>정확한 승차 위치를 기사에게 전달하기 위해 잠시 정확한 위치가 필요합니다.</string>
+</dict>
+```
+
+정확도를 항상 요구하지 말고 기능을 실행하는 시점에 목적을 설명한 뒤 요청하세요. 거부한 경우 지도를 직접 움직여 위치를 고르거나 주소를 검색하는 대안을 제공하면 기능 전체가 막히지 않습니다.
+
+## 권한 상태별 UI를 설계해요
+
+| 상태              | 화면 동작                                                        |
+| ----------------- | ---------------------------------------------------------------- |
+| not determined    | 기능을 설명한 뒤 사용자 액션에서 권한을 요청해요.                |
+| authorized        | Puck과 내 위치 버튼을 활성화해요.                                |
+| reduced accuracy  | 대략적 위치임을 고려하고 정밀 기능에 대안을 제공해요.            |
+| denied/restricted | 설정 이동 안내와 수동 장소 선택을 제공해요.                      |
+| 위치 신호 대기 중 | 마지막 위치를 현재 위치로 단정하지 말고 loading 상태를 보여줘요. |
+
+권한 거부를 오류처럼 반복 alert로 막기보다 위치 없이도 쓸 수 있는 기본 지도와 검색 기능을 유지하세요.
+
+## 위치가 안 보일 때 순서대로 확인해요
+
+1. `NSLocationWhenInUseUsageDescription`이 실제 앱 Target의 `Info.plist`에 들어갔는지 확인해요.
+2. Simulator에서 **Debug → Simulate Location**으로 테스트 위치를 선택해요.
+3. Settings → Privacy & Security → Location Services에서 앱 권한을 확인해요.
+4. `Map` content에 Puck이 하나만 선언되었는지 확인해요.
+5. 카메라가 다른 대륙을 보고 있다면 `.followPuck`으로 이동해요.
+6. 실제 기기에서 위치 서비스, 비행기 모드와 실내 GPS 환경을 확인해요.
+
+공식 가이드는 한 지도에 Puck을 여러 개 선언하면 마지막 Puck만 표시된다고 안내합니다.
+
+## custom location provider는 테스트·특수 센서에 사용해요
+
+기본 GPS가 아니라 재생 경로, 외부 센서, 테스트 위치를 지도에 공급해야 할 수 있어요. 이때 `LocationProvider`와 `HeadingProvider`를 override할 수 있습니다.
+
+```text
+프로덕션: AppleLocationProvider ──> LocationManager ──> Puck
+테스트:   RecordedLocationProvider ─> LocationManager ──> Puck
+```
+
+custom provider를 사용해도 위치 권한 책임이 자동으로 사라지지는 않아요. 실제 사용자 위치를 얻는 주체가 앱이라면 적절한 권한을 요청해야 합니다. provider의 update 주기, MainActor 전달, 종료와 재시작 수명 주기도 명시적으로 관리하세요.
+
+## 위치 이벤트와 비즈니스 요청을 분리해요
+
+위치가 갱신될 때마다 주변 API를 호출하면 배터리와 네트워크 사용량이 커질 수 있어요.
+
+```text
+위치 update
+  ├─ Puck은 부드럽게 갱신
+  └─ 앱 model은 거리·시간 조건 검사
+         └─ 의미 있게 이동했을 때만 주변 장소 재조회
+```
+
+지도 표현은 빠른 update를 받을 수 있지만 서버 요청은 거리 threshold, debounce, 사용자 새로고침 같은 별도 정책을 적용합니다. 위치 provider나 View 안에서 네트워크 요청을 직접 섞지 않는 편이 테스트하기 쉬워요.
+
+## 개인정보와 telemetry를 함께 확인해요
+
+위치 권한 문구만 추가했다고 개인정보 검토가 끝난 것은 아닙니다.
+
+- 수집하는 위치의 정확도와 보관 기간을 정했나요?
+- 위치를 서버로 보낼 때 꼭 필요한가요?
+- 사용자가 위치 기능을 끈 뒤 기존 데이터 삭제 경로가 있나요?
+- 앱 개인정보 처리방침과 App Store Privacy 응답이 실제 동작과 맞나요?
+- Mapbox attribution control을 통한 telemetry opt-out 경로가 유지되나요?
+
+법적 요구와 Mapbox 약관은 출시 시점에 다시 검토하세요.
+
+## 적용 순서를 정리해요
+
+1. 위치가 필요한 사용자 기능과 대체 흐름을 먼저 정의해요.
+2. 그 기능에 필요한 최소 권한과 정확도를 선택해요.
+3. 사용자 액션 시점에 구체적인 목적을 설명하고 요청해요.
+4. Puck으로 위치를 표시하고 카메라 추적은 별도 Viewport로 연결해요.
+5. 사용자 제스처가 추적을 멈추게 하고 버튼으로 다시 시작해요.
+6. denied·reduced accuracy·신호 대기 상태의 UI를 각각 준비해요.
+7. 위치 update와 서버 요청의 빈도를 분리해 배터리와 비용을 관리해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Puck과 follow-puck Viewport의 차이는 무엇인가요?
+
+Puck은 사용자 위치를 지도에 그리는 콘텐츠이고, follow-puck은 카메라가 그 위치를 따라가게 하는 상태입니다. 하나만 사용해도 다른 하나가 자동으로 생기지 않아요.
+
+### heading과 course는 어떻게 다른가요?
+
+heading은 기기가 향한 나침반 방향이고 course는 실제 이동 방향입니다. 정지 중 방향이 필요하면 heading이 맞고, 차량처럼 움직임을 기준으로 회전하려면 course를 검토해요.
+
+### reduced accuracy에서는 어떻게 대응하나요?
+
+정밀 위치가 없어도 가능한 기능은 대략적 위치로 계속 제공합니다. 정말 필요한 특정 기능에서만 임시 full accuracy를 설명하고 요청하며, 거부하면 주소 검색이나 지도 핀 이동 같은 대안을 제공해요.
+
+## 참고 자료
+
+- [Mapbox User Location 가이드](https://docs.mapbox.com/ios/maps/guides/user-location/)
+- [Mapbox SwiftUI의 사용자 위치](https://docs.mapbox.com/ios/maps/guides/swift-ui/#displaying-a-users-location)
+- [Apple 위치 서비스 권한 요청](https://developer.apple.com/documentation/corelocation/requesting-authorization-to-use-location-services)
+- [Apple `accuracyAuthorization`](https://developer.apple.com/documentation/corelocation/cllocationmanager/accuracyauthorization)
+- [Mapbox 모바일 앱과 telemetry 안내](https://docs.mapbox.com/help/dive-deeper/mobile-apps/)


### PR DESCRIPTION
## 개요

Mapbox Maps SDK for iOS를 처음 도입하는 Swift 개발자가 설치부터 지도 데이터 표현, 위치와 오프라인 저장까지 단계적으로 학습할 수 있는 최상위 문서 섹션을 추가했습니다.

## 변경 사항

- Maps SDK와 Navigation·Search SDK, Mapbox Studio의 역할 경계 및 attribution·telemetry 운영 조건 정리
- SPM source·binary 설치, `MBXAccessToken`, 공개·비밀 Token과 CocoaPods 지원 종료 일정 정리
- SwiftUI `Map`, `Viewport`, 카메라 애니메이션, 고빈도 이벤트와 `MapReader` 사용 기준 정리
- Map Style, GeoJSON·Vector Source, Layer, Expression과 선언형 Map Styling 예제 추가
- View·Layer Annotation 선택 기준, `PointAnnotationGroup`과 GeoJSON 클러스터링 예제 추가
- Core Location 권한, `Puck2D`, heading·course와 follow-puck Viewport 정리
- Style Pack, Tile Region, `OfflineManager`, `TileStore`의 다운로드·갱신·삭제 수명 주기 정리
- 상단 내비게이션과 접힌 한글 사이드바 목차, 7개 페이지의 description metadata 연결

## 검증

- `npm run format`
- `npm run lint`
- `npm run build`
- `git diff --check`
- description 길이와 내부 링크 대상 검사
- 생성된 정적 HTML에서 Mapbox 사이드바의 한글 링크 이름 확인

## 관련 이슈

Closes #47

## 참고

- 공식 Mapbox 가이드, API Reference, 예제와 공식 GitHub 저장소를 기준으로 2026년 8월의 v11 API를 확인했습니다.
- 실제 Access Token은 포함하지 않고 공개·비밀 Token의 배치 경계와 placeholder만 문서화했습니다.
