### PR TITLE
[#49] 상단 내비게이션 항목이 줄바꿈되는 문제를 수정한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -67,7 +67,7 @@
   },
   {
     "text": "디자인 패턴",
-    "link": "/guide/design-patterns/dependency-injection",
+    "link": "/guide/design-patterns/mvc",
     "activeMatch": "/guide/design-patterns/",
     "position": "left"
   }

--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -36,6 +36,12 @@
     "position": "left"
   },
   {
+    "text": "MapKit",
+    "link": "/guide/mapkit/index",
+    "activeMatch": "/guide/mapkit/",
+    "position": "left"
+  },
+  {
     "text": "네이버 지도 SDK",
     "link": "/guide/naver-maps-sdk/index",
     "activeMatch": "/guide/naver-maps-sdk/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -31,6 +31,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "mapkit",
+    "label": "MapKit"
+  },
+  {
+    "type": "dir-section-header",
     "name": "naver-maps-sdk",
     "label": "네이버 지도 SDK"
   },

--- a/docs/guide/combine/_meta.json
+++ b/docs/guide/combine/_meta.json
@@ -8,7 +8,7 @@
     "type": "custom-link",
     "label": "모든 연산자",
     "collapsible": true,
-    "collapsed": false,
+    "collapsed": true,
     "items": [
       {
         "type": "custom-link",

--- a/docs/guide/design-patterns/_meta.json
+++ b/docs/guide/design-patterns/_meta.json
@@ -1,8 +1,23 @@
 [
   {
     "type": "file",
+    "name": "mvc",
+    "label": "MVC"
+  },
+  {
+    "type": "file",
+    "name": "mvvm",
+    "label": "MVVM"
+  },
+  {
+    "type": "file",
+    "name": "mvi",
+    "label": "MVI"
+  },
+  {
+    "type": "file",
     "name": "dependency-injection",
-    "label": "의존성 주입"
+    "label": "의존성·DI·DIP"
   },
   {
     "type": "file",

--- a/docs/guide/design-patterns/dependency-injection.md
+++ b/docs/guide/design-patterns/dependency-injection.md
@@ -342,6 +342,34 @@ final class ProfileViewModel {
 
 이 코드의 의존성은 이니셜라이저에 드러나지 않아요. `ProfileViewModel`이 전역 locator를 직접 호출하므로 locator 자체에도 의존해요. 전역 상태를 테스트마다 바꾸면 테스트가 서로 영향을 줄 수도 있어요.
 
+## MVC, MVVM, MVI에서도 조립 방식은 같아요
+
+의존성 주입은 특정 아키텍처에만 속한 패턴이 아니에요. 화면을 조정하는 객체가 달라져도 저장소를 직접 만들지 않고 앱 시작 지점에서 전달한다는 원칙은 같아요.
+
+```swift
+let repository = LiveProductRepository()
+
+let viewController = ProductListViewController(
+  repository: repository
+)
+
+let viewModel = ProductListViewModel(
+  repository: repository
+)
+
+let store = ProductListStore(
+  repository: repository
+)
+```
+
+| 아키텍처          | 의존성을 받는 대표 객체  | 주입으로 분리하는 책임            |
+| ----------------- | ------------------------ | --------------------------------- |
+| [MVC](./mvc.md)   | Controller               | 화면 흐름과 저장소 생성           |
+| [MVVM](./mvvm.md) | ViewModel                | 표현 상태와 실제 데이터 제공 방식 |
+| [MVI](./mvi.md)   | Store 또는 Effect 실행기 | 순수한 상태 전이와 외부 작업      |
+
+세 구조 모두 `ProductRepository`라는 사용하는 쪽의 약속에 의존하고, 실제 구현은 컴포지션 루트에서 선택할 수 있어요. 의존관계 역전은 아키텍처 이름이 아니라 중요한 정책이 세부 구현을 직접 알지 않게 만드는 의존 방향에 관한 원칙이에요.
+
 ## 모든 의존성을 추상화하지 않아도 돼요
 
 의존성 주입은 비용도 만들어요.

--- a/docs/guide/design-patterns/mvc.md
+++ b/docs/guide/design-patterns/mvc.md
@@ -1,0 +1,315 @@
+---
+title: Swift로 이해하는 MVC
+description: UIKit 상품 목록 예제로 Model·View·Controller의 책임과 데이터 흐름을 이해하고 Massive View Controller를 피하는 분리 기준을 설명합니다.
+---
+
+# Swift로 이해하는 MVC
+
+> **면접 답변 한 줄 요약:** MVC는 앱의 데이터와 핵심 규칙을 Model, 화면 표현을 View, 사용자 입력과 두 영역의 연결을 Controller로 나눠 변경 이유를 분리하는 UI 아키텍처 패턴이에요.
+
+MVC(Model-View-Controller)는 앱 전체를 세 가지 역할로 나누는 오래된 UI 아키텍처 패턴이에요. Apple의 Cocoa와 UIKit도 MVC의 영향을 크게 받았지만, `UIViewController`를 사용한다는 사실만으로 책임이 잘 분리되는 것은 아니에요.
+
+이 문서에서는 상품 목록 화면 하나를 만들며 각 역할의 경계와 데이터 흐름을 살펴봐요.
+
+## 먼저 알아둘 설계 용어
+
+| 용어               | 쉬운 뜻                                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Model              | 화면과 무관한 데이터와 핵심 규칙을 맡는 객체예요. 서버나 저장소에서 데이터를 가져오는 코드도 Model 계층에 포함할 수 있어요. |
+| View               | 사용자가 보는 내용을 그리고 입력을 받는 UI 객체예요. UIKit에서는 `UIView`, `UILabel`, `UITableView` 등이 해당해요.          |
+| Controller         | 사용자 입력을 해석해 Model에 작업을 요청하고, 결과가 View에 반영되도록 조정하는 객체예요.                                   |
+| UIKit              | iPhone과 iPad 앱의 화면, 이벤트, 화면 전환을 구성하는 Apple UI 프레임워크예요.                                              |
+| `UIViewController` | UIKit 화면 하나의 View 계층과 생명주기를 관리하는 기본 Controller 타입이에요.                                               |
+| 도메인 규칙        | 할인, 주문 가능 여부처럼 앱이 해결하는 업무 자체의 규칙이에요. 특정 버튼이나 레이블과 관계없이 성립해야 해요.               |
+| 표현 로직          | 로딩 문구, 날짜 문자열, 버튼 활성화처럼 데이터를 화면에 어떤 형태로 보여줄지 정하는 로직이에요.                             |
+| 결합도             | 한 코드가 다른 코드의 구체적인 구현을 얼마나 많이 아는지 나타내요. 많이 알수록 함께 수정될 가능성이 커져요.                 |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- Model, View, Controller의 책임
+- UIKit에서 사용자 입력과 화면 갱신이 흐르는 순서
+- `UIViewController`가 지나치게 커지는 이유
+- Model과 외부 통신을 Controller에서 분리하는 방법
+- MVC, MVVM, MVI의 차이와 선택 기준
+
+## MVC는 객체를 변경 이유에 따라 나눠요
+
+Apple의 [Model-View-Controller 문서](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Model-View-Controller/Model-View-Controller.html)는 세 역할을 다음처럼 설명해요.
+
+- Model은 앱의 데이터와 그 데이터를 다루는 동작을 캡슐화해요.
+- View는 Model의 내용을 표시하고 사용자의 입력을 받아요.
+- Controller는 View와 Model 사이에서 입력, 상태 변경, 화면 갱신을 조정해요.
+
+상품 목록을 불러오는 흐름은 다음처럼 표현할 수 있어요.
+
+```text
+사용자 입력
+    │
+    ▼
+  View ─────> Controller ─────> Model
+    ▲              │               │
+    └──────── 화면 갱신 <───────────┘
+```
+
+화살표는 객체가 꼭 서로를 직접 참조해야 한다는 뜻이 아니에요. 핵심은 입력을 처리하고 결과를 화면에 반영하는 책임이 어느 역할에 있는지를 보여주는 거예요.
+
+## Model은 UIKit을 몰라도 동작해야 해요
+
+먼저 상품 데이터와 저장소의 약속을 정의해요.
+
+```swift
+struct Product: Decodable, Equatable, Sendable {
+  let id: Int
+  let name: String
+  let price: Int
+}
+
+protocol ProductRepository: Sendable {
+  func fetchProducts() async throws -> [Product]
+}
+```
+
+`Product`와 `ProductRepository`에는 `UIView`, `UITableView`, 화면 색상 같은 UI 타입이 없어요. 이들은 상품 목록이라는 앱의 데이터를 표현하므로 Model 역할에 속해요.
+
+실제 서버 구현도 Model 계층의 세부 구현으로 둘 수 있어요.
+
+```swift
+import Foundation
+
+struct LiveProductRepository: ProductRepository {
+  let session: URLSession
+  let endpoint: URL
+
+  func fetchProducts() async throws -> [Product] {
+    let (data, _) = try await session.data(from: endpoint)
+    return try JSONDecoder().decode([Product].self, from: data)
+  }
+}
+```
+
+이 구현은 네트워크와 JSON 형식을 알지만 화면이 표인지 그리드인지는 몰라요. 같은 Model을 UIKit 목록, SwiftUI 화면, 위젯에서 다시 사용할 수 있어요.
+
+## 모든 코드를 View Controller에 넣으면 책임이 섞여요
+
+처음에는 다음처럼 한 파일에서 빠르게 구현하기 쉬워요.
+
+```swift
+import UIKit
+
+final class ProductListViewController: UITableViewController {
+  private var products: [Product] = []
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    Task {
+      do {
+        let url = URL(string: "https://example.com/products")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        products = try JSONDecoder().decode([Product].self, from: data)
+        tableView.reloadData()
+      } catch {
+        let alert = UIAlertController(
+          title: "불러오기 실패",
+          message: error.localizedDescription,
+          preferredStyle: .alert
+        )
+        present(alert, animated: true)
+      }
+    }
+  }
+}
+```
+
+이 Controller는 너무 많은 사실을 알아요.
+
+- 어떤 URL을 호출하는지 알아요.
+- `URLSession`과 JSON 디코딩 방법을 알아요.
+- 상품 배열을 보관해요.
+- 테이블을 갱신하고 오류 화면도 만들어요.
+- 화면 생명주기와 비동기 작업도 함께 관리해요.
+
+기능이 늘면 이런 타입을 흔히 **Massive View Controller**라고 불러요. 문제는 파일의 줄 수 자체보다 서로 다른 변경 이유가 한 타입에 모인다는 점이에요. API 형식 변경과 화면 디자인 변경이 모두 같은 Controller를 수정하게 만들어요.
+
+## Controller는 조정에 집중하게 만들어요
+
+네트워크와 디코딩을 `ProductRepository` 뒤로 옮기고 Controller는 필요한 저장소를 외부에서 받아요.
+
+```swift
+import UIKit
+
+@MainActor
+final class ProductListViewController: UITableViewController {
+  private let repository: any ProductRepository
+  private var products: [Product] = []
+
+  init(repository: any ProductRepository) {
+    self.repository = repository
+    super.init(style: .plain)
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    title = "상품"
+
+    Task {
+      await loadProducts()
+    }
+  }
+
+  private func loadProducts() async {
+    do {
+      products = try await repository.fetchProducts()
+      tableView.reloadData()
+    } catch {
+      presentError(message: error.localizedDescription)
+    }
+  }
+
+  private func presentError(message: String) {
+    let alert = UIAlertController(
+      title: "불러오기 실패",
+      message: message,
+      preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(title: "확인", style: .default))
+    present(alert, animated: true)
+  }
+}
+```
+
+Controller는 여전히 화면 생명주기, 사용자 입력, View 갱신을 담당해요. 대신 서버 주소와 데이터 해석 방법은 몰라요. 저장소를 이니셜라이저로 받는 방식은 [의존성 주입](./dependency-injection.md)이에요.
+
+앱 시작 지점에서 실제 구현을 조립해요.
+
+```swift
+let repository = LiveProductRepository(
+  session: .shared,
+  endpoint: URL(string: "https://example.com/products")!
+)
+
+let viewController = ProductListViewController(
+  repository: repository
+)
+```
+
+객체를 조립하는 코드와 사용하는 코드를 나누면 테스트나 미리보기에서 저장소 구현을 교체하기 쉬워져요.
+
+## View는 표시와 입력 전달에 집중해요
+
+UIKit의 View 객체는 화면을 그리고 이벤트를 발생시켜요. 버튼을 누르는 입력은 target-action으로 Controller에 전달할 수 있어요.
+
+```swift
+private lazy var retryButton: UIButton = {
+  var configuration = UIButton.Configuration.filled()
+  configuration.title = "다시 시도"
+
+  return UIButton(
+    configuration: configuration,
+    primaryAction: UIAction { [weak self] _ in
+      Task { await self?.loadProducts() }
+    }
+  )
+}()
+```
+
+View가 서버에 직접 요청하거나 상품 가격 규칙을 판단하기 시작하면 역할 경계가 흐려져요. 반대로 폰트, 색상, 레이아웃, 애니메이션처럼 화면 표현에만 필요한 동작은 View에 남겨도 괜찮아요.
+
+## Controller에 어느 정도 로직을 두어도 되나요
+
+Controller에 모든 `if`와 `switch`가 있으면 잘못된 것은 아니에요. 로직이 답하는 질문으로 위치를 판단하세요.
+
+| 질문                                            | 적합한 위치                      |
+| ----------------------------------------------- | -------------------------------- |
+| 상품이 주문 가능한가요?                         | Model의 도메인 규칙              |
+| 상품을 언제 불러오나요?                         | Controller의 화면 흐름           |
+| 오류를 경고창과 빈 화면 중 무엇으로 보여주나요? | Controller와 View의 표현 흐름    |
+| 가격을 어떤 문자열로 보여주나요?                | 작은 Formatter 또는 표현 로직    |
+| 다음 화면으로 언제 이동하나요?                  | Controller 또는 별도 Coordinator |
+
+Controller가 Model의 규칙을 대신 구현하면 같은 규칙을 다른 화면에서 복사하게 돼요. 반대로 작은 화면 흐름까지 모두 별도 객체로 빼면 파일 탐색 비용만 늘어날 수 있어요.
+
+## MVC와 UIKit의 View Controller는 같은 말이 아니에요
+
+`UIViewController`는 UIKit이 제공하는 화면 관리 타입이고, MVC는 책임을 나누는 설계 패턴이에요.
+
+Apple의 Cocoa 문서는 한 객체가 View와 Controller 역할을 함께 맡는 **View Controller**를 허용하지만, 가능한 한 각 역할의 주된 책임을 분명히 하라고 설명해요. 따라서 `UIViewController` 안에 코드를 작성했다는 사실만으로 그 코드가 모두 Controller 역할이 되는 것은 아니에요.
+
+- API 응답을 해석하는 코드는 Model 또는 데이터 계층의 책임이에요.
+- 할인 가능 여부를 판단하는 코드는 도메인 Model의 책임이에요.
+- View 생명주기와 버튼 입력을 연결하는 코드는 Controller의 책임이에요.
+- Auto Layout과 셀 모양은 View의 책임이에요.
+
+역할 이름보다 **왜 이 코드가 바뀌는가**를 기준으로 경계를 찾는 편이 더 정확해요.
+
+## MVC, MVVM, MVI는 연결 방식이 달라요
+
+| 기준           | MVC                           | MVVM                                    | MVI                           |
+| -------------- | ----------------------------- | --------------------------------------- | ----------------------------- |
+| 화면 중간 역할 | Controller                    | ViewModel                               | Intent를 처리하는 Store·Model |
+| 사용자 입력    | View가 Controller에 전달      | View가 ViewModel의 메서드나 입력을 호출 | View가 Intent를 전송          |
+| 화면 상태 전달 | Controller가 View를 갱신      | View가 ViewModel 상태를 관찰·바인딩     | View가 하나의 State를 렌더링  |
+| 상태 변경 경로 | Controller마다 달라질 수 있음 | ViewModel의 공개 API를 통해 변경        | Intent와 Reducer 경로로 제한  |
+| 대표적인 비용  | Controller 비대화             | ViewModel 비대화와 양방향 변경 추적     | State·Intent·Effect 타입 증가 |
+
+[MVVM](./mvvm.md)은 화면에 필요한 상태와 표현 로직을 ViewModel로 옮기고 관찰이나 바인딩으로 View를 갱신해요. [MVI](./mvi.md)는 모든 입력을 Intent로 표현하고 이전 State에서 다음 State를 만드는 한 방향 흐름을 강조해요.
+
+패턴 이름만으로 품질이 결정되지는 않아요. MVC도 Model과 저장소가 잘 분리되어 있다면 충분히 테스트하고 확장할 수 있어요.
+
+## 언제 사용해야 하나요
+
+MVC가 잘 맞는 경우는 다음과 같아요.
+
+- UIKit의 화면 생명주기와 target-action을 직접 다루는 화면이에요.
+- 화면 상태와 사용자 흐름이 단순해요.
+- Controller가 조정할 Model과 View의 수가 많지 않아요.
+- 팀이 UIKit 기본 구조를 유지하면서 필요한 경계부터 분리하려고 해요.
+
+다음 신호가 보이면 MVVM, MVI, Coordinator 또는 별도 서비스 분리를 검토하세요.
+
+- Controller에 네트워크, 디코딩, 저장, 도메인 규칙이 함께 있어요.
+- 로딩·빈 화면·오류·재시도처럼 상태 조합이 많아요.
+- 같은 표현 로직을 여러 화면에서 반복해요.
+- Controller 테스트를 위해 UIKit 객체를 지나치게 많이 준비해야 해요.
+- 화면 전환 코드가 View Controller 전체를 가려요.
+
+작은 정적 화면이라면 추가 추상화 없이 `UIViewController` 하나로도 충분할 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. View Controller의 코드를 Model, View, Controller 역할로 표시해 보세요.
+2. 네트워크, 데이터베이스, 디코딩 코드를 별도 저장소로 옮기세요.
+3. 화면과 무관한 업무 규칙을 Model로 옮기세요.
+4. Controller에는 생명주기, 입력 해석, 화면 갱신 순서를 남기세요.
+5. 바뀔 가능성이 있는 저장소는 이니셜라이저로 주입하세요.
+6. Controller가 계속 커지면 표현 상태는 ViewModel, 화면 전환은 Coordinator처럼 실제 변경 이유에 따라 나누세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### MVC에서 Controller의 역할은 무엇인가요
+
+View에서 발생한 입력을 해석해 Model에 필요한 작업을 요청하고, 결과가 View에 반영되도록 조정해요. 데이터 저장 규칙이나 UI 그리기 자체를 모두 담당하는 객체는 아니에요.
+
+### Massive View Controller는 왜 생기나요
+
+`UIViewController`가 화면 생명주기뿐 아니라 네트워크, 디코딩, 도메인 규칙, 화면 전환까지 맡을 때 생겨요. 줄 수보다 서로 다른 변경 이유가 한 타입에 모였는지를 먼저 확인해야 해요.
+
+### UIKit 앱은 모두 MVC인가요
+
+아니에요. UIKit이 `UIViewController`를 제공하고 MVC의 영향을 받았지만, 앱 코드의 책임과 데이터 흐름을 어떻게 설계했는지에 따라 MVC, MVVM, MVI 또는 혼합 구조가 될 수 있어요.
+
+### Model은 데이터 구조만 의미하나요
+
+아니에요. Model은 데이터뿐 아니라 그 데이터를 검증하고 변경하는 핵심 규칙도 포함해요. 저장소와 서비스처럼 외부 데이터를 제공하는 객체도 넓은 Model 계층에 둘 수 있어요.
+
+## 참고 자료
+
+- [Apple — Model-View-Controller](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Model-View-Controller/Model-View-Controller.html)
+- [Apple — Cocoa Design Patterns](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CocoaFundamentals/CocoaDesignPatterns/CocoaDesignPatterns.html)
+- [Apple — UIViewController](https://developer.apple.com/documentation/uikit/uiviewcontroller)
+- [The Swift Programming Language — Protocols](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/)

--- a/docs/guide/design-patterns/mvi.md
+++ b/docs/guide/design-patterns/mvi.md
@@ -1,0 +1,468 @@
+---
+title: Swift로 이해하는 MVI
+description: SwiftUI 상품 목록 예제로 Model·View·Intent의 단방향 데이터 흐름과 State·Reducer·Effect·Store 구현, 테스트와 적용 기준을 설명합니다.
+---
+
+# Swift로 이해하는 MVI
+
+> **면접 답변 한 줄 요약:** MVI는 사용자와 시스템의 모든 입력을 Intent로 표현하고 이전 State에서 다음 State를 만드는 한 방향 경로를 거쳐 View가 상태를 렌더링하게 해서, 복잡한 화면 변화를 예측하고 테스트하기 쉽게 만드는 패턴이에요.
+
+MVI(Model-View-Intent)는 화면 상태와 입력이 흐르는 경로를 명시적으로 제한하는 UI 아키텍처 패턴이에요. 로딩, 검색, 재시도, 페이지네이션처럼 동시에 고려할 상태가 많을 때 “누가 이 값을 바꿨는가”를 추적하기 쉽게 해요.
+
+MVI 구현마다 사용하는 이름은 달라요. 이 문서에서는 Swift에서 이해하기 쉽도록 `State`, `Intent`, `Reducer`, `Effect`, `Store`라는 이름을 사용해요.
+
+## 먼저 알아둘 설계 용어
+
+| 용어               | 쉬운 뜻                                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Model              | MVI에서 View를 그리는 데 필요한 현재 상태와 상태를 바꾸는 규칙을 뜻해요. 도메인 데이터만 뜻하는 MVC의 Model보다 넓게 쓰일 수 있어요. |
+| View               | 현재 State를 읽어 UI를 그리고 사용자 입력을 Intent로 보내는 역할이에요.                                                              |
+| Intent             | 사용자가 무엇을 하려는지 또는 시스템에서 무엇이 일어났는지를 표현한 입력 값이에요.                                                   |
+| State              | 특정 시점의 화면 전체를 표현하는 값이에요. 같은 State라면 같은 화면을 그릴 수 있어야 해요.                                           |
+| 단방향 데이터 흐름 | 입력, 상태 변경, 화면 렌더링이 정해진 한 방향으로만 순환하는 구조예요.                                                               |
+| Reducer            | 이전 State와 Intent를 받아 다음 State와 필요한 Effect를 계산하는 함수예요.                                                           |
+| Effect             | 네트워크, 데이터베이스, 시각처럼 순수한 상태 계산 밖에서 실행해야 하는 작업이에요.                                                   |
+| Store              | 현재 State를 보관하고 Intent를 Reducer에 전달하며 Effect 실행을 조정하는 객체예요.                                                   |
+| 순수 함수          | 같은 입력에 항상 같은 결과를 내고 함수 바깥의 상태를 직접 바꾸지 않는 함수예요.                                                      |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- Model, View, Intent의 의미와 단방향 데이터 흐름
+- 여러 Bool 상태가 만들 수 있는 모순
+- State, Intent, Reducer, Effect, Store를 순서대로 구현하는 방법
+- SwiftUI와 Observation으로 Store를 관찰하는 방법
+- Reducer와 비동기 Effect를 테스트하는 방법
+- MVVM, Redux, TCA와 MVI의 관계 및 선택 기준
+
+## MVI는 입력과 상태 변경 경로를 하나로 모아요
+
+Cycle.js의 [Model-View-Intent 문서](https://cycle.js.org/model-view-intent.html)는 사용자의 입력을 Intent로 해석하고, Model이 이를 상태로 바꾸며, View가 Model을 렌더링하는 순환 구조를 설명해요.
+
+현대적인 모바일 앱 구현에서는 다음처럼 표현하는 경우가 많아요.
+
+```text
+┌─────────────────────────────────────────────────────┐
+│                                                     │
+│  View ── Intent ──> Store·Reducer ──> State ──> View │
+│                         │                           │
+│                         └── Effect ──> 새 Intent ───┘
+└─────────────────────────────────────────────────────┘
+```
+
+View는 State를 직접 수정하지 않고 Intent를 보내요. Reducer는 이전 State와 Intent를 보고 다음 State를 계산해요. 네트워크 응답도 다시 Intent가 되어 같은 경로로 들어와요.
+
+## 서로 독립적인 상태는 모순을 만들 수 있어요
+
+상품 목록 화면에 여러 프로퍼티를 따로 두어 볼게요.
+
+```swift
+@Observable
+final class ProductListModel {
+  var products: [Product] = []
+  var isLoading = false
+  var isEmpty = false
+  var errorMessage: String?
+}
+```
+
+각 값은 단순하지만 조합이 늘면 허용하면 안 되는 상태가 생겨요.
+
+- `isLoading == true`인데 오류도 표시돼요.
+- 상품이 있는데 `isEmpty == true`예요.
+- 이전 요청의 응답이 새 요청의 상태를 덮어써요.
+- View와 비동기 콜백이 같은 프로퍼티를 서로 다른 순서로 바꿔요.
+
+MVI는 모든 문제를 자동으로 없애지는 않아요. 대신 현재 화면을 State 하나로 표현하고 변경 입구를 Intent로 제한해, 모순이 어디에서 만들어졌는지 찾기 쉽게 해요.
+
+## State는 화면을 다시 그릴 수 있는 값이에요
+
+상품 목록의 상태를 값 타입으로 정의해요.
+
+```swift
+struct Product: Identifiable, Equatable, Sendable {
+  let id: Int
+  let name: String
+  let price: Int
+}
+
+struct ProductListState: Equatable {
+  var products: [Product] = []
+  var query = ""
+  var isLoading = false
+  var errorMessage: String?
+
+  var visibleProducts: [Product] {
+    guard !query.isEmpty else {
+      return products
+    }
+
+    return products.filter { product in
+      product.name.localizedCaseInsensitiveContains(query)
+    }
+  }
+}
+```
+
+`ProductListState`만 있으면 상품 목록, 검색어, 로딩 표시, 오류 메시지를 다시 그릴 수 있어요. `struct`의 값 의미를 사용하면 상태 변경 전후의 스냅샷도 비교하기 쉬워요.
+
+모든 UI 세부 값을 State에 넣을 필요는 없어요. 셀 그림자나 고정된 여백처럼 상태에 따라 달라지지 않는 표현은 View에 두세요.
+
+## Intent는 일어난 일을 값으로 표현해요
+
+View와 시스템에서 들어올 수 있는 입력을 열거형으로 정의해요.
+
+```swift
+enum ProductListIntent: Equatable {
+  case appeared
+  case queryChanged(String)
+  case retryButtonTapped
+  case productsLoaded([Product])
+  case productsLoadingFailed(message: String)
+}
+```
+
+Intent 이름은 구현 명령보다 **무슨 일이 일어났는가**를 드러내는 편이 좋아요.
+
+- `appeared`는 화면이 나타났다는 이벤트예요.
+- `queryChanged`는 검색어 입력이 바뀌었다는 이벤트예요.
+- `productsLoaded`는 비동기 작업이 성공했다는 이벤트예요.
+
+여기서 Intent는 Siri·단축어에 사용하는 Apple의 `AppIntent` 타입과 다른 설계 용어예요. 프로젝트에 혼동이 있다면 `Action`, `Event`, `Msg` 같은 이름을 사용해도 괜찮아요.
+
+## Reducer는 다음 State를 계산해요
+
+네트워크처럼 외부 작업이 필요하다는 사실은 Effect 값으로 표현해요.
+
+```swift
+enum ProductListEffect: Equatable {
+  case loadProducts
+}
+
+struct ProductListTransition: Equatable {
+  let state: ProductListState
+  let effect: ProductListEffect?
+}
+```
+
+Reducer는 이전 State를 복사해 다음 State를 만들어요.
+
+```swift
+func reduce(
+  state: ProductListState,
+  intent: ProductListIntent
+) -> ProductListTransition {
+  var nextState = state
+
+  switch intent {
+  case .appeared, .retryButtonTapped:
+    guard !state.isLoading else {
+      return ProductListTransition(state: state, effect: nil)
+    }
+
+    nextState.isLoading = true
+    nextState.errorMessage = nil
+
+    return ProductListTransition(
+      state: nextState,
+      effect: .loadProducts
+    )
+
+  case let .queryChanged(query):
+    nextState.query = query
+
+  case let .productsLoaded(products):
+    nextState.products = products
+    nextState.isLoading = false
+    nextState.errorMessage = nil
+
+  case let .productsLoadingFailed(message):
+    nextState.isLoading = false
+    nextState.errorMessage = message
+  }
+
+  return ProductListTransition(state: nextState, effect: nil)
+}
+```
+
+이 함수는 네트워크를 호출하거나 전역 값을 읽지 않아요. 같은 State와 Intent에는 항상 같은 Transition을 반환하므로 상태 전이만 빠르게 테스트할 수 있어요.
+
+Reducer가 `inout` State를 수정하는 구현도 가능해요. 중요한 점은 외부 상태를 몰래 바꾸지 않고 Intent를 통해 변경 이유가 드러나는 것이에요.
+
+## Effect는 상태 계산 밖에서 실행해요
+
+상품을 제공하는 저장소의 약속을 정의해요.
+
+```swift
+protocol ProductRepository: Sendable {
+  func fetchProducts() async throws -> [Product]
+}
+```
+
+Store는 현재 State를 보관하고 Reducer가 반환한 Effect를 실행해요.
+
+```swift
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ProductListStore {
+  private(set) var state = ProductListState()
+
+  private let repository: any ProductRepository
+  @ObservationIgnored
+  private var loadTask: Task<Void, Never>?
+
+  init(repository: any ProductRepository) {
+    self.repository = repository
+  }
+
+  func send(_ intent: ProductListIntent) {
+    let transition = reduce(state: state, intent: intent)
+    state = transition.state
+
+    guard let effect = transition.effect else {
+      return
+    }
+
+    run(effect)
+  }
+
+  private func run(_ effect: ProductListEffect) {
+    switch effect {
+    case .loadProducts:
+      loadTask?.cancel()
+      loadTask = Task { [weak self] in
+        guard let self else { return }
+
+        do {
+          let products = try await repository.fetchProducts()
+          guard !Task.isCancelled else { return }
+          send(.productsLoaded(products))
+        } catch {
+          guard !Task.isCancelled else { return }
+          send(
+            .productsLoadingFailed(
+              message: error.localizedDescription
+            )
+          )
+        }
+      }
+    }
+  }
+}
+```
+
+네트워크 성공과 실패도 `productsLoaded`, `productsLoadingFailed` Intent로 돌아와요. 따라서 State를 바꾸는 최종 경로는 다시 Reducer 하나로 모여요.
+
+실무에서는 Effect의 식별자와 취소 정책, 재시도, debounce, 우선순위를 더 정교하게 관리해야 할 수 있어요. 작은 화면에서는 위처럼 직접 구현하고, 기능이 커지면 검증된 아키텍처 라이브러리를 고려할 수 있어요.
+
+## View는 State를 렌더링하고 Intent만 보내요
+
+SwiftUI View는 Store의 State를 읽고 사용자 입력을 Intent로 바꿔요.
+
+```swift
+import SwiftUI
+
+struct ProductListView: View {
+  @State private var store: ProductListStore
+
+  @MainActor
+  init(store: ProductListStore) {
+    _store = State(initialValue: store)
+  }
+
+  var body: some View {
+    NavigationStack {
+      Group {
+        if store.state.isLoading && store.state.products.isEmpty {
+          ProgressView("상품을 불러오는 중이에요")
+        } else if let message = store.state.errorMessage {
+          ContentUnavailableView {
+            Label("불러오기 실패", systemImage: "exclamationmark.triangle")
+          } description: {
+            Text(message)
+          } actions: {
+            Button("다시 시도") {
+              store.send(.retryButtonTapped)
+            }
+          }
+        } else {
+          List(store.state.visibleProducts) { product in
+            VStack(alignment: .leading) {
+              Text(product.name)
+              Text(product.price, format: .currency(code: "KRW"))
+            }
+          }
+        }
+      }
+      .navigationTitle("상품")
+      .searchable(
+        text: Binding(
+          get: { store.state.query },
+          set: { store.send(.queryChanged($0)) }
+        )
+      )
+      .task {
+        store.send(.appeared)
+      }
+    }
+  }
+}
+```
+
+검색창도 `state.query`를 직접 쓰지 않고 `queryChanged` Intent를 보내요. View는 같은 State가 들어오면 같은 UI를 만들고, 상태 변경 규칙은 알지 못해요.
+
+## State와 일회성 동작을 구분해요
+
+화면을 다시 만들 때 복원되어야 하는 정보는 State에 잘 맞아요.
+
+- 현재 검색어
+- 선택한 상품 ID
+- 로딩과 오류 상태
+- 표시 중인 상품 목록
+
+한 번만 실행해야 하는 동작은 별도 Effect나 목적지 State로 모델링할 수 있어요.
+
+- 토스트를 한 번 표시하기
+- 외부 브라우저 열기
+- 햅틱 실행하기
+- 분석 이벤트 보내기
+
+화면 전환은 두 방식 모두 가능해요. 선택된 목적지를 State로 두면 복원과 딥 링크에 유리하고, 외부 시스템 호출은 Effect로 두는 편이 자연스러워요. 일회성 이벤트를 State에 넣고 소비 후 즉시 `nil`로 만드는 방식은 화면 재생성 시 중복 처리되지 않는지 주의해야 해요.
+
+## Reducer는 상태 전이 표처럼 테스트해요
+
+Reducer는 저장소나 View 없이 입력과 출력만 검증할 수 있어요.
+
+```swift
+import Testing
+
+@Test
+func 화면이_나타나면_로딩을_시작해요() {
+  let transition = reduce(
+    state: ProductListState(),
+    intent: .appeared
+  )
+
+  #expect(transition.state.isLoading)
+  #expect(transition.state.errorMessage == nil)
+  #expect(transition.effect == .loadProducts)
+}
+
+@Test
+func 상품을_받으면_로딩을_끝내요() {
+  let products = [
+    Product(id: 1, name: "Swift 책", price: 30_000)
+  ]
+  var state = ProductListState()
+  state.isLoading = true
+
+  let transition = reduce(
+    state: state,
+    intent: .productsLoaded(products)
+  )
+
+  #expect(transition.state.products == products)
+  #expect(!transition.state.isLoading)
+  #expect(transition.effect == nil)
+}
+```
+
+복잡한 화면은 다음처럼 전이 표를 먼저 만들면 빠진 상태를 찾기 쉬워요.
+
+| 이전 State | Intent                  | 다음 State | Effect    |
+| ---------- | ----------------------- | ---------- | --------- |
+| 대기       | `appeared`              | 로딩       | 상품 요청 |
+| 로딩       | `productsLoaded`        | 상품 표시  | 없음      |
+| 로딩       | `productsLoadingFailed` | 오류       | 없음      |
+| 오류       | `retryButtonTapped`     | 로딩       | 상품 요청 |
+
+Effect 테스트에서는 Stub Repository를 주입하고 최종 Intent와 State를 확인할 수 있어요. Reducer 테스트와 비동기 통합 테스트를 분리하면 실패 원인을 찾기 쉬워져요.
+
+## MVI, Redux, TCA는 같은 이름의 패턴이 아니에요
+
+MVI는 단방향 흐름을 강조하는 패턴이고, Redux와 The Composable Architecture(TCA)는 비슷한 원리를 구체적인 도구와 규칙으로 제공해요.
+
+| 개념  | 핵심 구성                                         | MVI와의 관계                                                                   |
+| ----- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| MVI   | Model, View, Intent                               | Intent가 Model을 바꾸고 View가 Model을 렌더링하는 패턴이에요.                  |
+| Redux | Store, State, Action, Reducer                     | 읽기 전용 State와 Action, 순수 Reducer를 사용하는 단방향 상태 관리 방식이에요. |
+| TCA   | State, Action, Reducer, Store, Effect, Dependency | Swift 기능의 합성, 효과, 의존성, 테스트를 함께 제공하는 라이브러리예요.        |
+
+Redux 공식 문서는 Action을 발생한 사건, Reducer를 이전 State와 Action으로 다음 State를 계산하는 함수로 설명하고 한 방향 데이터 흐름을 사용해요. TCA 공식 저장소도 State, Action, Reducer, Store를 핵심 도구로 설명해요.
+
+공통점이 많지만 TCA를 단순히 “MVI 라이브러리”라고 단정할 필요는 없어요. 실제 코드의 상태 변경 경로와 도구가 제공하는 규칙을 설명하는 편이 더 정확해요.
+
+## MVVM과 MVI의 경계는 구현에 따라 겹쳐요
+
+| 기준        | MVVM                                | MVI                                         |
+| ----------- | ----------------------------------- | ------------------------------------------- |
+| 화면 상태   | 여러 관찰 프로퍼티 또는 하나의 상태 | 보통 화면 전체를 표현하는 State 하나        |
+| 사용자 입력 | ViewModel 메서드, Command, Binding  | Intent 또는 Action 값                       |
+| 상태 변경   | ViewModel 내부의 여러 메서드        | Reducer 같은 한 경로로 제한                 |
+| 비동기 작업 | ViewModel이 직접 조정할 수 있음     | Effect로 분리하고 결과를 다시 Intent로 보냄 |
+| 테스트      | ViewModel의 입력 후 상태 확인       | State와 Intent의 전이, Effect를 분리해 확인 |
+| 비용        | 관찰과 ViewModel 타입               | State·Intent·Reducer·Effect·Store 타입      |
+
+[MVVM](./mvvm.md)도 State와 Action, 단방향 흐름을 적용할 수 있어요. 반대로 MVI Store가 화면별 표현 상태를 제공한다는 점에서는 ViewModel처럼 보일 수 있어요. 팀이 같은 용어로 책임과 흐름을 이해하는지가 패턴 이름보다 중요해요.
+
+## 언제 사용해야 하나요
+
+MVI가 잘 맞는 경우는 다음과 같아요.
+
+- 로딩, 오류, 빈 화면, 재시도, 페이지네이션 상태 조합이 복잡해요.
+- 여러 비동기 이벤트가 같은 화면 상태를 바꿔요.
+- 상태 변경 원인을 Action 로그나 전이 테스트로 추적하고 싶어요.
+- 기능을 값 타입 State와 순수 Reducer로 합성하고 싶어요.
+- 동일한 이벤트를 재생해 문제 상황을 재현할 필요가 있어요.
+
+다음 경우에는 더 단순한 MVC나 MVVM으로 충분할 수 있어요.
+
+- 상태가 적고 사용자 입력이 단순한 화면이에요.
+- Intent와 Effect 타입이 실제 문제보다 더 많은 코드를 만들어요.
+- 팀이 Effect 취소, 상태 소유권, Reducer 합성 규칙을 합의하지 않았어요.
+- 일회성 이벤트를 모두 State로 넣어 오히려 수명주기가 불분명해졌어요.
+
+MVI의 목적은 열거형과 `switch`를 늘리는 것이 아니에요. 복잡한 상태 변경의 경로를 제한해 예측 가능성을 얻는 것이 목적이에요.
+
+## 적용 순서를 정리해요
+
+1. 화면을 다시 그리는 데 필요한 값을 하나의 State로 적으세요.
+2. 사용자 입력과 시스템 이벤트를 Intent로 나열하세요.
+3. 각 Intent에 대한 이전 State와 다음 State를 전이 표로 만드세요.
+4. 순수한 상태 계산을 Reducer로 분리하세요.
+5. 네트워크, 저장소, 시각 같은 작업을 Effect로 분리하세요.
+6. Effect 결과를 새 Intent로 보내 같은 변경 경로에 합치세요.
+7. View는 State 렌더링과 Intent 전달만 담당하게 하세요.
+8. Reducer 전이와 Effect 취소·실패 경로를 각각 테스트하세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### MVI의 Intent는 무엇인가요
+
+사용자가 하려는 행동이나 시스템에서 발생한 사건을 값으로 표현한 입력이에요. View가 State를 직접 바꾸지 않고 Intent를 보내게 해서 상태 변경 이유와 경로를 드러내요.
+
+### MVI에서 Model은 도메인 Model과 같은가요
+
+항상 같지는 않아요. MVI의 Model은 View가 렌더링할 현재 상태와 그 상태 변화까지 넓게 가리킬 수 있어요. 실무 구현에서는 혼동을 줄이기 위해 `State`라는 이름을 자주 사용해요.
+
+### Reducer 안에서 네트워크를 호출하면 안 되나요
+
+순수 Reducer로 설계하려면 네트워크 같은 Effect를 직접 실행하지 않는 편이 좋아요. Reducer는 필요한 Effect를 값으로 반환하고 Store가 실행한 뒤 결과를 새 Intent로 보내면 상태 계산을 빠르고 결정적으로 테스트할 수 있어요.
+
+### MVI의 단점은 무엇인가요
+
+작은 기능에도 State, Intent, Reducer, Effect 타입이 늘어날 수 있어요. 비동기 취소와 일회성 이벤트 규칙도 별도로 설계해야 하므로 단순한 화면에서는 비용이 장점보다 클 수 있어요.
+
+### MVI와 MVVM의 가장 큰 차이는 무엇인가요
+
+일반적인 MVI는 모든 입력을 Intent로 만들고 상태 변경을 Reducer 같은 한 경로로 제한한다는 점을 더 강하게 강조해요. MVVM은 View와 표현 로직의 분리가 핵심이며 상태 변경 방식은 구현에 따라 단방향 또는 양방향이 될 수 있어요.
+
+## 참고 자료
+
+- [Cycle.js — Model-View-Intent](https://cycle.js.org/model-view-intent.html)
+- [Hannes Dorfmann — Reactive Apps with Model-View-Intent](https://hannesdorfmann.com/android/mosby3-mvi-2/)
+- [Redux — Concepts and Data Flow](https://redux.js.org/tutorials/fundamentals/part-2-concepts-data-flow)
+- [Point-Free — The Composable Architecture](https://github.com/pointfreeco/swift-composable-architecture)
+- [Apple — Managing model data in your app](https://developer.apple.com/documentation/SwiftUI/Managing-model-data-in-your-app)

--- a/docs/guide/design-patterns/mvvm.md
+++ b/docs/guide/design-patterns/mvvm.md
@@ -1,0 +1,411 @@
+---
+title: Swift로 이해하는 MVVM
+description: SwiftUI와 Observation 상품 목록 예제로 Model·View·ViewModel의 책임, 상태 관찰, 입력 처리, 테스트와 비대화 방지 기준을 설명합니다.
+---
+
+# Swift로 이해하는 MVVM
+
+> **면접 답변 한 줄 요약:** MVVM은 화면에 필요한 상태와 표현 로직을 ViewModel에 두고 View가 이를 관찰하거나 바인딩하게 해서, UI 코드와 상태 변경 로직을 분리하고 View 없이도 동작을 테스트할 수 있게 하는 패턴이에요.
+
+MVVM(Model-View-ViewModel)은 UI와 화면에 필요한 상태·동작을 분리하는 아키텍처 패턴이에요. SwiftUI가 상태를 읽고 자동으로 화면을 다시 만드는 방식과 잘 어울리지만, `@Observable`이나 `ObservableObject`를 사용한다고 자동으로 MVVM이 되는 것은 아니에요.
+
+이 문서에서는 상품 목록 화면을 SwiftUI와 Observation으로 만들며 ViewModel의 역할과 경계를 살펴봐요.
+
+## 먼저 알아둘 설계 용어
+
+| 용어             | 쉬운 뜻                                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| Model            | 화면과 독립적인 데이터, 도메인 규칙, 저장소를 포함하는 영역이에요.                                           |
+| View             | 상태를 읽어 화면을 그리고 사용자 입력을 전달하는 UI예요. SwiftUI의 `View`가 한 예예요.                       |
+| ViewModel        | View가 바로 표시할 상태와 사용자 입력을 처리하는 동작을 제공하는 객체예요. 구체적인 View 타입은 몰라야 해요. |
+| 표현 로직        | 가격 문자열, 로딩 여부, 버튼 활성화처럼 Model을 화면에 맞는 형태로 바꾸는 규칙이에요.                        |
+| 관찰             | 값이 바뀌었을 때 이를 사용하는 View가 갱신될 수 있도록 변경을 추적하는 방식이에요.                           |
+| 바인딩           | View의 입력 값과 상태를 연결해 한쪽의 변경을 다른 쪽에 전달하는 연결이에요.                                  |
+| Observation      | `@Observable` 모델의 프로퍼티 접근과 변경을 추적하는 Apple 프레임워크예요.                                   |
+| 단일 진실 공급원 | 같은 상태를 여러 곳에 따로 저장하지 않고 한 위치를 기준으로 삼는 원칙이에요.                                 |
+
+이 문서에서는 다음 내용을 설명해요.
+
+- Model, View, ViewModel의 책임과 의존 방향
+- View에 비동기 처리와 상태를 모두 둘 때 생기는 문제
+- `@Observable` ViewModel과 SwiftUI View를 연결하는 방법
+- 입력, 출력, 오류, 로딩 상태를 설계하는 기준
+- ViewModel 테스트와 의존성 주입
+- MVC, MVI와 비교해 MVVM을 선택하는 기준
+
+## View는 ViewModel을 알고 ViewModel은 View를 몰라요
+
+Microsoft의 [MVVM 설명](https://learn.microsoft.com/en-us/dotnet/architecture/maui/mvvm)은 View가 ViewModel을 알고, ViewModel이 Model을 알지만, Model과 ViewModel은 자신을 사용하는 View를 모르는 관계로 설명해요.
+
+```text
+사용자 입력
+    │
+    ▼
+  View ─────> ViewModel ─────> Model
+    ▲             │
+    └──── 상태 관찰·바인딩 ────┘
+```
+
+ViewModel은 특정 `Text`, `List`, `UILabel`을 직접 조작하지 않아요. 대신 View가 표시할 값과 실행할 동작을 제공해요. 같은 ViewModel 상태를 SwiftUI View와 UIKit View가 서로 다른 방식으로 표현할 수도 있어요.
+
+## Model은 화면과 독립적인 데이터를 표현해요
+
+상품과 저장소를 먼저 정의해요.
+
+```swift
+struct Product: Identifiable, Equatable, Sendable {
+  let id: Int
+  let name: String
+  let price: Int
+}
+
+protocol ProductRepository: Sendable {
+  func fetchProducts() async throws -> [Product]
+}
+```
+
+이 Model은 상품을 어떤 색상의 셀로 보여줄지, 로딩 표시를 어디에 배치할지 몰라요. 상품 데이터와 이를 제공하는 동작만 표현해요.
+
+## 상태와 비동기 처리를 View에 모으면 테스트 경계가 흐려져요
+
+작은 SwiftUI 화면은 다음처럼 View 안에서 바로 구현할 수 있어요.
+
+```swift
+import SwiftUI
+
+struct ProductListView: View {
+  let repository: any ProductRepository
+
+  @State private var products: [Product] = []
+  @State private var isLoading = false
+  @State private var errorMessage: String?
+  @State private var query = ""
+
+  var body: some View {
+    List(products.filter { product in
+      query.isEmpty || product.name.localizedCaseInsensitiveContains(query)
+    }) { product in
+      Text(product.name)
+    }
+    .task {
+      isLoading = true
+
+      do {
+        products = try await repository.fetchProducts()
+      } catch {
+        errorMessage = error.localizedDescription
+      }
+
+      isLoading = false
+    }
+  }
+}
+```
+
+기능이 작다면 이 코드도 충분할 수 있어요. 하지만 로딩, 재시도, 검색, 정렬, 페이지네이션이 추가되면 View가 다음 책임을 모두 갖게 돼요.
+
+- 화면 선언
+- 비동기 작업 순서
+- 로딩과 오류 상태 전환
+- 상품 검색 규칙
+- 저장소 호출
+
+상태 전환을 테스트하려면 View를 만들고 SwiftUI 생명주기를 실행해야 해요. 같은 표현 로직을 다른 View에서 재사용하기도 어려워져요.
+
+## ViewModel에 화면 상태를 모아요
+
+iOS 17 이상에서는 `@Observable` 매크로로 ViewModel의 변경을 SwiftUI가 관찰하게 만들 수 있어요.
+
+```swift
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ProductListViewModel {
+  enum ViewState: Equatable {
+    case idle
+    case loading
+    case loaded([Product])
+    case failed(message: String)
+  }
+
+  private(set) var state: ViewState = .idle
+  var query = ""
+
+  private let repository: any ProductRepository
+
+  init(repository: any ProductRepository) {
+    self.repository = repository
+  }
+
+  var visibleProducts: [Product] {
+    guard case let .loaded(products) = state else {
+      return []
+    }
+
+    guard !query.isEmpty else {
+      return products
+    }
+
+    return products.filter { product in
+      product.name.localizedCaseInsensitiveContains(query)
+    }
+  }
+
+  func load() async {
+    state = .loading
+
+    do {
+      let products = try await repository.fetchProducts()
+      state = .loaded(products)
+    } catch {
+      state = .failed(message: error.localizedDescription)
+    }
+  }
+}
+```
+
+ViewModel은 화면에서 필요한 네 상태를 명시적으로 표현해요. `visibleProducts`는 원본 상품을 검색어에 맞춰 View가 바로 사용할 값으로 바꾸는 표현 로직이에요.
+
+`@MainActor`는 UI가 관찰하는 상태 변경을 메인 액터에 격리해요. 저장소의 비동기 작업이 끝난 뒤에도 `state` 변경이 같은 격리 영역에서 일어나도록 해요.
+
+## View는 상태를 읽고 입력을 전달해요
+
+View는 ViewModel의 상태를 어떤 UI로 표현할지 결정해요.
+
+```swift
+import SwiftUI
+
+struct ProductListView: View {
+  @State private var viewModel: ProductListViewModel
+
+  @MainActor
+  init(viewModel: ProductListViewModel) {
+    _viewModel = State(initialValue: viewModel)
+  }
+
+  var body: some View {
+    @Bindable var viewModel = viewModel
+
+    NavigationStack {
+      Group {
+        switch viewModel.state {
+        case .idle, .loading:
+          ProgressView("상품을 불러오는 중이에요")
+
+        case .loaded:
+          List(viewModel.visibleProducts) { product in
+            VStack(alignment: .leading) {
+              Text(product.name)
+              Text(product.price, format: .currency(code: "KRW"))
+            }
+          }
+
+        case let .failed(message):
+          ContentUnavailableView {
+            Label("불러오기 실패", systemImage: "exclamationmark.triangle")
+          } description: {
+            Text(message)
+          } actions: {
+            Button("다시 시도") {
+              Task { await viewModel.load() }
+            }
+          }
+        }
+      }
+      .navigationTitle("상품")
+      .searchable(text: $viewModel.query)
+      .task {
+        guard case .idle = viewModel.state else { return }
+        await viewModel.load()
+      }
+    }
+  }
+}
+```
+
+Apple의 [Managing model data in your app](https://developer.apple.com/documentation/SwiftUI/Managing-model-data-in-your-app) 문서는 `@Observable` 모델의 프로퍼티를 View의 `body`가 읽으면 SwiftUI가 그 의존성을 추적하고, 관련 값이 바뀔 때 View를 갱신한다고 설명해요.
+
+`@Bindable`은 `query`를 검색창과 연결하기 위해 사용해요. 관찰은 상태 변경을 알아차리는 기능이고, 바인딩은 View가 값을 다시 쓸 수 있는 연결이라는 차이가 있어요.
+
+## ViewModel은 View의 모양을 직접 결정하지 않아요
+
+ViewModel에는 화면이 필요한 정보가 들어가지만 구체 UI 객체는 넣지 않는 편이 좋아요.
+
+```swift
+// 피하는 편이 좋은 예
+final class ProductListViewModel {
+  var titleLabel: UILabel?
+  var errorAlert: UIAlertController?
+}
+```
+
+이렇게 작성하면 ViewModel을 UIKit 없이 테스트하기 어렵고 다른 UI에서 재사용할 수도 없어요. 대신 다음처럼 UI와 무관한 값으로 표현하세요.
+
+```swift
+enum ViewState: Equatable {
+  case loading
+  case loaded([Product])
+  case failed(message: String)
+}
+```
+
+오류를 경고창으로 보여줄지, 화면 전체 메시지로 보여줄지는 View가 결정해요. ViewModel은 사용자에게 전달할 오류 상태와 문구를 제공해요.
+
+## 입력 메서드는 사용자의 의도를 드러내게 이름 지어요
+
+View가 ViewModel의 프로퍼티를 아무 곳에서나 바꾸게 하면 상태 변경 경로를 찾기 어려워질 수 있어요. 의미 있는 작업은 메서드로 표현할 수 있어요.
+
+```swift
+@MainActor
+extension ProductListViewModel {
+  func retryButtonTapped() async {
+    await load()
+  }
+
+  func searchQueryChanged(_ query: String) {
+    self.query = query
+  }
+}
+```
+
+단순한 텍스트 입력은 바인딩이 간단하고, 로드·저장·삭제처럼 규칙과 부수 효과가 있는 작업은 메서드가 의도를 더 잘 드러내요. 모든 프로퍼티를 기계적으로 `input`과 `output` 타입으로 감싸야 하는 것은 아니에요.
+
+## 테스트에서는 View 없이 상태 전환을 확인해요
+
+저장소를 외부에서 주입하면 ViewModel 테스트에서 준비된 결과를 사용할 수 있어요.
+
+```swift
+private struct StubProductRepository: ProductRepository {
+  let products: [Product]
+
+  func fetchProducts() async throws -> [Product] {
+    products
+  }
+}
+```
+
+Swift Testing으로 로드 결과와 검색 표현을 검증해요.
+
+```swift
+import Testing
+
+@Test
+@MainActor
+func 상품을_불러오고_검색어로_필터링해요() async {
+  let products = [
+    Product(id: 1, name: "Swift 책", price: 30_000),
+    Product(id: 2, name: "키보드", price: 100_000)
+  ]
+  let viewModel = ProductListViewModel(
+    repository: StubProductRepository(products: products)
+  )
+
+  await viewModel.load()
+  viewModel.query = "Swift"
+
+  #expect(viewModel.state == .loaded(products))
+  #expect(viewModel.visibleProducts == [products[0]])
+}
+```
+
+View를 띄우지 않아도 저장소 응답이 어떤 상태로 바뀌는지 확인할 수 있어요. View의 레이아웃과 접근성은 별도의 View 또는 UI 테스트에서 검증해요.
+
+## `@Observable`은 MVVM 자체가 아니에요
+
+`@Observable`, `ObservableObject`, `@Published`는 상태 변경을 전달하는 도구예요. 다음 코드는 관찰 가능하지만 역할이 분리됐다고 보기는 어려워요.
+
+```swift
+@Observable
+final class AppData {
+  var products: [Product] = []
+  var selectedTab = 0
+  var loginToken = ""
+  var cartCount = 0
+}
+```
+
+앱 전체의 관련 없는 상태가 하나의 객체에 모이면 변경 이유와 생명주기가 다시 섞여요. MVVM의 핵심은 프로퍼티 래퍼가 아니라 **화면 표현 책임을 ViewModel이라는 경계에 모으고 View와 Model을 분리하는 것**이에요.
+
+iOS 16 이하를 지원한다면 `ObservableObject`와 `@Published`, `@StateObject`를 사용할 수 있어요. 관찰 기술이 달라져도 ViewModel의 책임은 같아요.
+
+## ViewModel도 지나치게 커질 수 있어요
+
+View Controller의 코드를 전부 ViewModel로 옮기면 **Massive ViewModel**이 돼요.
+
+다음 코드는 별도 역할로 나눌 수 있어요.
+
+- 서버·데이터베이스 접근은 Repository
+- 할인·주문 가능 여부는 도메인 Model
+- 날짜·가격 문자열 규칙이 복잡하면 Formatter
+- 여러 화면의 전환과 생명주기는 Coordinator 또는 Router
+- 여러 기능에서 공유하는 작업 흐름은 Use Case나 Service
+
+ViewModel은 해당 View가 표시할 상태와 입력을 조정하는 데 집중해야 해요. 화면과 무관한 업무 규칙까지 모두 소유하지 않도록 경계를 확인하세요.
+
+## MVC, MVVM, MVI의 차이를 비교해요
+
+| 기준          | MVC                                 | MVVM                                     | MVI                                   |
+| ------------- | ----------------------------------- | ---------------------------------------- | ------------------------------------- |
+| 중간 역할     | Controller가 View와 Model을 조정    | ViewModel이 표현 상태와 입력 동작을 제공 | Store·Reducer가 Intent를 State로 변환 |
+| View 갱신     | Controller가 명령하거나 관찰을 연결 | View가 ViewModel 상태를 관찰·바인딩      | View가 하나의 State를 렌더링          |
+| 상태 변경 API | Controller 메서드마다 다름          | ViewModel 메서드와 쓰기 가능한 상태      | Intent 전송으로 제한                  |
+| 테스트 초점   | Model과 Controller 조정             | ViewModel의 입력과 출력 상태             | State 전이와 Effect                   |
+| 주의할 점     | Massive View Controller             | Massive ViewModel, 숨은 양방향 변경      | 타입과 보일러플레이트 증가            |
+
+[MVC](./mvc.md)는 UIKit의 View Controller 중심 흐름에 자연스럽고, [MVI](./mvi.md)는 가능한 모든 상태와 입력 경로를 명시해 복잡한 상태 전이를 추적하는 데 유리해요.
+
+MVVM에서도 상태를 값 타입 하나로 모으고 Action을 사용하면 단방향 흐름을 만들 수 있어요. 패턴 경계는 구현 방식에 따라 겹칠 수 있으므로 이름보다 실제 의존 방향과 상태 변경 경로를 확인하세요.
+
+## 언제 사용해야 하나요
+
+MVVM이 잘 맞는 경우는 다음과 같아요.
+
+- View에 비동기 처리와 표현 로직이 쌓이고 있어요.
+- 같은 상태를 SwiftUI가 관찰해 자동으로 갱신해야 해요.
+- View 없이 로딩, 오류, 입력 검증을 단위 테스트하고 싶어요.
+- Model의 데이터를 화면에 맞게 조합하거나 변환할 필요가 있어요.
+- UIKit과 SwiftUI가 같은 표현 상태를 공유해야 해요.
+
+다음 경우에는 더 단순한 구조를 고려하세요.
+
+- 상태가 거의 없는 정적 화면이에요.
+- ViewModel이 View의 프로퍼티를 그대로 복사하기만 해요.
+- 도메인 규칙까지 ViewModel에 몰아넣어 또 다른 거대한 타입을 만들고 있어요.
+- 상태 전이가 매우 복잡해 누가 언제 값을 바꿨는지 추적하기 어려워요. 이 경우 MVI 같은 명시적인 단방향 흐름이 도움이 될 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. View에 있는 상태와 비동기 작업을 목록으로 적으세요.
+2. 화면과 무관한 데이터와 업무 규칙은 Model에 남기세요.
+3. View가 표시할 상태와 표현 로직을 ViewModel로 옮기세요.
+4. 저장소와 외부 환경은 ViewModel 이니셜라이저로 주입하세요.
+5. View는 상태를 읽어 그리는 코드와 입력 전달에 집중하세요.
+6. ViewModel 상태 전환을 View 없이 테스트하세요.
+7. ViewModel이 커지면 Repository, Use Case, Formatter, Coordinator처럼 실제 책임에 따라 나누세요.
+
+## 면접에서 이어질 수 있는 질문
+
+### MVVM에서 ViewModel의 역할은 무엇인가요
+
+Model을 View가 표시하기 쉬운 상태로 바꾸고 사용자 입력에 따른 작업을 조정해요. 구체적인 View 타입을 직접 조작하지 않아야 View 없이 테스트하고 다른 UI에서도 재사용할 수 있어요.
+
+### SwiftUI에서 `@Observable`을 사용하면 MVVM인가요
+
+아니에요. `@Observable`은 상태 관찰을 제공하는 기술일 뿐이에요. View, 표현 상태, 도메인 Model의 책임과 의존 방향을 분리했는지가 MVVM 판단의 핵심이에요.
+
+### ViewModel에 비즈니스 로직을 넣어도 되나요
+
+화면 상태를 만들기 위한 표현 로직은 ViewModel에 둘 수 있어요. 할인이나 주문 가능 여부처럼 화면과 무관한 도메인 규칙은 Model이나 별도 Use Case에 두어 여러 화면에서 재사용하는 편이 좋아요.
+
+### MVVM의 단점은 무엇인가요
+
+ViewModel과 관찰 상태가 늘어나고, 양방향 바인딩이 많으면 값이 바뀐 경로를 추적하기 어려워질 수 있어요. 작은 화면에 기계적으로 적용하면 타입과 연결 코드만 늘어날 수도 있어요.
+
+## 참고 자료
+
+- [Microsoft Learn — Model-View-ViewModel](https://learn.microsoft.com/en-us/dotnet/architecture/maui/mvvm)
+- [Apple — Managing model data in your app](https://developer.apple.com/documentation/SwiftUI/Managing-model-data-in-your-app)
+- [Apple — Migrating from the ObservableObject protocol to the Observable macro](https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro)
+- [The Swift Programming Language — Properties](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/properties/)

--- a/docs/guide/mapkit/_meta.json
+++ b/docs/guide/mapkit/_meta.json
@@ -1,0 +1,55 @@
+[
+  {
+    "type": "custom-link",
+    "label": "MapKit 시작하기",
+    "link": "/guide/mapkit/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "지도 화면과 카메라",
+    "link": "/guide/mapkit/swiftui-map-and-camera",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "SwiftUI 지도와 카메라",
+        "link": "/guide/mapkit/swiftui-map-and-camera"
+      },
+      {
+        "type": "custom-link",
+        "label": "UIKit MKMapView",
+        "link": "/guide/mapkit/uikit-map-view"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "지도 데이터와 탐색",
+    "link": "/guide/mapkit/annotations-overlays-and-clustering",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "Annotation·Overlay·클러스터링",
+        "link": "/guide/mapkit/annotations-overlays-and-clustering"
+      },
+      {
+        "type": "custom-link",
+        "label": "검색·지오코딩·Look Around",
+        "link": "/guide/mapkit/search-geocoding-and-look-around"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "사용자 위치와 경로",
+    "link": "/guide/mapkit/user-location-and-directions"
+  },
+  {
+    "type": "custom-link",
+    "label": "스냅샷과 커스텀 타일",
+    "link": "/guide/mapkit/snapshots-and-tile-overlays"
+  }
+]

--- a/docs/guide/mapkit/annotations-overlays-and-clustering.md
+++ b/docs/guide/mapkit/annotations-overlays-and-clustering.md
@@ -1,0 +1,229 @@
+---
+title: MapKit Annotation·Overlay·클러스터링
+description: SwiftUI Marker·Annotation·Overlay와 UIKit MKAnnotationView 자동 클러스터링을 비교하고 데이터 규모에 맞는 지도 표현 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# MapKit Annotation·Overlay·클러스터링
+
+> 면접용 한 줄 요약: **한 지점의 정보와 선택은 Annotation, 선·면처럼 지리 범위를 가진 데이터는 Overlay로 표현하고, 겹치는 대량 지점은 `MKAnnotationView.clusteringIdentifier`로 묶습니다.**
+
+## 먼저 점·선·면을 구분해요
+
+| 데이터    | SwiftUI MapKit            | UIKit MapKit                       | 대표 예시               |
+| --------- | ------------------------- | ---------------------------------- | ----------------------- |
+| 한 지점   | `Marker`, `Annotation`    | `MKAnnotation`, `MKAnnotationView` | 매장, 정류장, 사고 지점 |
+| 현재 위치 | `UserAnnotation`          | `MKUserLocation`                   | 사용자 위치와 정확도    |
+| 선        | `MapPolyline`             | `MKPolyline`, `MKPolylineRenderer` | 경로, 산책로            |
+| 닫힌 면   | `MapPolygon`              | `MKPolygon`, `MKPolygonRenderer`   | 배달 가능 구역          |
+| 원        | `MapCircle`               | `MKCircle`, `MKCircleRenderer`     | 반경 검색 범위          |
+| 타일      | SwiftUI 전용 content 없음 | `MKTileOverlay`, Renderer          | 날씨·지적도 타일        |
+
+Annotation과 Overlay는 둘 다 지도 위에 보이지만 수명과 렌더링 구조가 다릅니다. 경로의 모든 좌표를 작은 Annotation 수백 개로 만들지 마세요.
+
+## `Marker`는 표준 핀을 빠르게 만들어요
+
+```swift
+Map {
+  Marker(
+    "서울시청",
+    systemImage: "building.columns.fill",
+    coordinate: .init(latitude: 37.5666, longitude: 126.9784)
+  )
+  .tint(.blue)
+}
+```
+
+검색 결과가 `MKMapItem`이라면 `Marker(item:)`을 사용해 장소 이름과 Apple Maps의 아이콘·색 정보를 활용할 수 있어요.
+
+```swift
+Map {
+  ForEach(searchResults, id: \.self) { item in
+    Marker(item: item)
+  }
+}
+```
+
+표준 장소 표현에는 `Marker`를 먼저 선택하세요. 모든 핀을 custom SwiftUI View로 만들면 레이아웃과 렌더링 비용이 커질 수 있습니다.
+
+## `Annotation`은 custom View가 필요할 때 사용해요
+
+```swift
+Annotation(
+  "예약 가능",
+  coordinate: place.coordinate,
+  anchor: .bottom
+) {
+  VStack(spacing: 2) {
+    Text("3석")
+      .font(.caption.bold())
+      .padding(6)
+      .background(.blue, in: Capsule())
+      .foregroundStyle(.white)
+
+    Image(systemName: "mappin")
+      .foregroundStyle(.blue)
+  }
+  .accessibilityLabel("\(place.name), 예약 가능 3석")
+}
+```
+
+`anchor: .bottom`은 custom View의 아래쪽을 좌표에 맞춥니다. 화면에 보이는 말풍선 전체의 중심을 좌표에 놓는 실수를 피할 수 있어요. 텍스트와 선택 상태가 있는 custom View에는 VoiceOver label도 함께 설계합니다.
+
+## 선택은 콘텐츠의 정체성과 연결해요
+
+```swift
+@State private var selectedID: String?
+
+Map(selection: $selectedID) {
+  ForEach(places) { place in
+    Marker(place.name, coordinate: place.coordinate)
+      .tag(place.id)
+  }
+}
+```
+
+좌표는 변경될 수 있으므로 장소 ID로 선택을 추적하는 편이 안전합니다. 선택된 핀을 별도 배열로 복제하기보다 `selectedID`에서 표현을 계산하세요.
+
+## 경로와 영역은 Overlay로 그려요
+
+```swift
+Map {
+  MapPolyline(coordinates: routeCoordinates)
+    .stroke(.blue, style: StrokeStyle(lineWidth: 6, lineCap: .round))
+
+  MapCircle(
+    center: .init(latitude: 37.5666, longitude: 126.9784),
+    radius: 500
+  )
+  .foregroundStyle(.blue.opacity(0.12))
+  .stroke(.blue.opacity(0.6), lineWidth: 2)
+}
+```
+
+직선 좌표 배열은 `MapPolyline(coordinates:)`, 계산된 길 안내는 `MapPolyline(route)`로 표시할 수 있어요. 아주 먼 두 지점의 최단 곡선을 표현하려면 contour style의 `.geodesic`을 검토합니다.
+
+Overlay의 터치 영역은 선 두께와 일치하지 않을 수 있어요. 경로 선택이 핵심이면 접근 가능한 목록이나 버튼을 함께 제공하고, 화면 좌표 변환 뒤 선과의 거리를 계산하는 별도 hit testing 정책을 둡니다.
+
+## UIKit 자동 클러스터링은 View 식별자로 켜요
+
+MapKit은 같은 `clusteringIdentifier`를 가진 Annotation View가 화면에서 충돌하면 여러 지점을 `MKClusterAnnotation` 하나로 바꿉니다.
+
+```swift
+final class MapCoordinator: NSObject, MKMapViewDelegate {
+  private let placeID = "place"
+
+  func registerViews(on mapView: MKMapView) {
+    mapView.register(
+      MKMarkerAnnotationView.self,
+      forAnnotationViewWithReuseIdentifier: placeID
+    )
+    mapView.register(
+      MKMarkerAnnotationView.self,
+      forAnnotationViewWithReuseIdentifier:
+        MKMapViewDefaultClusterAnnotationViewReuseIdentifier
+    )
+  }
+
+  func mapView(
+    _ mapView: MKMapView,
+    viewFor annotation: any MKAnnotation
+  ) -> MKAnnotationView? {
+    guard !(annotation is MKUserLocation) else {
+      return nil
+    }
+
+    if annotation is MKClusterAnnotation {
+      let cluster = mapView.dequeueReusableAnnotationView(
+        withIdentifier: MKMapViewDefaultClusterAnnotationViewReuseIdentifier,
+        for: annotation
+      ) as? MKMarkerAnnotationView
+      cluster?.markerTintColor = .systemIndigo
+      return cluster
+    }
+
+    let marker = mapView.dequeueReusableAnnotationView(
+      withIdentifier: placeID,
+      for: annotation
+    ) as? MKMarkerAnnotationView
+    marker?.clusteringIdentifier = "places"
+    marker?.displayPriority = .defaultHigh
+    marker?.canShowCallout = true
+    return marker
+  }
+}
+```
+
+기본값 `nil`은 클러스터링에 참여하지 않는다는 뜻이에요. 서로 다른 종류를 별도 그룹으로 묶고 싶다면 `"restaurants"`, `"stations"`처럼 식별자를 나눕니다.
+
+## 클러스터 표시를 custom으로 만들 수 있어요
+
+delegate의 `mapView(_:clusterAnnotationForMemberAnnotations:)`에서 cluster 데이터 구성을 바꾸거나 custom `MKAnnotationView`에서 `MKClusterAnnotation.memberAnnotations`를 읽어 개수와 유형 비율을 표시할 수 있어요.
+
+```swift
+final class CountClusterView: MKMarkerAnnotationView {
+  override func prepareForDisplay() {
+    super.prepareForDisplay()
+
+    guard let cluster = annotation as? MKClusterAnnotation else {
+      return
+    }
+
+    glyphText = String(cluster.memberAnnotations.count)
+    markerTintColor = .systemIndigo
+    displayPriority = .defaultHigh
+  }
+}
+```
+
+재사용되므로 `prepareForDisplay()`에서 이전 cluster의 모든 가변 상태를 다시 설정해야 합니다.
+
+## SwiftUI `Map`의 클러스터링 경계를 알아둬요
+
+현재 SwiftUI `MapContent`의 `Marker`와 `Annotation`에는 UIKit의 `clusteringIdentifier`에 해당하는 공개 설정이 없습니다. 이 판단은 SwiftUI API 목록과 UIKit 클러스터링 API를 비교한 결과예요.
+
+클러스터링이 꼭 필요하면 두 방법을 검토합니다.
+
+1. `MKMapView`를 `UIViewRepresentable`로 감싸 시스템 자동 클러스터링을 사용해요.
+2. 화면 영역과 확대 수준에 따라 앱 모델에서 지점을 미리 묶고, 결과 cluster를 SwiftUI Marker로 표현해요.
+
+두 번째 방식은 반경·확대 수준·animation·selection을 모두 앱이 책임져야 합니다. 단순히 핀이 많다는 이유만으로 즉시 custom 알고리즘을 만들기보다 실제 기기에서 가독성과 frame time을 측정하고 `MKMapView`도 비교하세요.
+
+## 표시 우선순위는 클러스터링과 별개예요
+
+`displayPriority`는 Annotation이 겹칠 때 무엇을 먼저 보일지 정합니다. `collisionMode`는 충돌 영역을 사각형이나 원으로 판단하게 해요. 둘은 “같은 그룹으로 합친다”는 `clusteringIdentifier`와 역할이 다릅니다.
+
+```text
+clusteringIdentifier ──> 겹친 View를 하나의 cluster로 묶을 수 있는가?
+displayPriority ───────> 겹쳤을 때 어떤 Annotation을 우선 보일 것인가?
+collisionMode ─────────> 화면상의 충돌 영역을 어떤 모양으로 판단할 것인가?
+```
+
+## 체크리스트
+
+- [ ] 한 점은 Annotation, 선·면은 Overlay로 표현하나요?
+- [ ] 표준 핀으로 충분할 때 custom View를 만들지 않나요?
+- [ ] 선택과 갱신에 안정적인 장소 ID를 사용하나요?
+- [ ] UIKit leaf View에 non-nil `clusteringIdentifier`를 설정했나요?
+- [ ] cluster와 leaf 재사용 View 상태를 매번 초기화하나요?
+- [ ] 대량 핀 전후 성능을 실제 기기에서 측정했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `MKAnnotation`과 `MKOverlay`는 어떻게 다른가요?
+
+Annotation은 특정 좌표의 점 정보와 선택 UI에 적합하고, Overlay는 선·면처럼 지도상의 넓은 영역을 나타냅니다. UIKit에서는 각각 재사용 Annotation View와 Overlay Renderer가 화면 표현을 담당해요.
+
+### MapKit 자동 클러스터링은 언제 발생하나요?
+
+같은 non-nil `clusteringIdentifier`를 가진 Annotation View들이 화면에서 충돌할 때 MapKit이 `MKClusterAnnotation`으로 대체합니다. 원본 Annotation 데이터가 삭제되는 것은 아니며 확대하면 다시 개별 View로 나타날 수 있어요.
+
+## 참고 자료
+
+- [SwiftUI Marker 공식 문서](https://developer.apple.com/documentation/mapkit/marker)
+- [SwiftUI Annotation 공식 문서](https://developer.apple.com/documentation/mapkit/annotation)
+- [MapPolyline 공식 문서](https://developer.apple.com/documentation/mapkit/mappolyline)
+- [MapKit Annotation Clustering 공식 예제](https://developer.apple.com/documentation/mapkit/decluttering-a-map-with-mapkit-annotation-clustering)
+- [MKAnnotationView.clusteringIdentifier 공식 문서](https://developer.apple.com/documentation/mapkit/mkannotationview/clusteringidentifier)
+- [MKClusterAnnotation 공식 문서](https://developer.apple.com/documentation/mapkit/mkclusterannotation)

--- a/docs/guide/mapkit/index.md
+++ b/docs/guide/mapkit/index.md
@@ -1,0 +1,138 @@
+---
+title: Swift로 이해하는 Apple MapKit
+description: Apple MapKit의 SwiftUI·UIKit 지도 구조와 검색, 위치, 경로, Look Around, 클러스터링, 스냅샷 학습 순서를 한눈에 정리합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 Apple MapKit
+
+> 면접용 한 줄 요약: **MapKit은 Apple 지도 데이터를 SwiftUI의 선언형 `Map` 또는 UIKit의 `MKMapView`로 표시하고, `MKMapItem`을 중심으로 검색·장소·경로·Look Around 기능을 연결하는 시스템 프레임워크입니다.**
+
+## 먼저 MapKit의 범위를 구분해요
+
+MapKit은 단순한 지도 View 하나가 아니에요. 앱 화면, 장소 검색, 경로 계산, 정적 이미지까지 여러 API가 한 프레임워크 안에 있습니다.
+
+| 만들 기능         | 선택할 API                                        | 핵심 역할                                                |
+| ----------------- | ------------------------------------------------- | -------------------------------------------------------- |
+| SwiftUI 지도 화면 | `Map`, `MapContentBuilder`                        | Marker, Annotation, Overlay와 카메라를 선언해요.         |
+| UIKit 지도 화면   | `MKMapView`, `MKMapViewDelegate`                  | 재사용 Annotation View와 클러스터링을 세밀하게 제어해요. |
+| 장소·주소 검색    | `MKLocalSearch`, `MKLocalSearchCompleter`         | 자연어 검색과 자동 완성 결과를 `MKMapItem`으로 반환해요. |
+| 주소와 좌표 변환  | `MKGeocodingRequest`, `MKReverseGeocodingRequest` | 주소를 좌표로, 좌표를 주소로 바꿔요.                     |
+| 경로와 예상 시간  | `MKDirections`, `MKRoute`                         | 출발지와 목적지 사이 경로, 단계, 거리와 시간을 계산해요. |
+| 거리 수준 탐색    | `MKLookAroundSceneRequest`, `LookAroundPreview`   | 지원 지역의 Look Around 장면을 표시해요.                 |
+| 정적 지도 이미지  | `MKMapSnapshotter`                                | 공유 카드나 미리 보기에 쓸 지도 이미지를 만들어요.       |
+| 커스텀 타일       | `MKTileOverlay`, `MKTileOverlayRenderer`          | 앱이 제공하는 래스터 타일을 기본 지도 위나 대신 그려요.  |
+
+전체 흐름은 `MKMapItem`을 중심으로 이어집니다.
+
+```text
+검색어 ──> MKLocalSearch ──> MKMapItem ──┬─> Marker로 표시
+주소   ──> MKGeocodingRequest ───────────┤
+선택한 장소 ──────────────────────────────┼─> Look Around 장면 요청
+현재 위치 + 목적지 ───────────────────────┴─> MKDirections ──> MKRoute
+```
+
+## 설치형 SDK가 아니에요
+
+네이티브 MapKit은 Apple 플랫폼 SDK에 포함된 시스템 프레임워크입니다. Swift Package Manager로 패키지를 추가하거나 Mapbox·네이버 지도처럼 클라이언트 ID나 Access Token을 넣지 않고 Target 코드에서 import해 시작해요.
+
+```swift
+import MapKit
+import SwiftUI
+
+struct FirstMap: View {
+  var body: some View {
+    Map()
+  }
+}
+```
+
+`MapKit JS`, Maps Server API, Maps Embed API는 별도 제품입니다. 웹과 서버 API는 Maps Token을 사용하므로 네이티브 `MapKit`의 설정과 섞지 마세요.
+
+:::warning Maps capability를 무조건 켜지 않아요
+일반적인 지도 표시를 위해 별도 Maps capability를 추가할 필요는 없습니다. Xcode의 Maps capability와 routing app coverage 파일은 앱이 다른 앱에 길 안내를 제공하는 **routing app**으로 동작할 때 검토하는 설정이에요.
+:::
+
+## 지도 표시와 현재 위치 접근은 달라요
+
+지도를 보여 주거나 고정 좌표에 Marker를 놓는 것만으로는 위치 권한이 필요하지 않습니다. 사용자의 실제 위치를 읽을 때 Core Location 권한이 필요해요.
+
+```text
+고정된 서울시청 좌표 표시 ──> 위치 권한 불필요
+사용자가 지도를 이동·확대 ──> 위치 권한 불필요
+현재 위치 표시·추적 ─────────> Core Location 권한 필요
+```
+
+권한은 앱 시작과 동시에 요청하기보다 사용자가 “내 위치” 기능을 선택한 시점에 목적을 설명하고 최소 범위로 요청합니다.
+
+## SwiftUI와 UIKit 중 무엇을 고르나요?
+
+| 기준            | SwiftUI `Map`                                     | UIKit `MKMapView`                                   |
+| --------------- | ------------------------------------------------- | --------------------------------------------------- |
+| 화면 구성       | `MapContentBuilder`로 선언해요.                   | delegate와 add/remove 메서드로 갱신해요.            |
+| 카메라          | `MapCameraPosition` binding을 사용해요.           | `region`, `camera`, `setVisibleMapRect`를 사용해요. |
+| 커스텀 표시     | `Marker`, `Annotation`, `MapPolyline`이 간결해요. | 재사용 Annotation View와 Renderer를 직접 제어해요.  |
+| 자동 클러스터링 | SwiftUI 전용 설정이 없어요.                       | `clusteringIdentifier`를 제공합니다.                |
+| 기존 UIKit 화면 | wrapping 비용이 생길 수 있어요.                   | 자연스럽게 통합돼요.                                |
+
+새로운 iOS 17 이상 SwiftUI 화면은 `Map`부터 시작하세요. Annotation View 재사용, 자동 클러스터링, 세밀한 delegate 동작이 제품의 핵심이면 `MKMapView`가 더 명확합니다. SwiftUI에서 `MKMapView`가 필요하면 `UIViewRepresentable`로 감싸되 두 상태 체계가 서로 카메라를 계속 덮어쓰지 않게 경계를 정해야 해요.
+
+## 지도 SDK를 고르는 기준도 달라요
+
+| 기준                   | Apple MapKit                      | 네이버 지도 SDK            | Mapbox Maps SDK                |
+| ---------------------- | --------------------------------- | -------------------------- | ------------------------------ |
+| 배포 방식              | Apple SDK에 포함                  | 외부 SDK 설치              | 외부 SDK 설치                  |
+| 기본 지도 데이터       | Apple Maps                        | NAVER 지도                 | Mapbox Style·Tileset           |
+| 시작 인증              | 네이티브 앱은 별도 Token 없음     | Client ID 설정             | 공개 Access Token 설정         |
+| 선언형 SwiftUI API     | 공식 `Map` 제공                   | `UIViewRepresentable` 중심 | 공식 SwiftUI `Map` 제공        |
+| 데이터 시각화 자유도   | Annotation·Overlay 중심           | Overlay 중심               | Source·Layer·Expression이 강점 |
+| 오프라인 영역 다운로드 | Apple 기본 지도 다운로드 API 없음 | 별도 요구 사항 확인        | Tile Region·Style Pack 제공    |
+
+MapKit이 항상 정답이라는 뜻은 아니에요. 서비스 국가의 지도 품질, 브랜드 Style, 대량 지리 데이터, 오프라인 요구, 검색·길 안내 결과 품질을 실제 제품 지역에서 비교해야 합니다.
+
+## API 가용성을 먼저 정해요
+
+- iOS 17부터 확장된 SwiftUI `Map`, `MapCameraPosition`, `MapContentBuilder`를 이 섹션의 기본 예제로 사용해요.
+- iOS 16 이하를 지원하면 deprecated된 예제를 그대로 복사하기보다 `MKMapView` bridge 또는 별도 호환 계층을 검토해요.
+- iOS 26의 `MKGeocodingRequest`와 `MKReverseGeocodingRequest`를 쓸 때는 deployment target을 확인하고, 이전 OS에서는 기존 Core Location 지오코딩 경로를 유지해야 해요.
+- Look Around와 검색 결과는 모든 장소에서 같은 수준으로 제공되지 않으므로 “결과 없음” UI가 필요해요.
+
+## 여섯 페이지를 이 순서로 읽어요
+
+1. [SwiftUI 지도와 카메라](/guide/mapkit/swiftui-map-and-camera)에서 지도 콘텐츠와 카메라 상태를 연결해요.
+2. [UIKit MKMapView](/guide/mapkit/uikit-map-view)에서 delegate, 재사용, SwiftUI bridge를 배워요.
+3. [Annotation·Overlay·클러스터링](/guide/mapkit/annotations-overlays-and-clustering)에서 점·선·면과 대량 지점을 구분해요.
+4. [검색·지오코딩·Look Around](/guide/mapkit/search-geocoding-and-look-around)에서 문자열과 좌표를 장소 정보로 바꿔요.
+5. [사용자 위치와 경로](/guide/mapkit/user-location-and-directions)에서 권한과 `MKDirections`를 연결해요.
+6. [스냅샷과 커스텀 타일](/guide/mapkit/snapshots-and-tile-overlays)에서 상호작용 없는 이미지와 외부 타일을 다뤄요.
+
+시작 페이지를 포함해 총 7개 문서예요.
+
+## 시작 전 체크리스트
+
+- [ ] 지원 OS에 맞는 SwiftUI `Map` API를 선택했나요?
+- [ ] 지도 표시와 현재 위치 권한을 분리했나요?
+- [ ] 장소의 공통 모델로 `MKMapItem`을 사용할지 정했나요?
+- [ ] 검색·경로 요청을 화면 수명과 함께 취소하나요?
+- [ ] Look Around와 검색 결과가 없을 때 대체 UI가 있나요?
+- [ ] Apple 지도 로고와 Legal 링크를 다른 UI로 가리지 않나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### MapKit과 Core Location은 어떻게 다른가요?
+
+MapKit은 지도 표시, 장소 검색, 경로, Look Around 같은 지도 경험을 담당합니다. Core Location은 사용자 위치와 방향, 위치 권한을 담당해요. MapKit 지도만 표시할 때는 권한이 필요 없지만 실제 현재 위치를 읽으면 Core Location 규칙을 따라야 합니다.
+
+### MapKit 네이티브 앱에도 Maps Token이 필요한가요?
+
+네이티브 `MapKit` 프레임워크의 일반 지도 표시는 별도 Maps Token을 요구하지 않습니다. Maps Token은 MapKit JS, Maps Server API, Maps Embed API 같은 웹·서버 제품의 인증에 사용돼요.
+
+## 참고 자료
+
+- [Apple MapKit 공식 문서](https://developer.apple.com/documentation/mapkit)
+- [MapKit for SwiftUI 공식 문서](https://developer.apple.com/documentation/mapkit/mapkit-for-swiftui)
+- [MapKit for AppKit and UIKit 공식 문서](https://developer.apple.com/documentation/mapkit/mapkit-for-appkit-and-uikit)
+- [Meet MapKit for SwiftUI](https://developer.apple.com/videos/play/wwdc2023/10043/)
+- [Go further with MapKit](https://developer.apple.com/videos/play/wwdc2025/204/)
+- [MapKit JS 공식 문서](https://developer.apple.com/documentation/mapkitjs)

--- a/docs/guide/mapkit/search-geocoding-and-look-around.md
+++ b/docs/guide/mapkit/search-geocoding-and-look-around.md
@@ -1,0 +1,255 @@
+---
+title: MapKit 검색·지오코딩·Look Around
+description: MKLocalSearch와 자동 완성, iOS 26 MapKit 지오코딩, MKMapItem, Look Around를 취소 가능한 비동기 흐름으로 연결하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# MapKit 검색·지오코딩·Look Around
+
+> 면접용 한 줄 요약: **장소 탐색은 자연어 검색·주소 변환·좌표 역변환을 구분하고 결과를 `MKMapItem`으로 통합하며, 입력과 선택이 바뀔 때 이전 비동기 요청을 취소해야 합니다.**
+
+## 먼저 네 가지 요청을 구분해요
+
+| 입력과 목적                 | API                         | 결과                           |
+| --------------------------- | --------------------------- | ------------------------------ |
+| “근처 카페”처럼 장소를 찾기 | `MKLocalSearch`             | 여러 `MKMapItem`               |
+| 입력 중 검색어 제안         | `MKLocalSearchCompleter`    | `MKLocalSearchCompletion` 목록 |
+| 완전한 주소를 좌표로 변환   | `MKGeocodingRequest`        | 주소 지점 `MKMapItem`          |
+| 좌표를 주소로 변환          | `MKReverseGeocodingRequest` | 주소 지점 `MKMapItem`          |
+| 선택한 장소의 거리 사진     | `MKLookAroundSceneRequest`  | `MKLookAroundScene?`           |
+
+지오코딩은 주소 변환이고 Local Search는 관련 장소를 찾는 검색이에요. “스타벅스”를 geocoder에 넣어 지점 목록을 기대하거나, 정확한 도로명 주소를 넓은 POI 검색만으로 처리하지 않습니다.
+
+## `MKMapItem`을 장소의 연결점으로 사용해요
+
+`MKMapItem`에는 위치, 이름, 주소, 전화번호, URL과 장소 식별 정보가 들어올 수 있어요. 모든 값이 항상 존재한다고 가정하지 않습니다.
+
+```swift
+struct PlaceSummary: Identifiable {
+  let id: String
+  let name: String
+  let coordinate: CLLocationCoordinate2D
+
+  init(item: MKMapItem) {
+    id = item.identifier?.rawValue
+      ?? "\(item.location.coordinate.latitude),\(item.location.coordinate.longitude)"
+    name = item.name ?? "이름 없는 장소"
+    coordinate = item.location.coordinate
+  }
+}
+```
+
+장소를 장기간 저장한다면 좌표만 고유 키로 쓰지 마세요. 건물 안 여러 매장이 같은 좌표를 가질 수 있고 좌표가 보정될 수도 있어 MapKit Place ID처럼 지속 가능한 식별자를 우선 검토합니다.
+
+## 현재 보이는 영역에서 장소를 검색해요
+
+```swift
+import Combine
+import MapKit
+
+@MainActor
+final class PlaceSearchModel: ObservableObject {
+  @Published private(set) var results: [MKMapItem] = []
+  @Published private(set) var errorMessage: String?
+
+  private var activeSearch: MKLocalSearch?
+
+  func search(query: String, region: MKCoordinateRegion) async {
+    activeSearch?.cancel()
+
+    let request = MKLocalSearch.Request()
+    request.naturalLanguageQuery = query
+    request.region = region
+    request.resultTypes = [.pointOfInterest, .address]
+
+    let search = MKLocalSearch(request: request)
+    activeSearch = search
+
+    do {
+      let response = try await search.start()
+      guard activeSearch === search else { return }
+      results = response.mapItems
+      errorMessage = nil
+    } catch is CancellationError {
+      // 새 검색으로 교체된 정상 흐름이에요.
+    } catch {
+      guard activeSearch === search else { return }
+      results = []
+      errorMessage = "장소를 검색하지 못했습니다."
+    }
+  }
+}
+```
+
+region은 결과를 제한하는 힌트이며 현재 화면 주변 검색의 관련도를 높입니다. 검색 버튼을 누를 때나 debounce가 끝난 뒤 요청하고, 키 입력마다 동시에 요청하지 마세요. MapKit은 짧은 시간에 너무 많은 요청을 보내면 throttling 오류를 반환할 수 있습니다.
+
+## 자동 완성과 실제 검색은 두 단계예요
+
+`MKLocalSearchCompleter`는 입력 중 title과 subtitle 제안을 빠르게 제공합니다. 제안 하나를 선택한 뒤 그 completion으로 `MKLocalSearch.Request`를 만들어 실제 `MKMapItem`을 얻어요.
+
+```swift
+final class SearchCompleterModel: NSObject,
+  ObservableObject,
+  MKLocalSearchCompleterDelegate {
+  @Published private(set) var completions: [MKLocalSearchCompletion] = []
+
+  let completer = MKLocalSearchCompleter()
+
+  override init() {
+    super.init()
+    completer.delegate = self
+    completer.resultTypes = [.pointOfInterest, .address]
+  }
+
+  func update(query: String, region: MKCoordinateRegion) {
+    completer.region = region
+    completer.queryFragment = query
+  }
+
+  func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
+    completions = completer.results
+  }
+
+  func completer(
+    _ completer: MKLocalSearchCompleter,
+    didFailWithError error: any Error
+  ) {
+    completions = []
+  }
+}
+```
+
+```swift
+func resolve(_ completion: MKLocalSearchCompletion) async throws -> MKMapItem? {
+  let request = MKLocalSearch.Request(completion: completion)
+  return try await MKLocalSearch(request: request).start().mapItems.first
+}
+```
+
+completion의 title·subtitle만 저장해 장소 데이터처럼 사용하면 좌표와 최신 상세 정보가 없습니다. 사용자가 선택했을 때 실제 검색으로 해석하세요.
+
+## iOS 26부터 지오코딩이 MapKit으로 이동했어요
+
+Apple은 iOS 26 계열에서 `CLGeocoder`를 deprecated하고 `MKGeocodingRequest`, `MKReverseGeocodingRequest`를 제공합니다. 새 API는 결과를 `MKMapItem`으로 반환해 검색·지도·경로와 연결하기 쉬워요.
+
+```swift
+@available(iOS 26.0, *)
+func geocode(address: String) async throws -> MKMapItem? {
+  guard let request = MKGeocodingRequest(addressString: address) else {
+    return nil
+  }
+
+  request.preferredLocale = Locale(identifier: "ko_KR")
+  request.region = MKCoordinateRegion(
+    center: .init(latitude: 37.5666, longitude: 126.9784),
+    span: .init(latitudeDelta: 1, longitudeDelta: 1)
+  )
+  return try await request.mapItems.first
+}
+```
+
+```swift
+@available(iOS 26.0, *)
+func reverseGeocode(_ coordinate: CLLocationCoordinate2D) async throws -> MKMapItem? {
+  let location = CLLocation(
+    latitude: coordinate.latitude,
+    longitude: coordinate.longitude
+  )
+  guard let request = MKReverseGeocodingRequest(location: location) else {
+    return nil
+  }
+  return try await request.mapItems.first
+}
+```
+
+initializer가 optional인 이유는 빈 주소나 유효하지 않은 좌표로 요청을 만들 수 없기 때문입니다. 지오코딩 결과는 주소 지점 정보이며, 주변 영업시간 같은 풍부한 POI 정보가 항상 포함되는 것은 아니에요.
+
+### iOS 25 이하도 지원한다면
+
+구버전 배포 대상에서는 Core Location의 `CLGeocoder` 호환 경로가 필요합니다.
+
+```swift
+func legacyGeocode(address: String) async throws -> CLPlacemark? {
+  try await CLGeocoder()
+    .geocodeAddressString(address)
+    .first
+}
+```
+
+새 코드 전부를 deprecated API로 유지하기보다 availability를 경계로 결과를 앱의 `PlaceSummary` 같은 공통 모델로 변환하세요.
+
+## 선택한 장소에 Look Around를 연결해요
+
+```swift
+struct PlaceDetailView: View {
+  let item: MKMapItem
+  @State private var scene: MKLookAroundScene?
+
+  var body: some View {
+    Group {
+      if let scene {
+        LookAroundPreview(initialScene: scene)
+          .frame(height: 220)
+          .clipShape(RoundedRectangle(cornerRadius: 16))
+      } else {
+        ContentUnavailableView(
+          "Look Around 없음",
+          systemImage: "binoculars",
+          description: Text("이 장소에서는 거리 이미지를 제공하지 않습니다.")
+        )
+      }
+    }
+    .task(id: item) {
+      scene = nil
+      scene = try? await MKLookAroundSceneRequest(mapItem: item).scene
+    }
+  }
+}
+```
+
+Look Around는 지역별 제공 범위가 다르고 요청이 실패하거나 장면이 없을 수 있습니다. loading, unavailable, error를 같은 빈 화면으로 뭉개지 말고 제품 요구에 따라 구분하세요. `.task(id:)`는 선택 장소가 바뀌면 이전 Task를 취소하므로 늦게 도착한 이전 장면이 새 선택을 덮는 문제를 줄여요.
+
+## 하나의 화면 요청 흐름을 정리해요
+
+```text
+검색어 입력
+  └─ debounce ─> MKLocalSearchCompleter
+                    └─ completion 선택
+                         └─ MKLocalSearch ─> MKMapItem
+                                              ├─ Marker 표시
+                                              ├─ 장소 상세 표시
+                                              ├─ Look Around 요청
+                                              └─ Directions 목적지
+```
+
+View가 각 API를 직접 호출하기보다 요청 취소와 최신 결과 판별을 model/service에 모으면 테스트하기 쉬워요.
+
+## 체크리스트
+
+- [ ] 장소 검색과 주소 지오코딩을 구분했나요?
+- [ ] 검색 입력을 debounce하고 이전 요청을 취소하나요?
+- [ ] completion 선택 후 실제 `MKLocalSearch`로 장소를 해석하나요?
+- [ ] iOS 26 지오코딩과 이전 OS 호환 경계를 정했나요?
+- [ ] `MKMapItem`의 optional 정보를 안전하게 표시하나요?
+- [ ] Look Around 장면이 없는 장소의 UI가 있나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `MKLocalSearchCompleter` 결과를 바로 지도에 표시하면 안 되나요?
+
+completion은 입력 문자열 제안이지 완전한 장소 객체가 아닙니다. 선택한 completion으로 `MKLocalSearch.Request`를 만들고 `MKMapItem`을 얻은 뒤 좌표와 상세 정보를 사용해야 해요.
+
+### Local Search와 geocoding의 차이는 무엇인가요?
+
+Local Search는 자연어와 지역 힌트로 관련 장소 여러 개를 찾습니다. 지오코딩은 주소와 좌표를 서로 변환하는 작업이므로 입력 의도와 결과 개수가 달라요.
+
+## 참고 자료
+
+- [MKLocalSearch 공식 문서](https://developer.apple.com/documentation/mapkit/mklocalsearch)
+- [MKLocalSearch.Request 공식 문서](https://developer.apple.com/documentation/mapkit/mklocalsearch/request)
+- [MKLocalSearchCompleter 공식 문서](https://developer.apple.com/documentation/mapkit/mklocalsearchcompleter)
+- [MKGeocodingRequest 공식 문서](https://developer.apple.com/documentation/mapkit/mkgeocodingrequest)
+- [MKReverseGeocodingRequest 공식 문서](https://developer.apple.com/documentation/mapkit/mkreversegeocodingrequest)
+- [MKLookAroundSceneRequest 공식 문서](https://developer.apple.com/documentation/mapkit/mklookaroundscenerequest)
+- [Go further with MapKit](https://developer.apple.com/videos/play/wwdc2025/204/)

--- a/docs/guide/mapkit/snapshots-and-tile-overlays.md
+++ b/docs/guide/mapkit/snapshots-and-tile-overlays.md
@@ -1,0 +1,177 @@
+---
+title: MapKit 스냅샷과 커스텀 타일
+description: MKMapSnapshotter로 정적 지도 이미지를 만들고 Annotation을 합성하는 방법과 MKTileOverlay의 좌표·캐시·저작권·오프라인 경계를 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# MapKit 스냅샷과 커스텀 타일
+
+> 면접용 한 줄 요약: **상호작용 없는 지도 이미지는 `MKMapSnapshotter`, 앱이 소유하거나 사용권을 가진 래스터 타일은 `MKTileOverlay`를 사용하며, snapshot에는 custom Annotation과 Overlay가 자동으로 포함되지 않습니다.**
+
+## 상호작용 목적부터 구분해요
+
+| 요구 사항                                | 선택할 API                     |
+| ---------------------------------------- | ------------------------------ |
+| 사용자가 이동·확대하는 지도              | SwiftUI `Map` 또는 `MKMapView` |
+| 공유 카드·목록 thumbnail                 | `MKMapSnapshotter`             |
+| 거리 수준 정적 이미지                    | `MKLookAroundSnapshotter`      |
+| 날씨·지적도 등 custom 래스터 타일        | `MKTileOverlay`                |
+| Apple 기본 지도의 오프라인 영역 다운로드 | 공개된 전용 다운로드 API 없음  |
+
+스크롤 목록의 모든 셀에 대화형 `MKMapView`를 넣으면 renderer와 네트워크 비용이 커질 수 있어요. 조작이 필요 없는 셀은 snapshot을 만들어 캐시하는 편이 적합합니다.
+
+## 기본 지도 snapshot을 만들어요
+
+```swift
+import MapKit
+import UIKit
+
+@MainActor
+func makeMapSnapshot(
+  region: MKCoordinateRegion,
+  size: CGSize
+) async throws -> UIImage {
+  let options = MKMapSnapshotter.Options()
+  options.region = region
+  options.size = size
+  options.scale = UIScreen.main.scale
+  options.mapType = .standard
+
+  let snapshotter = MKMapSnapshotter(options: options)
+  let snapshot = try await snapshotter.start()
+  return snapshot.image
+}
+```
+
+`region`, `mapRect`, `camera` 중 목적에 맞는 framing을 지정할 수 있어요. point 단위 `size`와 화면 scale을 함께 설정해야 Retina 결과가 흐릿하지 않습니다.
+
+화면이 사라지거나 새 장소를 선택하면 실행 중인 Task를 취소하세요. 같은 장소·크기·appearance의 결과는 메모리 또는 디스크 캐시를 검토하되 지도 정보가 최신이어야 하는 수명도 함께 정합니다.
+
+## custom 핀은 결과 이미지에 직접 합성해요
+
+Apple 공식 문서에 따르면 snapshot은 앱이 만든 Annotation과 Overlay의 화면 표현을 자동으로 캡처하지 않습니다. `Snapshot.point(for:)`로 좌표를 이미지 점으로 바꿔 직접 그려요.
+
+```swift
+func snapshotWithPin(
+  snapshot: MKMapSnapshotter.Snapshot,
+  coordinate: CLLocationCoordinate2D
+) -> UIImage {
+  let renderer = UIGraphicsImageRenderer(size: snapshot.image.size)
+
+  return renderer.image { _ in
+    snapshot.image.draw(at: .zero)
+
+    let point = snapshot.point(for: coordinate)
+    let pin = UIImage(systemName: "mappin.circle.fill")?
+      .withTintColor(.systemRed, renderingMode: .alwaysOriginal)
+    let pinSize = CGSize(width: 34, height: 34)
+    let origin = CGPoint(
+      x: point.x - pinSize.width / 2,
+      y: point.y - pinSize.height
+    )
+    pin?.draw(in: CGRect(origin: origin, size: pinSize))
+  }
+}
+```
+
+이미지 아래쪽을 좌표에 맞추는 이유는 핀 끝이 실제 장소를 가리키기 때문이에요. 선과 다각형도 지리 좌표를 point로 변환해 그릴 수 있지만 복잡한 Overlay는 scale, clipping, line join을 신중하게 구현해야 합니다.
+
+## snapshot cache key를 명확히 만들어요
+
+```text
+SnapshotCacheKey
+  ├─ 중심과 span 또는 mapRect
+  ├─ 출력 size와 scale
+  ├─ mapType·elevation·POI filter
+  ├─ light/dark appearance
+  └─ custom 핀·경로 데이터 버전
+```
+
+좌표만 key로 쓰면 같은 장소라도 다른 크기나 다크 모드 결과가 섞여요. 반대로 카메라의 작은 부동소수점 차이를 모두 다른 key로 만들면 cache hit가 사라지므로 제품 단위로 값을 정규화합니다.
+
+## `MKTileOverlay`는 앱이 제공하는 타일을 그려요
+
+```swift
+final class WeatherTileController: NSObject, MKMapViewDelegate {
+  func install(on mapView: MKMapView) {
+    let tiles = MKTileOverlay(
+      urlTemplate: "https://tiles.example.com/weather/{z}/{x}/{y}@2x.png"
+    )
+    tiles.minimumZ = 3
+    tiles.maximumZ = 18
+    tiles.canReplaceMapContent = false
+    mapView.addOverlay(tiles, level: .aboveLabels)
+  }
+
+  func mapView(
+    _ mapView: MKMapView,
+    rendererFor overlay: any MKOverlay
+  ) -> MKOverlayRenderer {
+    guard let tiles = overlay as? MKTileOverlay else {
+      return MKOverlayRenderer(overlay: overlay)
+    }
+    return MKTileOverlayRenderer(tileOverlay: tiles)
+  }
+}
+```
+
+URL template의 `{z}`, `{x}`, `{y}`, `@2x`는 확대 수준, 타일 좌표, scale에 맞게 치환됩니다. 제공자가 쓰는 좌표 원점과 Retina URL 규칙이 다르면 `geometryFlipped` 설정이나 `url(forTilePath:)` override를 검토하세요.
+
+`canReplaceMapContent = true`는 custom 타일이 Apple 기본 지도를 대신한다는 뜻입니다. 날씨처럼 기본 지도 위에 겹칠 데이터라면 `false`를 유지해요.
+
+## 네트워크와 캐시 정책은 TileOverlay 밖의 책임이에요
+
+기본 `MKTileOverlay`는 URL을 구성해 타일을 요청하지만 제품의 인증, 만료, 재시도, 디스크 제한을 설계해 주지 않습니다. 제어가 필요하면 subclass에서 `loadTile(at:result:)`를 구현하고 별도 loader/cache를 연결할 수 있어요.
+
+```text
+MKTileOverlay 요청
+  └─ TileLoader
+       ├─ 메모리 cache
+       ├─ 허용된 디스크 cache
+       ├─ HTTP 재검증
+       └─ provider 사용 조건과 만료 정책
+```
+
+동일 타일의 동시 요청을 합치고, 실패를 무한 재시도하지 않으며, 취소와 최대 디스크 용량을 정하세요.
+
+## 오프라인 지도와 custom 타일을 혼동하지 않아요
+
+`MKTileOverlay`가 있다고 Apple 기본 지도 데이터를 임의로 내려받아 오프라인 패키지로 만들 수 있는 것은 아닙니다. 공개 MapKit API에는 Mapbox Tile Region 같은 Apple basemap 영역 다운로드 관리 API가 없습니다. 이는 현재 공개 API 범위를 비교한 결론이며 향후 SDK에서는 다시 확인해야 해요.
+
+오프라인이 필수라면 다음을 검토합니다.
+
+- 직접 제작하거나 오프라인 사용권을 가진 custom 타일을 제공해요.
+- 타일 제공자의 저장·재배포·attribution 조건을 확인해요.
+- 용량 제한, 만료, 데이터 갱신, 부분 다운로드 복구 UI를 설계해요.
+- 지도 SDK 선택 단계에서 공식 오프라인 영역 API를 제공하는 제품과 비교해요.
+
+## Legal과 attribution을 가리지 않아요
+
+MapKit의 대화형 지도나 snapshot을 최종 UI에 배치할 때 Apple Maps 로고와 Legal 정보를 자르거나 다른 UI로 덮지 않도록 확인하세요. custom tile도 원본 데이터 제공자가 요구하는 attribution을 별도로 표시해야 할 수 있습니다. 출시 시점의 Apple 약관과 타일 제공자 계약을 기준으로 검토해요.
+
+## 체크리스트
+
+- [ ] 조작 없는 화면에 불필요한 `MKMapView`를 여러 개 만들지 않나요?
+- [ ] snapshot의 size와 scale, appearance가 cache key에 들어가나요?
+- [ ] custom Annotation과 Overlay를 snapshot에 직접 합성했나요?
+- [ ] TileOverlay의 좌표 원점과 최대 zoom을 확인했나요?
+- [ ] custom 타일의 캐시·오프라인 사용권과 attribution을 확인했나요?
+- [ ] Apple 기본 지도 다운로드 API가 있다고 가정하지 않나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `MKMapSnapshotter`가 Annotation도 함께 찍어 주나요?
+
+시스템 지도 콘텐츠를 이미지로 만들지만 앱이 추가한 Annotation과 Overlay 표현은 자동으로 포함하지 않습니다. snapshot의 좌표 변환 API로 이미지 점을 구해 custom 핀과 경로를 직접 합성해야 해요.
+
+### `MKTileOverlay`는 완전한 오프라인 지도 기능인가요?
+
+아니요. 앱의 custom 래스터 타일을 요청하고 그리는 Overlay입니다. Apple basemap 다운로드를 제공하지 않으며 custom 타일의 다운로드, cache, 만료, 사용권은 앱과 데이터 제공자가 책임져요.
+
+## 참고 자료
+
+- [MKMapSnapshotter 공식 문서](https://developer.apple.com/documentation/mapkit/mkmapsnapshotter)
+- [MKMapSnapshotter.Options 공식 문서](https://developer.apple.com/documentation/mapkit/mkmapsnapshotter/options)
+- [MKTileOverlay 공식 문서](https://developer.apple.com/documentation/mapkit/mktileoverlay)
+- [MKTileOverlayRenderer 공식 문서](https://developer.apple.com/documentation/mapkit/mktileoverlayrenderer)

--- a/docs/guide/mapkit/swiftui-map-and-camera.md
+++ b/docs/guide/mapkit/swiftui-map-and-camera.md
@@ -1,0 +1,233 @@
+---
+title: MapKit SwiftUI 지도와 카메라
+description: SwiftUI Map의 MapContentBuilder와 MapCameraPosition, 카메라 경계·이벤트·선택·좌표 변환을 단계적으로 연결하는 방법을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# MapKit SwiftUI 지도와 카메라
+
+> 면접용 한 줄 요약: **SwiftUI `Map`은 `MapContentBuilder`로 지도 콘텐츠를 선언하고, `MapCameraPosition` binding은 앱과 사용자의 카메라 변경을 연결하므로 초기 위치와 지속 제어를 구분해야 합니다.**
+
+## 먼저 알아둘 카메라 용어
+
+| 용어       | 쉬운 뜻                                                                     |
+| ---------- | --------------------------------------------------------------------------- |
+| coordinate | 위도와 경도로 표현한 지구 위 한 점이에요.                                   |
+| region     | 중심 좌표와 위도·경도 범위인 span으로 표현한 사각 영역이에요.               |
+| map rect   | Mercator 지도 평면의 점과 크기로 표현한 영역이에요.                         |
+| camera     | 중심, 지면과의 거리, heading, pitch를 가진 가상 시점이에요.                 |
+| position   | 자동 맞춤, 영역, 장소, 현재 위치, 직접 camera 중 무엇을 보여 줄지 나타내요. |
+| bounds     | 사용자가 이동할 중심 영역과 최소·최대 camera 거리를 제한해요.               |
+
+## `MapContentBuilder`로 지도 내용을 선언해요
+
+iOS 17 이상의 현대적인 SwiftUI MapKit API에서는 Marker와 Overlay를 `Map`의 content closure에 작성합니다.
+
+```swift
+import MapKit
+import SwiftUI
+
+struct Place: Identifiable {
+  let id: String
+  let name: String
+  let coordinate: CLLocationCoordinate2D
+}
+
+struct PlaceMap: View {
+  private let places = [
+    Place(
+      id: "city-hall",
+      name: "서울시청",
+      coordinate: .init(latitude: 37.5666, longitude: 126.9784)
+    ),
+    Place(
+      id: "seoul-station",
+      name: "서울역",
+      coordinate: .init(latitude: 37.5547, longitude: 126.9707)
+    )
+  ]
+
+  var body: some View {
+    Map {
+      ForEach(places) { place in
+        Marker(place.name, coordinate: place.coordinate)
+      }
+    }
+  }
+}
+```
+
+`Map`도 `List`처럼 result builder가 데이터 반복과 조건을 받아 하나의 지도 콘텐츠를 만들어요. 예전 `Map(coordinateRegion:annotationItems:)`, `MapMarker`, `MapAnnotation`은 deprecated되었으므로 새 프로젝트에서 복사하지 않습니다.
+
+## 한 번만 정할 위치는 `initialPosition`을 사용해요
+
+처음 서울시청을 보여 준 뒤 사용자가 자유롭게 지도를 움직이게 하려면 초기 위치만 전달합니다.
+
+```swift
+struct InitialCameraMap: View {
+  private let initialPosition = MapCameraPosition.region(
+    MKCoordinateRegion(
+      center: .init(latitude: 37.5666, longitude: 126.9784),
+      span: .init(latitudeDelta: 0.04, longitudeDelta: 0.04)
+    )
+  )
+
+  var body: some View {
+    Map(initialPosition: initialPosition)
+  }
+}
+```
+
+`initialPosition`은 View를 만든 뒤 계속 카메라를 명령하는 상태가 아니에요.
+
+## 앱이 카메라를 바꾸면 binding을 사용해요
+
+검색 결과 전체 보기, 장소 선택, 내 위치 복귀처럼 화면이 나타난 뒤에도 카메라를 움직여야 하면 `MapCameraPosition`을 상태로 둡니다.
+
+```swift
+struct ControllableMap: View {
+  @State private var position: MapCameraPosition = .automatic
+
+  private let cityHall = MKCoordinateRegion(
+    center: .init(latitude: 37.5666, longitude: 126.9784),
+    span: .init(latitudeDelta: 0.02, longitudeDelta: 0.02)
+  )
+
+  var body: some View {
+    ZStack(alignment: .bottomTrailing) {
+      Map(position: $position)
+
+      Button("서울시청") {
+        withAnimation {
+          position = .region(cityHall)
+        }
+      }
+      .buttonStyle(.borderedProminent)
+      .padding()
+    }
+  }
+}
+```
+
+`MapCameraPosition`에는 다음과 같은 의미 기반 선택지가 있어요.
+
+| 위치                 | 사용할 때                                                |
+| -------------------- | -------------------------------------------------------- |
+| `.automatic`         | Marker와 Overlay 전체가 보이도록 MapKit에 맞춤을 맡겨요. |
+| `.region(...)`       | 사용자가 이해하기 쉬운 중심과 span으로 영역을 정해요.    |
+| `.rect(...)`         | 여러 좌표나 Overlay의 정확한 지도 평면 경계를 맞춰요.    |
+| `.item(...)`         | `MKMapItem` 한 곳을 주변 맥락과 함께 보여 줘요.          |
+| `.camera(...)`       | distance, heading, pitch를 직접 정해 3D 시점을 만들어요. |
+| `.userLocation(...)` | 사용자 위치를 따라가고 실패할 때 fallback을 사용해요.    |
+
+사용자가 드래그하면 binding의 `positionedByUser`가 `true`인 위치로 바뀝니다. 앱이 매 렌더링마다 원래 region을 다시 넣으면 사용자 제스처와 카메라가 싸우므로 버튼이나 검색 완료 같은 명확한 사건에서만 위치를 변경하세요.
+
+## 카메라 이동 범위와 확대를 제한해요
+
+캠퍼스나 행사장 지도처럼 특정 영역 밖으로 벗어날 이유가 없다면 `MapCameraBounds`를 전달할 수 있습니다.
+
+```swift
+let campusBounds = MapCameraBounds(
+  centerCoordinateBounds: MKCoordinateRegion(
+    center: .init(latitude: 37.5666, longitude: 126.9784),
+    span: .init(latitudeDelta: 0.08, longitudeDelta: 0.08)
+  ),
+  minimumDistance: 300,
+  maximumDistance: 20_000
+)
+
+Map(position: $position, bounds: campusBounds)
+```
+
+`minimumDistance`와 `maximumDistance`는 zoom 숫자가 아니라 camera와 중심 사이의 미터 거리예요. 너무 강한 제한은 사용자가 위치 관계를 이해하지 못하게 할 수 있으므로 제품 목적이 분명할 때 사용합니다.
+
+## 카메라가 멈춘 뒤 보이는 영역을 읽어요
+
+현재 화면에서 장소를 검색할 때는 카메라 이동이 끝난 뒤 region을 저장하는 방식이 적합해요.
+
+```swift
+@State private var visibleRegion: MKCoordinateRegion?
+
+Map(position: $position)
+  .onMapCameraChange(frequency: .onEnd) { context in
+    visibleRegion = context.region
+  }
+```
+
+`.continuous`는 제스처 도중에도 자주 호출됩니다. 매번 검색 API를 요청하거나 무거운 SwiftUI 상태를 갱신하지 말고, 애니메이션에 꼭 필요한 값만 처리하거나 throttle해야 해요.
+
+## 선택 상태는 안정적인 Hashable 값으로 연결해요
+
+```swift
+@State private var selectedPlaceID: String?
+
+Map(selection: $selectedPlaceID) {
+  ForEach(places) { place in
+    Marker(place.name, coordinate: place.coordinate)
+      .tag(place.id)
+  }
+}
+```
+
+`Map`의 selection 타입과 각 콘텐츠의 `tag` 타입이 같아야 합니다. 화면 갱신마다 바뀌는 임의 UUID 대신 서버 장소 ID처럼 안정적인 값을 사용하세요.
+
+## 화면 점과 지도 좌표는 `MapReader`로 변환해요
+
+사용자가 누른 화면 위치에 핀을 놓으려면 `MapReader`가 제공하는 `MapProxy`를 사용합니다.
+
+```swift
+MapReader { proxy in
+  Map(position: $position) {
+    if let droppedCoordinate {
+      Marker("선택 위치", coordinate: droppedCoordinate)
+    }
+  }
+  .onTapGesture { point in
+    droppedCoordinate = proxy.convert(point, from: .local)
+  }
+}
+```
+
+`CGPoint`를 위도·경도로 비례 변환하면 Mercator 투영, camera pitch와 회전을 무시하게 됩니다. 화면과 지도의 좌표계 변환은 MapKit에 맡기세요.
+
+## 시스템 지도 컨트롤을 연결해요
+
+```swift
+Map(position: $position)
+  .mapControls {
+    MapCompass()
+    MapScaleView()
+    MapPitchToggle()
+    MapUserLocationButton()
+  }
+```
+
+내 위치 버튼은 위치 권한과 신호가 없을 때도 고려해야 합니다. 지도 위 시트나 버튼은 `safeAreaInset`으로 배치해 Apple Maps 로고, Legal 링크와 시스템 컨트롤을 가리지 않게 하세요.
+
+## 체크리스트
+
+- [ ] deprecated된 `coordinateRegion` initializer 대신 현대적인 `Map` API를 사용하나요?
+- [ ] 초기 위치와 이후 앱이 제어하는 위치를 구분했나요?
+- [ ] 사용자 제스처 뒤 카메라 상태를 매번 덮어쓰지 않나요?
+- [ ] 카메라 연속 이벤트에서 네트워크 요청을 직접 실행하지 않나요?
+- [ ] selection의 ID가 화면 갱신 사이에도 안정적인가요?
+- [ ] 좌표계 변환을 `MapProxy`에 맡기나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `initialPosition`과 `position` binding은 어떻게 다른가요?
+
+`initialPosition`은 지도가 생성될 때 한 번 적용할 시작 위치입니다. binding은 앱과 사용자가 바꾼 카메라 상태를 양방향으로 전달하므로 검색 결과 이동이나 사용자 위치 추적처럼 지속 제어가 필요할 때 사용해요.
+
+### `.onEnd`와 `.continuous`는 언제 사용하나요?
+
+주변 검색이나 결과 저장은 카메라 이동이 끝나는 `.onEnd`가 적합합니다. 이동 중 UI를 실시간으로 바꿔야 할 때만 `.continuous`를 사용하고, 고빈도 이벤트의 계산과 상태 갱신 비용을 제한해요.
+
+## 참고 자료
+
+- [SwiftUI Map 공식 문서](https://developer.apple.com/documentation/mapkit/map)
+- [MapCameraPosition 공식 문서](https://developer.apple.com/documentation/mapkit/mapcameraposition)
+- [MapCameraBounds 공식 문서](https://developer.apple.com/documentation/mapkit/mapcamerabounds)
+- [MapReader 공식 문서](https://developer.apple.com/documentation/mapkit/mapreader)
+- [Meet MapKit for SwiftUI](https://developer.apple.com/videos/play/wwdc2023/10043/)

--- a/docs/guide/mapkit/uikit-map-view.md
+++ b/docs/guide/mapkit/uikit-map-view.md
@@ -1,0 +1,231 @@
+---
+title: UIKit에서 MKMapView 사용하기
+description: MKMapView의 카메라·delegate·Annotation View 재사용과 Overlay Renderer 구조를 익히고 SwiftUI bridge의 상태 동기화 원칙을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# UIKit에서 MKMapView 사용하기
+
+> 면접용 한 줄 요약: **`MKMapView`는 Annotation 모델과 화면에 보이는 재사용 View를 분리하고, `MKMapViewDelegate`가 표현과 사용자 이벤트를 연결하는 명령형 지도 View입니다.**
+
+## `MKMapView`가 필요한 경우부터 구분해요
+
+SwiftUI `Map`으로 대부분의 새 지도 화면을 만들 수 있지만 다음 요구가 핵심이면 `MKMapView`가 더 직접적입니다.
+
+- 기존 UIKit View Controller와 수명 주기를 함께 사용해요.
+- `MKAnnotationView`의 재사용, callout, drag, 표시 우선순위를 세밀하게 제어해요.
+- `clusteringIdentifier`로 자동 클러스터링해요.
+- custom `MKOverlayRenderer`를 구현해요.
+- `MKMapViewDelegate`의 렌더링·선택·카메라 이벤트가 필요해요.
+
+## 가장 작은 지도 화면을 만들어요
+
+```swift
+import MapKit
+import UIKit
+
+final class PlaceMapViewController: UIViewController {
+  private let mapView = MKMapView()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    mapView.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(mapView)
+
+    NSLayoutConstraint.activate([
+      mapView.topAnchor.constraint(equalTo: view.topAnchor),
+      mapView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      mapView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      mapView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    ])
+
+    let region = MKCoordinateRegion(
+      center: .init(latitude: 37.5666, longitude: 126.9784),
+      latitudinalMeters: 3_000,
+      longitudinalMeters: 3_000
+    )
+    mapView.setRegion(region, animated: false)
+  }
+}
+```
+
+Apple 공식 문서는 `MKMapView` 자체를 subclass하지 말고 delegate로 동작을 확장하라고 안내합니다.
+
+## 카메라 API를 목적별로 선택해요
+
+| API                                          | 적합한 상황                                   |
+| -------------------------------------------- | --------------------------------------------- |
+| `setRegion(_:animated:)`                     | 중심과 가로·세로 범위를 지정해요.             |
+| `setVisibleMapRect(_:edgePadding:animated:)` | 여러 지점이나 경로 전체를 여백과 함께 맞춰요. |
+| `setCamera(_:animated:)`                     | 고도, pitch, heading을 직접 제어해요.         |
+| `cameraBoundary`                             | 카메라 중심이 벗어날 영역을 제한해요.         |
+| `cameraZoomRange`                            | 최소·최대 camera 거리를 제한해요.             |
+
+하단 시트가 경로를 가린다면 화면 크기를 임의로 줄이지 말고 `edgePadding`으로 실제 가시 영역을 표현하세요.
+
+## Annotation 데이터와 View를 분리해요
+
+```swift
+final class PlaceAnnotation: NSObject, MKAnnotation {
+  let id: String
+  let title: String?
+  dynamic var coordinate: CLLocationCoordinate2D
+
+  init(id: String, title: String, coordinate: CLLocationCoordinate2D) {
+    self.id = id
+    self.title = title
+    self.coordinate = coordinate
+  }
+}
+```
+
+`MKAnnotation`은 좌표와 제목 같은 **데이터**예요. 실제 핀 UI는 `MKAnnotationView`가 담당합니다. MapKit은 화면 밖의 View를 reuse queue에 넣으므로 수천 개 Annotation이 있어도 모든 View를 동시에 만들지 않아요.
+
+```swift
+final class PlaceMapViewController: UIViewController, MKMapViewDelegate {
+  private let mapView = MKMapView()
+  private let placeReuseID = "place"
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    mapView.delegate = self
+    mapView.register(
+      MKMarkerAnnotationView.self,
+      forAnnotationViewWithReuseIdentifier: placeReuseID
+    )
+  }
+
+  func mapView(
+    _ mapView: MKMapView,
+    viewFor annotation: any MKAnnotation
+  ) -> MKAnnotationView? {
+    guard !(annotation is MKUserLocation) else {
+      return nil
+    }
+
+    let view = mapView.dequeueReusableAnnotationView(
+      withIdentifier: placeReuseID,
+      for: annotation
+    ) as? MKMarkerAnnotationView
+
+    view?.canShowCallout = true
+    view?.markerTintColor = .systemBlue
+    view?.glyphImage = UIImage(systemName: "cup.and.saucer.fill")
+    return view
+  }
+}
+```
+
+`MKUserLocation`에 custom 장소 View를 반환하면 시스템 위치 표시가 깨질 수 있으므로 먼저 제외합니다. 재사용 View의 색, 이미지, accessory, 선택 상태는 매번 완전히 재설정해 이전 Annotation의 상태가 남지 않게 하세요.
+
+## 데이터 갱신은 ID 차이만 반영해요
+
+서버 응답마다 `removeAnnotations` 후 `addAnnotations`를 반복하면 선택과 callout이 사라지고 화면이 깜빡일 수 있어요.
+
+```swift
+func apply(_ places: [Place]) {
+  let existing = mapView.annotations
+    .compactMap { $0 as? PlaceAnnotation }
+  let oldByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+  let newByID = Dictionary(uniqueKeysWithValues: places.map { ($0.id, $0) })
+
+  let removed = existing.filter { newByID[$0.id] == nil }
+  mapView.removeAnnotations(removed)
+
+  for place in places {
+    if let annotation = oldByID[place.id] {
+      annotation.coordinate = place.coordinate
+    } else {
+      mapView.addAnnotation(
+        PlaceAnnotation(
+          id: place.id,
+          title: place.name,
+          coordinate: place.coordinate
+        )
+      )
+    }
+  }
+}
+```
+
+동일 ID의 위치가 바뀌면 기존 Annotation을 갱신하고, 없어진 항목과 새 항목만 제거·추가합니다.
+
+## Overlay는 데이터와 Renderer를 분리해요
+
+`MKPolyline`, `MKPolygon`, `MKCircle`은 지리 데이터이고 화면 표현은 delegate가 반환한 Renderer예요.
+
+```swift
+func mapView(
+  _ mapView: MKMapView,
+  rendererFor overlay: any MKOverlay
+) -> MKOverlayRenderer {
+  if let polyline = overlay as? MKPolyline {
+    let renderer = MKPolylineRenderer(polyline: polyline)
+    renderer.strokeColor = .systemBlue
+    renderer.lineWidth = 5
+    return renderer
+  }
+
+  return MKOverlayRenderer(overlay: overlay)
+}
+```
+
+Annotation View와 Overlay Renderer를 혼동하지 마세요. 한 점의 상호작용 UI는 Annotation, 넓은 영역이나 경로는 Overlay가 적합합니다.
+
+## SwiftUI에서 감쌀 때 두 상태 체계를 중복시키지 않아요
+
+```swift
+struct LegacyMapView: UIViewRepresentable {
+  let places: [Place]
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeUIView(context: Context) -> MKMapView {
+    let mapView = MKMapView()
+    mapView.delegate = context.coordinator
+    return mapView
+  }
+
+  func updateUIView(_ mapView: MKMapView, context: Context) {
+    context.coordinator.apply(places, to: mapView)
+  }
+
+  final class Coordinator: NSObject, MKMapViewDelegate {
+    func apply(_ places: [Place], to mapView: MKMapView) {
+      // 안정적인 ID로 추가·변경·삭제만 반영해요.
+    }
+  }
+}
+```
+
+`updateUIView`는 SwiftUI 상태 변경 때 여러 번 호출될 수 있어요. 호출될 때마다 카메라를 초기화하거나 모든 Annotation을 교체하지 않습니다. delegate에서 발생한 사용자 카메라 변경을 binding으로 보낼 때도 다시 `updateUIView`가 같은 카메라를 명령하지 않도록 출처를 구분해야 해요.
+
+## 체크리스트
+
+- [ ] `MKMapView`를 subclass하지 않고 delegate를 사용하나요?
+- [ ] Annotation 데이터와 재사용 View의 책임을 분리했나요?
+- [ ] 재사용 View의 모든 변경 가능한 상태를 다시 설정하나요?
+- [ ] 서버 갱신에서 전체 삭제 대신 안정적인 ID 차이를 반영하나요?
+- [ ] 경로 전체 보기에서 sheet 크기만큼 edge padding을 주나요?
+- [ ] SwiftUI `updateUIView`가 사용자의 카메라를 반복 초기화하지 않나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Annotation과 Annotation View를 왜 분리하나요?
+
+Annotation은 지리 데이터라 지도에 모두 등록할 수 있고, Annotation View는 현재 화면에 필요한 수만 재사용할 수 있습니다. 이 분리 덕분에 메모리 사용을 줄이고 View 생성 비용을 완화해요.
+
+### SwiftUI 화면에서도 `MKMapView`를 선택할 이유가 있나요?
+
+자동 클러스터링, custom reuse View, drag와 callout, 세밀한 delegate callback처럼 SwiftUI `Map`이 직접 제공하지 않는 제어가 제품 핵심이면 bridge가 유효합니다. 그렇지 않다면 공식 SwiftUI `Map`이 상태 동기화 비용이 더 적어요.
+
+## 참고 자료
+
+- [MKMapView 공식 문서](https://developer.apple.com/documentation/mapkit/mkmapview)
+- [MKMapViewDelegate 공식 문서](https://developer.apple.com/documentation/mapkit/mkmapviewdelegate)
+- [MKAnnotationView 공식 문서](https://developer.apple.com/documentation/mapkit/mkannotationview)
+- [MapKit for AppKit and UIKit 공식 문서](https://developer.apple.com/documentation/mapkit/mapkit-for-appkit-and-uikit)

--- a/docs/guide/mapkit/user-location-and-directions.md
+++ b/docs/guide/mapkit/user-location-and-directions.md
@@ -1,0 +1,246 @@
+---
+title: MapKit 사용자 위치와 경로
+description: Core Location 최소 권한으로 MapKit 사용자 위치를 표시하고 MKDirections의 경로·예상 시간·Polyline을 취소 가능한 비동기 흐름으로 연결합니다.
+pageType: doc-wide
+outline: false
+---
+
+# MapKit 사용자 위치와 경로
+
+> 면접용 한 줄 요약: **MapKit은 위치를 지도에 표현하고 경로를 계산하지만, 사용자 위치의 권한·정확도·업데이트는 Core Location이 담당하며 위치 표시와 카메라 추적도 별도 상태입니다.**
+
+## 네 가지 책임을 먼저 분리해요
+
+```text
+Core Location
+  ├─ 위치 권한과 정확도
+  └─ 현재 CLLocation 전달
+
+MapKit
+  ├─ UserAnnotation으로 위치 표현
+  ├─ MapCameraPosition으로 카메라 추적
+  ├─ MKDirections로 경로 계산
+  └─ MapPolyline으로 경로 표현
+```
+
+지도의 파란 점이 보이는 것, 카메라가 그 점을 따라가는 것, 출발지로 사용하는 것은 서로 다른 결정이에요.
+
+## 1단계: 기능에 필요한 최소 권한을 설명해요
+
+앱을 사용하는 동안 현재 위치에서 목적지까지 경로를 보여 준다면 `Info.plist`에 When In Use 목적 문구를 추가합니다.
+
+```xml
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>현재 위치에서 선택한 장소까지의 경로를 안내하기 위해 위치를 사용합니다.</string>
+```
+
+위치가 필요하지 않은 지도 화면에서 앱 시작 즉시 요청하지 마세요. 사용자가 “내 위치”나 “여기서 출발”을 선택한 직후 요청하면 권한의 가치를 이해하기 쉽습니다.
+
+:::warning Always 권한은 지도 화면의 기본 설정이 아니에요
+백그라운드에서도 지속적으로 위치를 처리해야 하는 실제 기능이 있을 때만 Always 권한과 background mode를 검토합니다. 일반적인 지도 표시와 foreground 경로 탐색은 When In Use부터 시작해요.
+:::
+
+## 2단계: 권한 상태를 한곳에서 관리해요
+
+```swift
+import Combine
+import CoreLocation
+
+@MainActor
+final class LocationPermissionModel: NSObject, ObservableObject {
+  @Published private(set) var authorizationStatus: CLAuthorizationStatus
+
+  private let manager = CLLocationManager()
+
+  override init() {
+    authorizationStatus = manager.authorizationStatus
+    super.init()
+    manager.delegate = self
+  }
+
+  func requestWhenInUse() {
+    manager.requestWhenInUseAuthorization()
+  }
+}
+
+extension LocationPermissionModel: CLLocationManagerDelegate {
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    authorizationStatus = manager.authorizationStatus
+  }
+}
+```
+
+`.denied`나 `.restricted` 상태에서 요청 메서드를 반복 호출해도 시스템 prompt가 다시 나타나지 않습니다. 설정 안내와 주소 검색, 지도 직접 선택 같은 대체 흐름을 제공하세요.
+
+## 3단계: 위치 표시와 추적을 선언해요
+
+```swift
+struct UserLocationMap: View {
+  @State private var position: MapCameraPosition = .userLocation(
+    followsHeading: false,
+    fallback: .region(
+      MKCoordinateRegion(
+        center: .init(latitude: 37.5666, longitude: 126.9784),
+        span: .init(latitudeDelta: 0.1, longitudeDelta: 0.1)
+      )
+    )
+  )
+
+  var body: some View {
+    Map(position: $position) {
+      UserAnnotation()
+    }
+    .mapControls {
+      MapUserLocationButton()
+      MapCompass()
+    }
+  }
+}
+```
+
+`UserAnnotation()`은 위치를 표현하고 `.userLocation(...)` position은 카메라가 위치를 따라가게 합니다. 권한이 없거나 아직 위치를 얻지 못하면 fallback을 사용해 빈 세계 지도에서 시작하지 않아요.
+
+사용자가 지도를 드래그하면 추적이 풀릴 수 있습니다. 즉시 다시 사용자 위치로 강제 이동하지 말고 내 위치 버튼을 눌렀을 때만 추적을 재개해 사용자의 탐색 의도를 존중하세요.
+
+## 권한과 정확도별 대체 UI를 준비해요
+
+| 상태                     | 권장 동작                                                     |
+| ------------------------ | ------------------------------------------------------------- |
+| `.notDetermined`         | 기능을 설명한 뒤 사용자 액션에서 요청해요.                    |
+| `.authorizedWhenInUse`   | 사용자 위치와 출발지 기능을 활성화해요.                       |
+| reduced accuracy         | 대략적인 주변 기능은 유지하고 정밀 지점 선택 대안을 제공해요. |
+| `.denied`, `.restricted` | 설정 안내와 수동 주소·핀 선택을 제공해요.                     |
+| 신호 대기                | 마지막 위치를 현재 위치라고 단정하지 말고 loading을 표시해요. |
+
+Simulator에서는 **Debug → Location**에서 테스트 좌표나 GPX 경로를 선택해야 실제 위치 흐름을 확인할 수 있어요.
+
+## 4단계: 출발지와 목적지로 경로를 요청해요
+
+```swift
+import Combine
+import MapKit
+
+@MainActor
+final class DirectionsModel: ObservableObject {
+  @Published private(set) var route: MKRoute?
+  @Published private(set) var errorMessage: String?
+
+  private var activeDirections: MKDirections?
+
+  func calculate(to destination: MKMapItem) async {
+    activeDirections?.cancel()
+
+    let request = MKDirections.Request()
+    request.source = .forCurrentLocation()
+    request.destination = destination
+    request.transportType = .automobile
+    request.requestsAlternateRoutes = true
+
+    let directions = MKDirections(request: request)
+    activeDirections = directions
+
+    do {
+      let response = try await directions.calculate()
+      guard activeDirections === directions else { return }
+      route = response.routes.first
+      errorMessage = route == nil ? "이동 가능한 경로가 없습니다." : nil
+    } catch is CancellationError {
+      // 새 목적지를 선택한 정상 흐름이에요.
+    } catch {
+      guard activeDirections === directions else { return }
+      route = nil
+      errorMessage = "경로를 계산하지 못했습니다."
+    }
+  }
+}
+```
+
+`MKDirections` 한 인스턴스는 한 요청을 담당합니다. 목적지가 바뀌면 이전 요청을 취소하고 새 인스턴스를 만들어요. 짧은 시간에 너무 많은 요청을 보내면 `MKError.Code.loadingThrottled`가 발생할 수 있으므로 지도 이동이나 위치 update마다 재계산하지 않습니다.
+
+## 5단계: 경로와 전체 영역을 지도에 표시해요
+
+```swift
+struct RouteMap: View {
+  let destination: MKMapItem
+  let route: MKRoute?
+
+  @State private var position: MapCameraPosition = .automatic
+
+  var body: some View {
+    Map(position: $position) {
+      UserAnnotation()
+      Marker(item: destination)
+
+      if let route {
+        MapPolyline(route)
+          .stroke(.blue, style: .init(lineWidth: 7, lineCap: .round))
+      }
+    }
+    .onChange(of: route) { _, newRoute in
+      guard let newRoute else { return }
+      withAnimation {
+        position = .rect(newRoute.polyline.boundingMapRect)
+      }
+    }
+  }
+}
+```
+
+하단 시트가 지도 일부를 가리면 route의 bounding rect만 맞추지 말고 safe area나 UIKit의 edge padding을 고려합니다. 출발·도착 Marker와 Polyline이 모두 실제 가시 영역에 들어와야 해요.
+
+## 경로 결과에서 무엇을 사용할 수 있나요?
+
+| 속성                 | 의미                                                               |
+| -------------------- | ------------------------------------------------------------------ |
+| `distance`           | 전체 이동 거리예요. 미터 단위라 `MeasurementFormatter`로 표시해요. |
+| `expectedTravelTime` | 예상 이동 시간이에요. 교통 상황과 요청 시점에 따라 바뀔 수 있어요. |
+| `polyline`           | 지도에 그릴 경로의 지리 형태예요.                                  |
+| `steps`              | 구간별 안내, 거리와 polyline이에요.                                |
+| `advisoryNotices`    | 경로와 관련된 주의 문구예요.                                       |
+
+예상 시간은 저장된 상수가 아니므로 오래 캐시한 값을 현재 시간처럼 보여 주지 않습니다. alternate route를 요청했다면 시간만 비교하지 말고 거리, 통행 제한, 사용자 선택을 함께 보여 주세요.
+
+## `MKDirections`와 턴 바이 턴 내비게이션은 달라요
+
+`MKDirections`는 경로 데이터와 단계 정보를 계산하지만 자동차 내비게이션 앱의 전체 주행 세션, 경로 이탈 재탐색, 음성 안내, 잠금 화면 경험을 자동으로 제공하지 않습니다.
+
+요구 사항에 따라 다음 중 하나를 선택해요.
+
+- 앱 안에서 간단한 경로와 예상 시간을 보여 줘요.
+- `MKMapItem.openInMaps`로 Apple Maps 앱에 목적지를 넘겨 실제 안내를 시작해요.
+- 자체 navigation app을 만든다면 위치 업데이트, 재탐색, 안전 UI와 관련 capability·정책을 별도 설계해요.
+
+```swift
+destination.openInMaps(
+  launchOptions: [
+    MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving
+  ]
+)
+```
+
+## 체크리스트
+
+- [ ] 지도 표시와 실제 위치 접근 권한을 구분했나요?
+- [ ] 사용자 동작 직후 최소 권한을 요청하나요?
+- [ ] denied·reduced accuracy 상태에서 수동 선택이 가능한가요?
+- [ ] 목적지가 바뀌면 이전 `MKDirections`를 취소하나요?
+- [ ] 위치 update마다 경로를 무조건 재계산하지 않나요?
+- [ ] route 없음, network 오류와 throttling을 사용자에게 구분해 처리하나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `UserAnnotation`을 추가하면 카메라도 자동으로 따라가나요?
+
+아니요. `UserAnnotation`은 위치 표시이고 카메라 추적은 `.userLocation` `MapCameraPosition`이 담당합니다. 권한, 위치 표시, 카메라 추적을 각각 설계해야 해요.
+
+### `MKDirections`는 내비게이션 SDK인가요?
+
+출발지와 목적지 사이의 경로, 예상 시간, 단계와 geometry를 제공하지만 완전한 주행 세션 UI를 만들어 주지는 않습니다. 앱 안의 경로 표시와 Apple Maps로 안내 넘기기를 요구에 맞게 구분해요.
+
+## 참고 자료
+
+- [Core Location 위치 권한 공식 문서](https://developer.apple.com/documentation/corelocation/requesting-authorization-to-use-location-services)
+- [UserAnnotation 공식 문서](https://developer.apple.com/documentation/mapkit/userannotation)
+- [MapUserLocationButton 공식 문서](https://developer.apple.com/documentation/mapkit/mapuserlocationbutton)
+- [MKDirections 공식 문서](https://developer.apple.com/documentation/mapkit/mkdirections)
+- [MKRoute 공식 문서](https://developer.apple.com/documentation/mapkit/mkroute)

--- a/docs/guide/rxswift/_meta.json
+++ b/docs/guide/rxswift/_meta.json
@@ -8,7 +8,7 @@
     "type": "custom-link",
     "label": "모든 연산자",
     "collapsible": true,
-    "collapsed": false,
+    "collapsed": true,
     "items": [
       {
         "type": "custom-link",

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,9 @@ features:
     icon: 📱
     link: /guide/uikit/collection-views/index
   - title: 디자인 패턴
-    details: 의존성 주입을 시작으로 Swift 코드에 적용하는 설계 원칙과 디자인 패턴을 설명합니다.
+    details: MVC를 시작으로 Swift 코드에 적용하는 아키텍처와 설계 원칙, 디자인 패턴을 설명합니다.
     icon: 📚
-    link: /guide/design-patterns/dependency-injection
+    link: /guide/design-patterns/mvc
   - title: 공식 자료 기반
     details: 공식 문서와 원전 자료를 바탕으로 개념과 코드 예제를 설명합니다.
     icon: 🔗

--- a/theme/index.css
+++ b/theme/index.css
@@ -32,7 +32,13 @@
 
 .rp-nav__left {
   align-items: center;
+  flex: 1 1 auto;
   gap: 24px;
+  min-width: 0;
+}
+
+.rp-nav__right {
+  flex: 0 0 auto;
 }
 
 html body .rp-nav {
@@ -66,6 +72,40 @@ body[data-show-nav-divider='false'] .rp-doc-layout__menu {
 
 .rp-nav-menu--left {
   gap: 8px;
+}
+
+@media (width >= 769px) {
+  html .rp-nav-menu--left {
+    flex: 1 1 0;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-inline: contain;
+    scrollbar-color: rgba(78, 89, 104, 0.4) transparent;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  html .rp-nav-menu--left .rp-nav-menu__item {
+    flex: 0 0 auto;
+  }
+
+  html .rp-nav-menu--left .rp-nav-menu__item__container {
+    white-space: nowrap;
+  }
+
+  html .rp-nav-menu--left::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  html .rp-nav-menu--left::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  html .rp-nav-menu--left::-webkit-scrollbar-thumb {
+    background: rgba(78, 89, 104, 0.4);
+    border-radius: 999px;
+  }
 }
 
 .rp-nav-menu--left .rp-nav-menu__item__container {


### PR DESCRIPTION
## Summary

상단 내비게이션 항목이 화면 폭보다 길어질 때 여러 줄로 접히거나 검색 영역을 밀어내는 문제를 수정합니다.

## Changes

- 상단바 왼쪽 영역이 오른쪽 검색·GitHub 영역을 침범하지 않도록 flex 크기와 `min-width`를 조정했습니다.
- 769px 이상에서 내비게이션 링크 목록을 한 줄로 유지하고, 넘치는 항목을 가로로 스크롤할 수 있게 했습니다.
- 각 메뉴 항목의 축소와 줄바꿈을 막고 트랙패드·터치 스크롤 및 얇은 스크롤바 스타일을 추가했습니다.
- 768px 이하의 기존 모바일 햄버거 메뉴 전환은 그대로 유지했습니다.

## Testing

- `npm run format`
- `npm run build`
- `npm run lint`
- `git diff --check`
- 정적 빌드 CSS에 가로 overflow, 줄바꿈 방지와 반응형 규칙이 포함되는지 확인

## Related Issues

Closes #49

## Notes

- 문서 URL과 내비게이션 항목 구성은 변경하지 않았습니다.
