### PR TITLE
[#55] XCFramework와 정적·동적 링킹 학습 문서 섹션을 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -6,6 +6,12 @@
     "position": "left"
   },
   {
+    "text": "빌드와 배포",
+    "link": "/guide/build-and-distribution/build-compile-and-link",
+    "activeMatch": "/guide/build-and-distribution/",
+    "position": "left"
+  },
+  {
     "text": "SwiftUI",
     "link": "/guide/swiftui/state-management/observable-object",
     "activeMatch": "/guide/swiftui/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -6,6 +6,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "build-and-distribution",
+    "label": "빌드와 바이너리 배포"
+  },
+  {
+    "type": "dir-section-header",
     "name": "swiftui",
     "label": "SwiftUI"
   },

--- a/docs/guide/build-and-distribution/_meta.json
+++ b/docs/guide/build-and-distribution/_meta.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "file",
+    "name": "build-compile-and-link",
+    "label": "컴파일과 링킹"
+  },
+  {
+    "type": "file",
+    "name": "static-and-dynamic-frameworks",
+    "label": "정적·동적 프레임워크"
+  },
+  {
+    "type": "file",
+    "name": "xcframework",
+    "label": "XCFramework"
+  }
+]

--- a/docs/guide/build-and-distribution/build-compile-and-link.md
+++ b/docs/guide/build-and-distribution/build-compile-and-link.md
@@ -1,0 +1,371 @@
+---
+title: Swift로 이해하는 빌드, 컴파일과 링킹
+description: Xcode 빌드 시스템, Swift 컴파일러, object file, module, symbol, linker와 dyld가 소스 코드를 실행 가능한 앱으로 연결하는 과정을 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 빌드, 컴파일과 링킹
+
+> **면접 답변 한 줄 요약:** 컴파일러는 Swift source를 type check하고 machine code가 든 object file과 module 정보를 만들며, linker는 여러 object와 library의 symbol을 해결해 Mach-O 실행 파일을 만들고, dynamic library의 남은 연결은 실행할 때 `dyld`가 처리해요.
+
+Xcode에서 `Command-B`를 누르면 “컴파일한다”고 말하곤 해요. 하지만 실제 **build**는 compile 하나보다 큰 작업이에요. source code를 compile하고, resource를 처리하고, library를 link하고, bundle을 조립하고, 마지막에는 code signing까지 수행해요.
+
+이 구분을 알면 다음 오류를 서로 다른 단계에서 찾을 수 있어요.
+
+- `Cannot find type ... in scope`는 대개 compiler가 선언을 이해하지 못한 문제예요.
+- `Undefined symbols for architecture arm64`는 linker가 구현 symbol을 찾지 못한 문제예요.
+- `Library not loaded: @rpath/...`는 만들어진 앱을 실행하면서 dynamic loader가 library를 찾지 못한 문제예요.
+
+이 문서에서는 다음 내용을 배워요.
+
+- build system, compiler, linker와 loader가 나누어 맡는 책임
+- Swift source가 AST, SIL, LLVM IR과 object file로 낮아지는 과정
+- `.swiftmodule`·`.swiftinterface`와 `.o`가 서로 다른 이유
+- symbol의 정의와 참조를 linker가 연결하는 방법
+- static link와 dynamic link가 갈라지는 지점
+- Xcode build log에서 오류 발생 단계를 찾는 방법
+
+## 먼저 알아둘 빌드 용어
+
+| 용어           | 쉬운 뜻                                                                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| target         | Xcode가 하나의 product를 만들기 위해 source, resource, build setting과 dependency를 묶은 단위예요.                                            |
+| build system   | 입력과 출력의 dependency graph를 만들고 compiler, linker, resource tool, code signer를 필요한 순서로 실행하는 orchestrator예요.               |
+| compiler       | source의 문법과 type을 검사하고 target CPU가 실행할 code를 생성하는 도구예요. Swift에서는 `swiftc`가 driver 역할도 해요.                      |
+| object file    | compile된 code와 data, symbol, relocation 정보가 들어 있지만 아직 독립적으로 실행할 수 없는 중간 산출물이에요. 보통 `.o`예요.                 |
+| module         | 다른 target이 `import`해서 사용할 declaration의 단위예요. Swift module 정보는 client compiler가 API를 type check하는 데 사용해요.             |
+| symbol         | function이나 global data처럼 code·data 조각을 linker가 식별하는 이름이에요. Swift 이름은 module과 type 정보가 mangling될 수 있어요.           |
+| linker         | object file과 library를 읽어 symbol의 definition과 reference를 연결하고 executable이나 library image를 만드는 도구예요.                       |
+| Mach-O         | Apple platform에서 object file, executable과 dynamic library가 사용하는 binary 형식이에요. 파일마다 Mach-O 종류는 다를 수 있어요.             |
+| dynamic loader | process를 시작할 때 dependent dynamic library를 찾고 mapping하며 symbol을 bind하는 runtime 구성 요소예요. Apple platform은 `dyld`를 사용해요. |
+| architecture   | machine code가 실행될 CPU 계열이에요. Apple device의 `arm64`, 일부 simulator의 `arm64`·`x86_64`가 예예요.                                     |
+| platform       | iOS device, iOS Simulator, macOS처럼 SDK와 runtime 환경이 다른 build 목적지예요. architecture가 같아도 platform은 다를 수 있어요.             |
+
+## Build는 여러 도구를 실행하는 dependency graph예요
+
+Apple의 [Behind the Scenes of the Xcode Build Process](https://developer.apple.com/videos/play/wwdc2018/415/)는 build를 source와 resource에서 배포 가능한 bundle까지 가는 여러 task의 집합으로 설명해요. 각 task의 출력이 다음 task의 입력이 되기 때문에 Xcode build system은 먼저 dependency graph를 만들어요.
+
+```text
+Swift source ─┐
+              ├─ compiler ─ object files ─┐
+ObjC source ──┘                            │
+                                           ├─ linker ─ Mach-O executable
+static libraries ──────────────────────────┤
+dynamic library stubs ─────────────────────┘
+
+asset catalog ─ asset compiler ─ resource output ─┐
+Info.plist ───── plist processing ─────────────────┼─ app bundle ─ code signing
+embedded dynamic frameworks ───────────────────────┘
+```
+
+이 그림에서 compiler와 linker는 build를 구성하는 일부 task예요.
+
+1. Xcode가 project, target, build setting과 dependency를 읽어요.
+2. source마다 필요한 compile task와 입력·출력을 계산해요.
+3. 서로 독립적인 task는 병렬로 실행할 수 있어요.
+4. linker는 필요한 object file이 모두 생성된 뒤 실행돼요.
+5. resource를 처리하고 product bundle의 올바른 위치로 복사해요.
+6. embedded code와 최종 bundle을 signing해요.
+
+따라서 “compiler error가 없으니 build가 성공한다”는 결론은 성립하지 않아요. compile 뒤에도 link, copy, validation과 signing이 남아 있어요.
+
+## Compiler는 source를 machine code로 낮춰요
+
+Swift compiler의 핵심 흐름을 학습용으로 단순화하면 다음과 같아요.
+
+```text
+.swift source
+  ↓ parse
+AST
+  ↓ semantic analysis와 type checking
+type-checked AST
+  ↓ SILGen
+SIL
+  ↓ Swift 전용 최적화
+optimized SIL
+  ↓ IRGen
+LLVM IR
+  ↓ LLVM 최적화와 target code generation
+machine code가 든 .o
+```
+
+[Swift Compiler 공식 문서](https://www.swift.org/documentation/swift-compiler/)는 parser가 AST를 만들고, semantic analysis가 type check한 AST를 만들며, SIL을 거쳐 LLVM IR과 machine code로 내려간다고 설명해요. 실제 compiler는 build mode와 최적화 설정에 따라 단계를 합치거나 별도 파일을 남기지 않을 수 있어요. 위 흐름은 각 표현의 책임을 이해하기 위한 개념도예요.
+
+### Parse와 type check에서 프로그램의 의미를 확인해요
+
+다음 코드는 문법에는 맞지만 type이 맞지 않아요.
+
+```swift
+let completedPages: Int = "42"
+```
+
+parser는 variable declaration의 구조를 만들 수 있지만 semantic analysis는 `String`을 `Int`에 넣을 수 없다는 오류를 기록해요. 이 단계가 실패하면 안전하게 code generation으로 갈 수 없어요.
+
+대표적인 compile-time 문제는 다음과 같아요.
+
+- 문법이 완성되지 않았어요.
+- type을 추론하거나 변환할 수 없어요.
+- access control 때문에 declaration을 볼 수 없어요.
+- 현재 SDK나 deployment target에서 API를 사용할 수 없어요.
+- import할 module interface를 찾거나 읽을 수 없어요.
+
+### SIL은 Swift 의미를 보존한 최적화 표현이에요
+
+SIL(Swift Intermediate Language)은 ARC 최적화, generic specialization과 devirtualization처럼 Swift 언어 의미를 아는 최적화에 적합해요. 그 뒤 LLVM IR로 낮아지면 LLVM이 target architecture에 맞는 machine code를 생성해요.
+
+앱 개발자가 보통 SIL이나 LLVM IR을 직접 작성하지는 않아요. 다만 “Swift code가 곧바로 assembly 한 줄로 번역된다”는 오해를 피하고, 최적화가 source와 binary 사이 여러 단계에서 이루어진다는 사실을 이해하면 돼요.
+
+## Module 정보와 object code는 목적이 달라요
+
+framework를 배포할 때 자주 혼동하는 두 산출물이 있어요.
+
+| 산출물                     | 누가 사용하나요?            | 담는 핵심 정보                                                  | 답하는 질문                                                         |
+| -------------------------- | --------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `.swiftmodule`             | client의 Swift compiler     | compiler가 빠르게 읽을 수 있는 serialized module 정보           | “어떤 public API를 어떤 type으로 호출할 수 있나요?”                 |
+| `.swiftinterface`          | 다른 Swift compiler version | public API를 표현한 stable textual module interface             | “다른 compiler가 이 module의 API를 다시 읽을 수 있나요?”            |
+| `.o`                       | linker                      | machine code, data, symbol과 relocation                         | “이 function 구현을 최종 binary 어디에 배치하나요?”                 |
+| `.a`                       | linker                      | 여러 object file을 모은 static archive                          | “참조된 구현이 들어 있는 object를 가져올 수 있나요?”                |
+| framework의 dynamic binary | linker와 `dyld`             | exported code·data와 dynamic linking metadata가 든 Mach-O image | “link 때 검증하고 runtime에 별도 image로 load할 구현은 무엇인가요?” |
+
+예를 들어 다음 한 줄에는 compile과 link 두 문제가 모두 숨어 있을 수 있어요.
+
+```swift
+import ReadingKit
+
+let score = ReadingScore.calculate(pages: 42)
+```
+
+client compiler는 `ReadingKit.swiftmodule`이나 `ReadingKit.swiftinterface`를 읽어 `ReadingScore.calculate`의 이름과 parameter·return type을 검사해요. 그러나 실제 function body의 machine code도 최종 product에 연결되어야 해요. interface는 있는데 library가 link input에 없으면 import와 type check는 성공해도 link가 실패할 수 있어요.
+
+즉, `import`는 “API 선언을 compiler가 이해한다”는 의미이고, 최종 구현을 product에 연결하는 target dependency와 **Link Binary With Libraries** 설정까지 항상 대신한다는 뜻은 아니에요. Apple의 [Customizing the build phases of a target](https://developer.apple.com/documentation/xcode/customizing-the-build-phases-of-a-target)은 이 build phase가 framework, library, XCFramework와 Swift package product에 대한 참조를 해결한다고 설명해요.
+
+## Object file에는 아직 결정하지 못한 주소가 있어요
+
+다음처럼 한 file의 function이 다른 module의 function을 호출한다고 생각해 볼게요.
+
+```swift
+public func summary(for pages: Int) -> String {
+  let score = ReadingScore.calculate(pages: pages)
+  return "점수: \(score)"
+}
+```
+
+compiler는 `summary`의 machine code를 만들 수 있지만 `ReadingScore.calculate`가 최종 binary의 어느 주소에 놓일지는 아직 몰라요. 그래서 object file에는 대략 다음 종류의 정보가 남아요.
+
+- 이 object가 **정의하는 symbol**: `summary`
+- 다른 object나 library에서 찾아야 할 **undefined symbol**: `ReadingScore.calculate`
+- symbol의 최종 주소가 정해지면 고쳐야 할 **relocation** 위치
+
+Apple WWDC의 설명처럼 symbol은 code나 data 조각을 가리키는 이름이에요. linker는 이름을 기준으로 definition을 찾고 reference가 실제 주소를 향하도록 code와 metadata를 patch해요.
+
+## Linker는 symbol graph를 완성해 product image를 만들어요
+
+linker의 주요 입력은 다음과 같아요.
+
+- 현재 target source에서 만들어진 `.o`
+- 다른 target이나 vendor가 제공한 static archive `.a`
+- dynamic library와 framework의 export 정보
+- Apple SDK의 text-based stub `.tbd`
+- architecture, deployment target, search path와 link option
+
+linker는 다음 일을 수행해요.
+
+1. 각 object의 defined·undefined symbol을 읽어요.
+2. 필요한 symbol definition을 다른 object와 library에서 찾아요.
+3. static archive에서는 참조를 만족하는 object member를 선택해 가져와요.
+4. code와 data의 최종 layout과 주소를 결정해 relocation을 적용해요.
+5. dynamic library symbol은 어느 dependent image에서 찾을지 load metadata에 기록해요.
+6. app executable이나 framework binary 같은 Mach-O image를 출력해요.
+
+LLVM의 [Clang Command Guide](https://clang.llvm.org/docs/CommandGuide/clang.html)는 compile·assemble 결과인 object file을 linker가 executable이나 shared library로 합치는 단계로 구분해요. Swift의 내부 표현은 Clang과 다르지만 “object file을 만들고 linker가 최종 image로 결합한다”는 경계는 Xcode의 Swift build에도 적용돼요.
+
+### Linker는 없는 구현을 새로 만들지 않아요
+
+interface에는 declaration이 있지만 어느 입력에도 definition이 없다면 linker는 보통 다음과 같은 오류를 내요.
+
+```text
+Undefined symbols for architecture arm64:
+  "$s10ReadingKit0A5ScoreO9calculate5pagesS2i_tF", referenced from: ...
+ld: symbol(s) not found for architecture arm64
+```
+
+Swift mangled symbol은 길고 읽기 어려울 수 있지만 핵심 질문은 같아요.
+
+1. 이 symbol을 정의하는 library가 target의 link input에 들어왔나요?
+2. library가 현재 platform과 architecture용으로 build되었나요?
+3. API를 `public`으로 선언하고 symbol이 실제로 export되었나요?
+4. library가 의존하는 다른 library까지 연결했나요?
+
+source code를 여러 번 clean build하는 것보다 먼저 link command와 input을 확인하는 편이 원인에 가까워요.
+
+## Static link와 dynamic link는 구현을 가져오는 방식이 달라요
+
+linker가 library를 만나는 지점에서 두 방식이 갈라져요.
+
+### Static library는 필요한 object code가 product 안으로 들어가요
+
+static archive는 object file의 모음이에요. linker는 undefined symbol을 만족시키는 member를 골라 최종 executable이나 dynamic library에 포함해요. 이제 그 code는 별도 static library file을 runtime에 찾지 않아요.
+
+```text
+App.o + ReadingKit.a
+          ↓ link
+App executable [App code + 선택된 ReadingKit code]
+```
+
+### Dynamic library는 별도 image에 대한 dependency를 기록해요
+
+dynamic framework를 link할 때 linker는 client의 reference가 framework의 exported symbol로 해결될 수 있는지 검사하지만, framework machine code 전체를 app executable에 복사하지 않아요. client Mach-O에는 dependent library와 symbol binding에 필요한 정보가 남아요.
+
+```text
+App executable ── load command ──▶ ReadingKit.framework/ReadingKit
+       │                                  │
+       └──────── runtime에서 dyld가 load·bind ────────┘
+```
+
+정적·동적 방식의 packaging, launch와 size tradeoff는 [정적·동적 프레임워크 문서](./static-and-dynamic-frameworks)에서 자세히 비교해요.
+
+## `dyld`는 실행할 때 dynamic dependency를 완성해요
+
+link가 성공했다는 것은 build machine에서 필요한 symbol과 library 정보를 확인했다는 뜻이에요. 사용자의 device에서 process가 시작되면 `dyld`가 executable의 load command를 읽고 dependent dynamic library를 찾아 address space에 mapping하고 symbol을 bind해요.
+
+embedded framework는 보통 install name에 다음과 같은 run-path 상대 경로를 사용해요.
+
+```text
+@rpath/ReadingKit.framework/ReadingKit
+```
+
+app의 run-path search path와 bundle 안의 framework 위치가 맞지 않거나 framework를 복사·sign하지 않았다면 build는 성공해도 launch가 실패할 수 있어요.
+
+```text
+dyld: Library not loaded: @rpath/ReadingKit.framework/ReadingKit
+  Reason: tried: ...
+```
+
+Apple의 [Overview of Dynamic Libraries](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/OverviewOfDynamicLibraries.html)는 static linker가 dependent library의 install name을 기록하고 `dyld`가 이를 사용해 runtime library를 찾는 과정을 설명해요.
+
+## 같은 API 사용도 세 단계에서 실패할 수 있어요
+
+| 실패 시점    | 대표 message·현상                                        | 먼저 확인할 것                                                                                |
+| ------------ | -------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| compile time | `No such module`, `Cannot find ... in scope`, type error | module search path, target membership, public API, SDK와 Swift compiler 호환성                |
+| link time    | `Undefined symbols`, `Duplicate symbols`                 | Link Binary With Libraries, architecture·platform, static archive 중복, transitive dependency |
+| bundle 단계  | framework validation·code signing 오류                   | Embed 설정, bundle 위치, code signature, framework의 supported platform                       |
+| runtime      | `Library not loaded`, missing symbol, launch crash       | `@rpath`, embedded dynamic framework, ABI 호환성, 실제 device에 포함된 image                  |
+
+이 표는 증상만으로 원인을 확정하는 규칙은 아니에요. 예를 들어 잘못된 generated module 때문에 compile이 실패할 수도 있고, API를 binary-incompatible하게 바꾸면 runtime에 symbol을 찾지 못할 수도 있어요. 중요한 점은 실패한 tool과 phase부터 범위를 줄이는 거예요.
+
+## Xcode build log를 단계별로 읽어요
+
+Xcode의 Report navigator에서 실패한 build를 열면 task 이름을 볼 수 있어요.
+
+| log에서 찾을 task 예                        | 의미                                                           |
+| ------------------------------------------- | -------------------------------------------------------------- |
+| `SwiftCompile`, `CompileSwiftSources`       | Swift source를 type check하고 object·module 산출물을 만들어요. |
+| `CompileC`, `CompileSwift`                  | C 계열 또는 Swift compile task예요.                            |
+| `Ld`                                        | linker가 executable이나 library image를 만들어요.              |
+| `Copy`, `CopyFiles`, `ProcessInfoPlistFile` | product bundle을 조립하고 metadata·resource를 처리해요.        |
+| `CodeSign`                                  | executable code와 bundle의 signature를 만들거나 검증해요.      |
+
+문제를 재현한 뒤 다음 순서로 읽어 보세요.
+
+1. 첫 번째 실제 error를 낸 task를 찾고 뒤따르는 cascade error와 구분해요.
+2. task를 펼쳐 실행된 `swiftc`, `clang`이나 `ld` command와 argument를 확인해요.
+3. `-target`, SDK, search path, `-framework`·`-l`과 input file이 의도와 맞는지 봐요.
+4. 같은 module이나 library가 두 경로에서 중복 입력되지 않았는지 확인해요.
+5. runtime 문제라면 build log뿐 아니라 최종 `.app` bundle과 Mach-O dependency도 검사해요.
+
+## 작은 command-line 실험으로 module과 object를 나눠 봐요
+
+Xcode가 평소 자동화하는 경계를 학습하기 위한 예예요. `ReadingKit.swift`를 만들어요.
+
+```swift
+public enum ReadingScore {
+  public static func calculate(pages: Int) -> Int {
+    pages * 10
+  }
+}
+```
+
+module 정보와 object file을 함께 출력해요.
+
+```bash
+mkdir -p Build
+
+xcrun swiftc ReadingKit.swift \
+  -parse-as-library \
+  -module-name ReadingKit \
+  -emit-module \
+  -emit-module-path Build/ReadingKit.swiftmodule \
+  -emit-object \
+  -o Build/ReadingKit.o
+```
+
+client인 `main.swift`는 module을 import해 type check하고 object와 link해요.
+
+```swift
+import ReadingKit
+
+print(ReadingScore.calculate(pages: 42))
+```
+
+```bash
+xcrun swiftc main.swift \
+  Build/ReadingKit.o \
+  -I Build \
+  -o Build/ReadingApp
+
+./Build/ReadingApp
+```
+
+여기서 `-I Build`를 빼면 compiler가 module을 못 찾고, `Build/ReadingKit.o`를 빼면 API를 이해한 뒤에도 linker가 구현을 못 찾을 수 있어요. 실제 output 이름과 option은 toolchain과 platform에 따라 달라질 수 있으므로 이 예제는 배포 script가 아니라 두 책임을 관찰하는 학습 실험으로 사용해요.
+
+## Binary를 검사하는 기본 도구
+
+| command                    | 확인하는 질문                                                  |
+| -------------------------- | -------------------------------------------------------------- |
+| `file <binary>`            | Mach-O인지 static archive인지, 어떤 architecture를 포함하나요? |
+| `nm -gU <binary>`          | 외부로 보이는 defined symbol은 무엇인가요?                     |
+| `nm -u <object-or-binary>` | 아직 다른 image에서 해결해야 할 undefined symbol은 무엇인가요? |
+| `otool -L <mach-o>`        | 어떤 dynamic library install name을 dependency로 기록했나요?   |
+| `otool -l <mach-o>`        | load command와 run path가 어떻게 기록되었나요?                 |
+| `ar -t <library.a>`        | static archive에 어떤 object member가 들어 있나요?             |
+
+결과는 Release optimization, symbol stripping과 toolchain에 따라 달라져요. `nm`에 source function이 그대로 보이지 않는다고 바로 누락으로 판단하지 말고 access level, mangling과 stripping 설정을 함께 봐야 해요.
+
+## 적용 체크리스트
+
+- [ ] “build”, “compile”, “link”를 같은 뜻으로 사용하지 않고 실패한 phase를 먼저 구분했나요?
+- [ ] module interface와 machine code binary가 모두 client target에 연결되어 있나요?
+- [ ] library의 platform과 architecture가 현재 destination과 일치하나요?
+- [ ] custom target dependency를 import의 auto-link 동작에만 의존하지 않았나요?
+- [ ] dynamic framework라면 최종 app bundle에 올바르게 embed·sign되었나요?
+- [ ] `otool -L`의 install name과 app의 run path를 함께 확인했나요?
+- [ ] 첫 error를 낸 build task와 실제 tool command를 build log에서 확인했나요?
+
+## 자주 묻는 면접 질문
+
+### Compiler와 linker의 차이는 무엇인가요?
+
+compiler는 source의 문법·type을 검사하고 object code를 만들어요. linker는 여러 object와 library가 정의·참조하는 symbol을 연결해 executable이나 library image를 만들어요. 선언을 못 이해하면 compile error, 선언은 이해했지만 구현을 못 찾으면 주로 link error가 나요.
+
+### `.swiftmodule`과 `.o`는 왜 둘 다 필요한가요?
+
+`.swiftmodule`은 client compiler가 public API를 import하고 type check할 때 사용하고, `.o`는 linker가 실제 machine code 구현을 최종 product에 배치할 때 사용해요. 하나는 compile-time interface, 다른 하나는 link-time implementation에 가까워요.
+
+### Link가 끝났는데 `dyld` 오류가 날 수 있는 이유는 무엇인가요?
+
+dynamic library code는 app executable에 전부 복사되지 않고 dependency로 남아요. build machine에서 link가 성공했어도 최종 app bundle에 library가 없거나, install name·run path·signature가 맞지 않으면 device에서 `dyld`가 load하지 못해요.
+
+### Mach-O와 XCFramework는 같은 binary 형식인가요?
+
+아니에요. Mach-O는 개별 object, executable이나 dynamic library가 사용하는 binary 형식이고, XCFramework는 platform·architecture별 framework나 library variant를 한 디렉터리 bundle로 묶는 배포 형식이에요. 자세한 구조는 [XCFramework 문서](./xcframework)에서 설명해요.
+
+## 참고 자료
+
+- [Behind the Scenes of the Xcode Build Process - WWDC18](https://developer.apple.com/videos/play/wwdc2018/415/)
+- [Customizing the build phases of a target - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/customizing-the-build-phases-of-a-target)
+- [Swift Compiler - Swift.org](https://www.swift.org/documentation/swift-compiler/)
+- [Swift Compiler Driver - Swift GitHub](https://github.com/swiftlang/swift-driver)
+- [Clang Command Guide - LLVM](https://clang.llvm.org/docs/CommandGuide/clang.html)
+- [Overview of Dynamic Libraries - Apple Developer Archive](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/OverviewOfDynamicLibraries.html)

--- a/docs/guide/build-and-distribution/static-and-dynamic-frameworks.md
+++ b/docs/guide/build-and-distribution/static-and-dynamic-frameworks.md
@@ -1,0 +1,351 @@
+---
+title: Swift로 이해하는 정적·동적 프레임워크
+description: library와 framework의 차이부터 static·dynamic linking, Mach-O, embed와 dyld 동작, 앱 크기·시작 시간·배포 선택 기준을 비교합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 정적·동적 프레임워크
+
+> **면접 답변 한 줄 요약:** Framework는 code·module·resource를 담는 bundle 형식이고 static·dynamic은 그 안의 binary를 client에 연결하는 방식으로, static code는 link할 때 product image에 포함되고 dynamic code는 별도 image로 embed되어 runtime에 `dyld`가 load해요.
+
+“Framework는 dynamic이고 library는 static이다”라고 외우면 금방 예외를 만나요. `.framework`는 **포장 형식**이고, 그 안의 main binary는 static archive일 수도 있고 dynamic library일 수도 있어요. Apple은 Xcode 15부터 resource까지 담는 static framework 제작을 공식 지원해요.
+
+반대로 `.xcframework`도 static·dynamic을 결정하지 않아요. 여러 platform·architecture용 framework 또는 library variant를 묶는 distribution container예요. 이 세 축을 먼저 나누어야 해요.
+
+```text
+포장:       .a / .framework / .xcframework
+연결 방식:  static / dynamic
+지원 범위:  iOS device / iOS Simulator / macOS / ...
+```
+
+이 문서에서는 다음 내용을 배워요.
+
+- library, bundle, framework와 XCFramework의 역할 차이
+- static archive와 static framework가 link되는 방식
+- dynamic framework가 embed되고 `dyld`에 load되는 방식
+- 실행 파일 크기, app launch, resource와 dependency의 tradeoff
+- Xcode에서 Link와 Embed 설정을 구분하는 방법
+- `file`, `nm`, `ar`, `otool`로 실제 binary 종류를 확인하는 방법
+
+## 먼저 알아둘 binary packaging 용어
+
+| 용어            | 쉬운 뜻                                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| library         | 다른 code가 재사용할 function·type의 compiled implementation을 제공하는 binary예요. static archive와 dynamic library가 있어요. |
+| static archive  | 여러 object file을 하나로 모은 archive예요. Apple platform에서 보통 `.a` 확장자를 사용해요.                                    |
+| dynamic library | 다른 image가 runtime에 load해서 사용할 exported code·data를 담은 별도 Mach-O image예요. macOS에서는 `.dylib`도 볼 수 있어요.   |
+| bundle          | code, resource와 metadata를 정해진 디렉터리 구조로 묶은 단위예요. Finder에서 file처럼 보여도 내부는 directory예요.             |
+| framework       | main binary, module, header, resource와 `Info.plist` 등을 표준 구조로 묶는 bundle이에요.                                       |
+| link            | client code의 symbol reference를 library가 제공하는 definition에 연결하는 과정이에요.                                          |
+| embed           | runtime이나 resource 접근에 필요한 framework bundle을 app bundle 안으로 복사하는 과정이에요. Link와 같은 동작이 아니에요.      |
+| install name    | dynamic library를 runtime에 찾기 위해 client Mach-O에 기록되는 식별 경로예요. embedded framework는 흔히 `@rpath`를 사용해요.   |
+| dead stripping  | 최종 product에서 도달할 수 없는 code·data section을 linker가 제거하는 최적화예요. build setting과 symbol 특성에 영향을 받아요. |
+
+## Library, framework와 XCFramework는 같은 분류가 아니에요
+
+### Library는 compiled code의 연결 단위예요
+
+library의 핵심은 client가 사용할 symbol definition을 제공하는 거예요.
+
+- static library는 object file의 archive예요.
+- dynamic library는 runtime에 별도 image로 존재해요.
+
+### Framework는 code와 부속물을 담는 bundle이에요
+
+간단한 iOS framework는 다음과 같은 구조를 가질 수 있어요.
+
+```text
+ReadingKit.framework/
+├── ReadingKit
+├── Info.plist
+├── Modules/
+│   └── ReadingKit.swiftmodule/
+├── Headers/
+└── Resources...
+```
+
+`ReadingKit` main binary의 Mach-O type이 static archive인지 dynamic library인지에 따라 linking 동작이 달라져요. directory 확장자가 `.framework`라는 사실만으로 판단하면 안 돼요.
+
+### XCFramework는 variant를 선택하게 하는 상위 container예요
+
+XCFramework는 iOS device용 framework, iOS Simulator용 framework처럼 서로 다른 variant를 한 bundle로 묶어요. 내부 framework가 static인지 dynamic인지는 각각의 main binary가 결정해요.
+
+| 질문                                       | 답을 결정하는 축                    |
+| ------------------------------------------ | ----------------------------------- |
+| API와 resource를 어떤 구조로 묶나요?       | framework bundle                    |
+| code가 client image 안으로 들어가나요?     | static 또는 dynamic linkage         |
+| device와 simulator를 한 artifact로 주나요? | XCFramework의 platform variant 구성 |
+
+[XCFramework 문서](./xcframework)에서는 variant 구조와 제작 과정을 자세히 설명해요.
+
+## Static library는 필요한 object가 최종 image에 포함돼요
+
+static archive `.a`는 여러 `.o` member의 모음이에요.
+
+```text
+libReadingKit.a
+├── ReadingScore.o
+├── ReadingHistory.o
+└── ReadingImage.o
+```
+
+App의 `ReadingScore.calculate` reference를 해결해야 한다면 linker는 이를 정의하는 member를 archive에서 선택해 final executable이나 dynamic library에 포함해요.
+
+```text
+App.o ─────── undefined: ReadingScore.calculate
+                       │
+libReadingKit.a ───────┘ definition을 제공
+                       ↓ static link
+App executable [App.o + 선택된 ReadingKit object code]
+```
+
+최종 App process가 시작할 때 `libReadingKit.a` file 자체를 load하지 않아요. 필요한 code가 이미 App executable에 들어갔기 때문이에요.
+
+### 모든 archive member가 무조건 복사되는 것은 아니에요
+
+“static library 전체가 언제나 복사된다”는 설명도 정확하지 않아요. 일반적으로 linker는 현재 undefined symbol을 만족하는 object member를 archive에서 가져오고, dead stripping 설정은 사용하지 않는 section을 추가로 제거할 수 있어요.
+
+다만 Objective-C category나 registration처럼 직접적인 symbol reference 없이 동작을 기대하는 code는 archive에서 선택되지 않을 수 있어요. 이때 `-ObjC`, `-force_load` 같은 linker flag가 필요할 수 있지만, 무조건 `-all_load`를 넣으면 duplicate symbol과 binary size가 늘 수 있어요. vendor 지침과 실제 link map을 확인한 뒤 필요한 범위만 load해요.
+
+## Static framework는 static code에 bundle 구조를 더해요
+
+Apple의 [Creating a static framework](https://developer.apple.com/documentation/xcode/creating-a-static-framework)는 Xcode 15 이상에서 main binary가 static archive인 framework bundle에 resource를 함께 넣을 수 있다고 설명해요.
+
+static framework를 만들 때는 framework target의 **Mach-O Type**을 **Static Library**로 설정해요. client가 이를 link하고 embed하면 Xcode 15 이상은 이미 client에 statically linked된 main binary를 embedded framework bundle에서 제외하고 resource·metadata를 유지할 수 있어요.
+
+따라서 다음 두 문장은 상황을 나누어 봐야 해요.
+
+- **code 관점:** static main binary는 runtime dependency로 별도 load되지 않아요.
+- **resource 관점:** static framework가 resource를 담았다면 framework wrapper를 app bundle에 복사해야 할 수 있어요.
+
+“Static이므로 항상 Do Not Embed” 또는 “Framework이므로 항상 Embed & Sign” 같은 한 줄 규칙보다 Xcode version, product type, resource 유무와 framework metadata를 기준으로 설정해야 해요.
+
+## Dynamic framework는 별도 Mach-O image로 남아요
+
+dynamic framework의 main binary는 client executable과 분리된 Mach-O image예요. link 시점과 runtime의 역할이 나뉘어요.
+
+### Link time에는 export와 dependency를 확인해요
+
+linker는 App이 참조하는 symbol을 framework가 export하는지 확인하고 App executable에 framework dependency를 기록해요.
+
+```text
+App executable load commands
+└── @rpath/ReadingKit.framework/ReadingKit
+```
+
+framework machine code 전체가 App executable 안으로 복사되는 것은 아니에요.
+
+### Bundle 단계에는 필요한 framework를 embed하고 sign해요
+
+직접 제공하거나 third-party에서 받은 iOS dynamic framework는 보통 App target의 **Frameworks, Libraries, and Embedded Content**에 추가하고 **Embed & Sign**으로 포함해요. Apple SDK의 system framework는 OS가 제공하므로 App bundle에 복사하지 않아요.
+
+대략적인 App bundle은 다음처럼 보여요.
+
+```text
+ReadingApp.app/
+├── ReadingApp
+├── Info.plist
+└── Frameworks/
+    └── ReadingKit.framework/
+        ├── ReadingKit
+        ├── Info.plist
+        └── Modules/
+```
+
+### Runtime에는 `dyld`가 load하고 bind해요
+
+App launch 때 `dyld`는 load command와 run path를 사용해 `ReadingKit.framework/ReadingKit`을 찾고 process address space에 mapping해요. library가 없거나 architecture, signature 또는 ABI가 맞지 않으면 launch가 중단될 수 있어요.
+
+```text
+dyld: Library not loaded: @rpath/ReadingKit.framework/ReadingKit
+```
+
+Apple의 [Overview of Dynamic Libraries](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/OverviewOfDynamicLibraries.html)는 static linker가 dependent library의 install name을 기록하고 dynamic loader가 runtime에 이를 찾는 흐름을 설명해요.
+
+## Static과 dynamic을 build부터 runtime까지 비교해요
+
+| 관점                    | Static library·framework                                                                                                | Dynamic framework                                                                                                                |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| link 결과               | 선택된 object code가 client executable이나 library image에 들어가요.                                                    | client에 dependent image 정보가 남고 framework binary는 별도 image예요.                                                          |
+| runtime code file       | 원래 `.a`나 static main binary를 별도로 load하지 않아요.                                                                | `dyld`가 framework binary를 찾아 load·bind해요.                                                                                  |
+| app bundle              | code는 client image에 있어요. resource wrapper는 별도 복사가 필요할 수 있어요.                                          | third-party framework bundle을 보통 embed·sign해야 해요.                                                                         |
+| 실행 파일 크기          | library code가 client image에 합쳐져 executable이 커질 수 있어요.                                                       | main executable은 작아질 수 있지만 framework까지 포함한 전체 app size를 같이 봐야 해요.                                          |
+| 사용하지 않는 code 제거 | archive member 선택과 dead stripping의 이점을 받을 수 있어요.                                                           | dynamic binary의 export와 build 방식에 따라 client linker가 내부 code를 제거하기 어려울 수 있어요.                               |
+| launch 비용             | 별도 dependent image load를 추가하지 않아요.                                                                            | image load, rebase·bind와 initializer가 launch 비용에 영향을 줄 수 있어요.                                                       |
+| 여러 executable의 사용  | App과 extension 각각에 link되면 code가 각 image에 중복될 수 있어요.                                                     | packaging을 잘 구성하면 code image를 공유할 여지가 있지만 process·bundle 구조와 platform 규칙을 확인해야 해요.                   |
+| library 교체            | client를 다시 link하고 배포해야 새 구현이 들어가요.                                                                     | ABI를 지키면 client를 다시 compile하지 않고 library를 교체할 수 있는 구조예요. iOS 배포에서는 결국 signed app update가 필요해요. |
+| runtime 누락 위험       | code가 final image 안에 있으므로 `Library not loaded`는 없어요.                                                         | embed, `@rpath`, signature와 architecture 문제로 runtime load가 실패할 수 있어요.                                                |
+| resource                | `.a`만으로 resource를 담지 못해 별도 resource bundle이 필요해요. Xcode 15 static framework는 resource를 담을 수 있어요. | framework bundle의 표준 resource 구조를 사용할 수 있어요.                                                                        |
+
+## “어느 쪽이 더 빠르고 작나요?”에는 측정이 필요해요
+
+static이 항상 빠르고 dynamic이 항상 작다는 식으로 결론 내리면 안 돼요.
+
+### Static이 유리할 수 있는 상황
+
+- 별도 dynamic image 수를 줄여 launch 작업을 줄이고 싶어요.
+- 모든 module을 App과 항상 같이 build·배포해 binary compatibility가 필요하지 않아요.
+- linker의 archive member 선택과 dead stripping으로 실제 사용 code만 포함하고 싶어요.
+- 내부 implementation module을 단순하게 배포하고 싶어요.
+
+하지만 같은 static code를 App, widget와 다른 extension에 각각 link하면 bundle 전체에는 code가 중복될 수 있어요. source-level generic specialization이나 `@inlinable`도 client code size를 늘릴 수 있으므로 link map과 App Store size report를 확인해요.
+
+### Dynamic이 유리할 수 있는 상황
+
+- framework를 client와 별도 release schedule로 발전시키고 ABI boundary를 유지해야 해요.
+- 여러 module이 같은 dynamic framework를 dependency로 사용하고 packaging 구조가 이를 지원해요.
+- SDK의 독립된 version과 binary identity를 유지하고 싶어요.
+- resource, module과 binary를 하나의 framework bundle로 전달하고 싶어요.
+
+반면 custom dynamic framework가 많아지면 launch 때 처리할 image와 transitive dependency가 늘 수 있어요. 실제 영향은 image 수, symbol 수, initializer와 device 상태에 따라 달라져요. Xcode Organizer와 Instruments의 App Launch template로 측정한 뒤 결정해요.
+
+## Framework 수와 모듈 수를 같은 기준으로 잡지 않아요
+
+code를 작은 Swift module로 나누는 것은 compile dependency와 ownership을 정리하는 데 유용해요. 그렇다고 각 module을 모두 별도 dynamic framework로 배포해야 하는 것은 아니에요.
+
+```text
+논리적 module 경계: 기능 소유권, import, compile dependency
+binary image 경계:  link 방식, launch, ABI, 배포와 version 정책
+```
+
+여러 source module을 static하게 App에 합칠 수도 있고, 배포용 public facade 하나를 dynamic framework로 만들고 내부 dependency를 static하게 합칠 수도 있어요. Xcode 15 이상의 mergeable library도 이런 image 수 최적화를 지원하지만, 여기서는 기본 static·dynamic 경계를 먼저 이해하면 충분해요.
+
+## Xcode에서 Link와 Embed를 따로 판단해요
+
+### Link는 symbol을 연결해요
+
+Target의 **Build Phases > Link Binary With Libraries**는 framework나 library가 제공하는 symbol을 link input으로 사용하게 해요. `import`만 추가하는 것과 같은 의미가 아니에요.
+
+### Embed는 runtime·resource bundle을 복사해요
+
+Target의 **General > Frameworks, Libraries, and Embedded Content**에서 Embed 설정은 product bundle에 framework를 복사할지를 정해요.
+
+| dependency 종류                          | 일반적인 시작점                                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| Apple system framework                   | Link하고 **Do Not Embed**예요. OS가 binary를 제공해요.                                 |
+| third-party dynamic framework            | Link하고 **Embed & Sign**이 일반적이에요.                                              |
+| resource 없는 static library `.a`        | Link하지만 runtime code file은 embed하지 않아요.                                       |
+| Xcode 15+ resource 포함 static framework | Apple 절차에 따라 wrapper를 embed·sign하고 Xcode가 static main binary를 처리하게 해요. |
+
+정확한 설정은 dependency manager가 생성한 product type과 vendor 문서를 우선해요. 같은 이름의 framework가 수동 추가와 package manager를 통해 중복으로 들어가면 duplicate symbol이나 multiple commands produce 오류가 생길 수 있어요.
+
+## 실제 binary 종류와 dependency를 확인해요
+
+확장자나 Xcode 화면만 믿지 말고 main binary를 검사할 수 있어요.
+
+### `file`로 archive와 Mach-O 종류를 구분해요
+
+```bash
+file ReadingKit.framework/ReadingKit
+file libReadingKit.a
+```
+
+결과에 `current ar archive`가 보이면 static archive예요. dynamic framework binary라면 architecture와 함께 dynamically linked shared library에 해당하는 Mach-O 정보가 보여요.
+
+### `ar`로 static archive member를 봐요
+
+```bash
+ar -t libReadingKit.a
+```
+
+어떤 `.o` member가 archive에 들어 있는지 확인할 수 있어요.
+
+### `otool`로 dynamic dependency를 봐요
+
+```bash
+otool -L ReadingApp.app/ReadingApp
+otool -L ReadingKit.framework/ReadingKit
+```
+
+첫 줄은 검사 대상 자신이고, 그 아래에 dependent dynamic library의 install name과 compatibility version이 보여요. `@rpath/ReadingKit.framework/ReadingKit`이 있다면 client는 runtime에 그 framework를 찾아야 해요.
+
+### `nm`으로 symbol을 확인해요
+
+```bash
+nm -gU ReadingKit.framework/ReadingKit
+nm -u ReadingApp.app/ReadingApp
+```
+
+exported global symbol과 undefined reference를 확인하는 출발점이에요. Swift symbol은 mangled되어 있으므로 필요하면 `xcrun swift-demangle`을 함께 사용해요.
+
+```bash
+nm -gU ReadingKit.framework/ReadingKit | xcrun swift-demangle
+```
+
+Release build의 stripping과 optimization에 따라 결과가 줄어들 수 있어요.
+
+## 대표 오류를 link 방식에 맞게 진단해요
+
+| 오류                                                  | 흔한 원인                                                                     | 확인 순서                                                             |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `Undefined symbols for architecture ...`              | library 누락, 잘못된 variant, export되지 않은 API, transitive dependency 누락 | link phase → platform·architecture → symbol export → dependency graph |
+| `duplicate symbol ...`                                | 같은 static code를 두 경로로 link, `-all_load` 과다 적용                      | 수동 framework와 package 중복 → link command → archive member         |
+| `Library not loaded: @rpath/...`                      | dynamic framework가 app에 없거나 run path가 맞지 않음                         | final `.app/Frameworks` → `otool -L` → `LC_RPATH` → Embed & Sign      |
+| `code signature ... not valid`                        | embedded framework가 잘못 sign되었거나 binary가 signing 뒤 변경됨             | framework signature → app signing 순서 → 원본 XCFramework의 출처      |
+| `building for iOS Simulator, but linking ... for iOS` | architecture가 같아도 platform variant가 다름                                 | XCFramework variant → SDK/destination → vendor artifact               |
+
+## 선택 기준
+
+### Static을 먼저 검토하기 좋은 경우
+
+- library와 App이 한 repository·release에서 항상 함께 build돼요.
+- 별도 ABI 호환성을 유지할 필요가 없어요.
+- 작은 내부 module이 많고 dynamic image 수를 늘리고 싶지 않아요.
+- App에 실제로 사용되는 code만 link하는 것이 중요해요.
+
+### Dynamic을 검토하기 좋은 경우
+
+- binary framework가 client와 독립적으로 version되고 여러 binary client에 의존돼요.
+- 배포 계약으로 ABI와 framework identity를 관리해야 해요.
+- system framework처럼 OS가 제공하는 shared image를 사용해요.
+- App 구조에서 별도 image 경계가 주는 이점이 측정으로 확인됐어요.
+
+### 결정 전에 함께 물어볼 질문
+
+1. source로 배포할 수 있나요, binary만 배포해야 하나요?
+2. framework와 client를 항상 함께 rebuild하나요?
+3. App, widget, extension에 같은 code가 어떻게 packaging되나요?
+4. resource는 어느 bundle에서 찾나요?
+5. transitive dependency를 누가 link·embed하나요?
+6. launch time과 전체 install·download size를 실제로 측정했나요?
+7. 지원할 Xcode, Swift, platform과 architecture 범위는 무엇인가요?
+
+## 적용 체크리스트
+
+- [ ] `.framework` 확장자만 보고 dynamic이라고 판단하지 않았나요?
+- [ ] `file`이나 Mach-O Type으로 main binary의 실제 linkage를 확인했나요?
+- [ ] Link와 Embed를 서로 다른 단계로 구분했나요?
+- [ ] static framework의 resource wrapper와 static code 처리를 나누어 봤나요?
+- [ ] dynamic framework의 `@rpath`, embed 위치와 signature를 확인했나요?
+- [ ] App executable 하나가 아니라 extension을 포함한 전체 bundle size를 비교했나요?
+- [ ] 성능 결론을 일반론으로 정하지 않고 실제 Release build를 측정했나요?
+- [ ] library를 업데이트할 release·ABI 정책을 결정했나요?
+
+## 자주 묻는 면접 질문
+
+### Framework와 library의 차이는 무엇인가요?
+
+library는 재사용할 compiled code를 제공하는 연결 단위이고, framework는 main binary와 module, header, resource, metadata를 표준 directory 구조로 묶은 bundle이에요. framework의 main binary는 static일 수도 dynamic일 수도 있어요.
+
+### Static framework는 runtime에 framework file이 필요 없나요?
+
+code는 client image에 statically linked되므로 main binary를 dynamic dependency로 load하지 않아요. 하지만 Xcode 15 이상의 static framework가 resource를 담았다면 resource·metadata wrapper가 app bundle에 embed될 수 있어요. code linkage와 resource packaging을 분리해서 답해야 해요.
+
+### Dynamic framework는 왜 `Embed & Sign`이 필요한가요?
+
+client executable에는 framework의 machine code가 전부 들어 있지 않아요. device에서 `dyld`가 별도 image를 load해야 하므로 third-party framework bundle이 app 안에 있어야 하고, 실행 가능한 code이므로 app의 signing chain에 맞게 sign되어야 해요.
+
+### Static과 dynamic 중 어느 쪽이 성능이 더 좋나요?
+
+static은 별도 image load를 줄이고 linker 최적화에 유리할 수 있지만 client별 code duplication으로 전체 size가 늘 수 있어요. dynamic은 image를 분리하고 binary evolution에 유리하지만 launch load·binding 비용과 embed 관리가 생겨요. 실제 module 수, code size와 launch profile로 결정해야 해요.
+
+## 참고 자료
+
+- [Creating a static framework - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/creating-a-static-framework)
+- [Bundles and frameworks - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/bundles-and-frameworks)
+- [Customizing the build phases of a target - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/customizing-the-build-phases-of-a-target)
+- [Overview of Dynamic Libraries - Apple Developer Archive](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/OverviewOfDynamicLibraries.html)
+- [Run-Path Dependent Libraries - Apple Developer Archive](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/RunpathDependentLibraries.html)
+- [Behind the Scenes of the Xcode Build Process - WWDC18](https://developer.apple.com/videos/play/wwdc2018/415/)
+- [Configuring your project to use mergeable libraries - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/configuring-your-project-to-use-mergeable-libraries)

--- a/docs/guide/build-and-distribution/xcframework.md
+++ b/docs/guide/build-and-distribution/xcframework.md
@@ -1,0 +1,593 @@
+---
+title: Swift로 이해하는 XCFramework 제작과 배포
+description: XCFramework의 variant 구조, device·simulator archive, xcodebuild 생성, Swift module 안정성, Xcode·SwiftPM 배포와 검증 절차를 설명합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 이해하는 XCFramework 제작과 배포
+
+> **면접 답변 한 줄 요약:** XCFramework는 iOS device·simulator처럼 platform과 architecture가 다른 framework나 library variant를 하나로 묶고 Xcode가 현재 build destination에 맞는 것을 고르게 하는 binary distribution bundle이며, 그 자체가 static 또는 dynamic linkage를 뜻하지는 않아요.
+
+XCFramework를 처음 보면 “fat framework의 새 이름” 또는 “dynamic framework 묶음”이라고 생각하기 쉬워요. 하지만 핵심은 **서로 호환되지 않는 platform variant를 분리해서 한 artifact로 전달하는 것**이에요.
+
+예를 들어 Apple silicon Mac에서 iOS Simulator도 `arm64`를 사용할 수 있어요. iPhone device binary 역시 `arm64`지만 두 binary는 같은 platform을 대상으로 하지 않아요. architecture 이름만 같다고 `lipo`로 하나의 framework에 합치면 Xcode가 올바른 SDK variant를 구분할 수 없어요. XCFramework는 이 문제를 container metadata와 variant directory로 해결해요.
+
+이 문서에서는 다음 내용을 배워요.
+
+- XCFramework가 해결하는 platform·architecture variant 문제
+- XCFramework와 framework, static·dynamic linkage의 관계
+- iOS device와 simulator archive를 만드는 build setting
+- `xcodebuild -create-xcframework`로 artifact를 만드는 방법
+- ABI stability, module stability와 library evolution의 차이
+- Xcode와 Swift Package Manager에서 binary를 배포하는 방법
+- checksum, code signature와 debug symbol을 포함한 release 검증
+- 자주 만나는 variant·link·runtime 오류의 진단 순서
+
+## 먼저 알아둘 binary distribution 용어
+
+| 용어               | 쉬운 뜻                                                                                                                                   |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| variant            | 특정 platform, environment와 architecture 조합을 위해 build한 framework 또는 library 하나예요.                                            |
+| platform           | iOS, iOS Simulator, macOS, Mac Catalyst처럼 SDK와 runtime contract가 다른 실행 환경이에요.                                                |
+| architecture slice | `arm64`, `x86_64`처럼 한 binary 안에서 특정 CPU용 machine code를 담은 부분이에요. 같은 platform 안에서 여러 slice를 포함할 수 있어요.     |
+| universal binary   | 같은 platform을 대상으로 하는 여러 architecture slice를 하나의 Mach-O에 담은 binary예요.                                                  |
+| XCFramework        | 여러 platform variant의 framework 또는 library와 header를 하나로 묶는 Xcode binary package예요.                                           |
+| archive            | 특정 destination의 Release product, dSYM과 distribution 정보를 보관하는 `.xcarchive`예요.                                                 |
+| ABI                | 이미 compile된 client와 library binary가 calling convention, symbol와 memory layout 수준에서 상호 작동하기 위한 binary contract예요.      |
+| module stability   | 다른 Swift compiler version이 framework의 public API module interface를 읽을 수 있게 하는 성질이에요.                                     |
+| library evolution  | client를 다시 compile하지 않고 library implementation과 허용된 API를 발전시킬 수 있도록 ABI flexibility를 남기는 build mode예요.          |
+| checksum           | remote ZIP의 byte 내용이 package manifest에 선언한 artifact와 같은지 검증하는 hash예요. 작성자의 신원을 증명하는 code signature와 달라요. |
+
+## XCFramework가 필요한 이유
+
+과거에는 iOS device와 simulator binary를 하나의 framework에 합치는 비공식 배포 방식이 사용됐어요. Intel Mac 시절에는 device `arm64`와 simulator `x86_64`의 architecture가 달라 우연히 구분되는 것처럼 보였어요.
+
+하지만 platform과 architecture는 다른 축이에요.
+
+| destination                   | 가능한 architecture 예 | SDK·runtime environment |
+| ----------------------------- | ---------------------- | ----------------------- |
+| iPhone·iPad device            | `arm64`                | iOS                     |
+| Apple silicon의 iOS Simulator | `arm64`                | iOS Simulator           |
+| Intel Mac의 iOS Simulator     | `x86_64`               | iOS Simulator           |
+
+device와 simulator가 모두 `arm64`일 수 있으므로 architecture slice만으로 어느 variant인지 표현할 수 없어요. Apple의 [Creating a multiplatform binary framework bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)은 iOS와 iOS Simulator static library를 별도로 만들고 `lipo`로 합치지 말라고 안내해요.
+
+XCFramework는 다음 정보를 함께 보관해요.
+
+- supported platform과 simulator·Mac Catalyst 같은 variant
+- 각 variant가 지원하는 architecture 목록
+- 실제 framework 또는 library의 상대 경로
+- library를 직접 담을 때 사용할 header 경로
+- code signing과 mergeable library 같은 추가 metadata
+
+Xcode는 client의 현재 build destination을 보고 일치하는 library identifier를 선택해 link해요.
+
+## XCFramework 내부는 variant directory의 모음이에요
+
+`ReadingSDK.xcframework`의 단순화한 예예요.
+
+```text
+ReadingSDK.xcframework/
+├── Info.plist
+├── ios-arm64/
+│   └── ReadingSDK.framework/
+│       ├── ReadingSDK
+│       ├── Info.plist
+│       └── Modules/
+└── ios-arm64_x86_64-simulator/
+    └── ReadingSDK.framework/
+        ├── ReadingSDK
+        ├── Info.plist
+        └── Modules/
+```
+
+root `Info.plist`의 `AvailableLibraries`에는 각 directory의 identifier, library path, supported platform, variant와 architecture가 기록돼요. directory 이름을 application code에서 직접 선택하지 않고 Xcode build system이 metadata를 읽어 선택해요.
+
+```text
+Client destination: generic/platform=iOS Simulator, arm64
+                         ↓ metadata와 일치
+ios-arm64_x86_64-simulator/ReadingSDK.framework
+```
+
+실제 key와 값은 Xcode version과 artifact 구성에 따라 달라질 수 있으므로 직접 plist를 수정하기보다 `xcodebuild -create-xcframework`로 생성해요.
+
+## XCFramework는 static·dynamic 모두 담을 수 있어요
+
+Apple 공식 문서는 XCFramework가 static 또는 dynamic framework를 포함할 수 있고, static library와 header도 묶을 수 있다고 명시해요.
+
+```text
+ReadingDynamic.xcframework
+└── 각 variant의 dynamic ReadingSDK.framework
+
+ReadingStatic.xcframework
+└── 각 variant의 static ReadingSDK.framework
+
+ReadingCLibrary.xcframework
+├── 각 variant의 libReading.a
+└── 각 variant의 Headers/
+```
+
+client가 XCFramework를 추가하면 Xcode가 variant를 선택한 뒤 내부 product의 방식대로 link해요.
+
+- static variant이면 필요한 object code가 client image에 들어가요.
+- dynamic variant이면 client가 별도 framework image를 dependency로 갖고 app에 embed·sign해야 해요.
+
+즉, **XCFramework는 “어느 variant를 고를지”를 해결하고 static·dynamic은 “선택한 binary를 어떻게 연결할지”를 결정해요.** 자세한 차이는 [정적·동적 프레임워크 문서](./static-and-dynamic-frameworks)를 참고해요.
+
+## 배포할 framework target을 준비해요
+
+예제에서는 `ReadingSDK`라는 Swift framework를 iOS device와 simulator용으로 배포해요.
+
+### 1. Public API를 명확히 만들어요
+
+binary client가 사용할 declaration은 `public` 또는 필요한 경우 `open`이어야 해요.
+
+```swift
+public struct ReadingProgress: Sendable {
+  public let completedPages: Int
+  public let totalPages: Int
+
+  public init(completedPages: Int, totalPages: Int) {
+    self.completedPages = completedPages
+    self.totalPages = totalPages
+  }
+
+  public var ratio: Double {
+    guard totalPages > 0 else { return 0 }
+    return min(Double(completedPages) / Double(totalPages), 1)
+  }
+}
+```
+
+source target 안에서 `internal` API가 동작하는 것과 외부 binary client가 import할 수 있는 것은 달라요. framework의 generated interface에서 실제 공개 surface를 확인해요.
+
+### 2. Framework만 build하는 scheme을 준비해요
+
+Apple은 framework target과 필요한 dependency만 build하는 scheme을 준비하라고 안내해요. CI의 `xcodebuild archive`가 scheme을 찾으려면 shared scheme으로 관리하는 것이 안전해요.
+
+### 3. Distribution build setting을 설정해요
+
+| build setting                    | 값          | 이유                                                                                                 |
+| -------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
+| Build Libraries for Distribution | `Yes`       | Swift library evolution을 켜고 stable module interface를 생성해 다른 compiler client를 지원해요.     |
+| Skip Install                     | `No`        | archive의 install product에 framework가 포함되게 해요.                                               |
+| Architectures                    | 기본값 유지 | destination과 Xcode가 지원하는 architecture를 선택하게 해요. 수동으로 오래된 목록을 고정하지 않아요. |
+| Build Configuration              | `Release`   | 배포 optimization과 distribution 설정으로 archive해요.                                               |
+
+command line에서는 `SKIP_INSTALL=NO`, `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`로 명시할 수 있어요.
+
+`BUILD_LIBRARY_FOR_DISTRIBUTION=YES`를 모든 source package나 내부 framework에 습관적으로 켜지는 마세요. Swift.org의 [Library Evolution in Swift](https://www.swift.org/blog/library-evolution/)는 client와 항상 함께 build·배포하는 library라면 library evolution이 필요하지 않고, 이 mode가 performance 특성과 enum switch 규칙에 영향을 준다고 설명해요. **다른 compiler·release schedule의 client에 Swift binary를 배포할 때** 이 비용과 호환성 계약을 받아들여 사용해요.
+
+## Device와 simulator archive를 각각 만들어요
+
+같은 scheme을 destination만 바꾸어 두 번 archive해요. command는 project 구조에 맞게 `-project` 대신 `-workspace`를 사용할 수 있어요.
+
+### iOS device archive
+
+```bash
+xcodebuild archive \
+  -project ReadingSDK.xcodeproj \
+  -scheme ReadingSDK \
+  -configuration Release \
+  -destination 'generic/platform=iOS' \
+  -archivePath 'Build/ReadingSDK-iOS.xcarchive' \
+  SKIP_INSTALL=NO \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+```
+
+### iOS Simulator archive
+
+```bash
+xcodebuild archive \
+  -project ReadingSDK.xcodeproj \
+  -scheme ReadingSDK \
+  -configuration Release \
+  -destination 'generic/platform=iOS Simulator' \
+  -archivePath 'Build/ReadingSDK-iOS-Simulator.xcarchive' \
+  SKIP_INSTALL=NO \
+  BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+```
+
+`-sdk`와 `-arch`를 직접 조합하기보다 `-destination`으로 platform을 지정하는 것이 Apple의 현재 권장 방식이에요. Xcode가 destination, SDK와 build setting을 조합해 필요한 architecture를 결정해요.
+
+archive가 만들어지면 framework가 있는지 확인해요.
+
+```text
+Build/ReadingSDK-iOS.xcarchive/
+└── Products/
+    └── Library/
+        └── Frameworks/
+            └── ReadingSDK.framework
+```
+
+`Products/Library/Frameworks`에 product가 없다면 scheme이 잘못된 target을 build했거나 `SKIP_INSTALL`이 `YES`인지 먼저 확인해요.
+
+## `xcodebuild -create-xcframework`로 묶어요
+
+현재 Xcode는 archive path와 framework name을 직접 받을 수 있어요.
+
+```bash
+xcodebuild -create-xcframework \
+  -archive 'Build/ReadingSDK-iOS.xcarchive' \
+  -framework ReadingSDK.framework \
+  -archive 'Build/ReadingSDK-iOS-Simulator.xcarchive' \
+  -framework ReadingSDK.framework \
+  -output 'Build/ReadingSDK.xcframework'
+```
+
+archive를 사용하지 않고 framework의 전체 path를 전달할 수도 있어요.
+
+```bash
+xcodebuild -create-xcframework \
+  -framework 'Build/ReadingSDK-iOS.xcarchive/Products/Library/Frameworks/ReadingSDK.framework' \
+  -framework 'Build/ReadingSDK-iOS-Simulator.xcarchive/Products/Library/Frameworks/ReadingSDK.framework' \
+  -output 'Build/ReadingSDK.xcframework'
+```
+
+### Static library와 header를 묶는 경우
+
+`.a`와 C·Objective-C public header를 배포한다면 `-library`와 `-headers`를 variant마다 제공해요.
+
+```bash
+xcodebuild -create-xcframework \
+  -library 'Build/iOS/libReadingCore.a' \
+  -headers 'Sources/ReadingCore/include' \
+  -library 'Build/iOS-Simulator/libReadingCore.a' \
+  -headers 'Sources/ReadingCore/include' \
+  -output 'Build/ReadingCore.xcframework'
+```
+
+static library를 `.framework`처럼 이름만 바꾸어 포장하지 말고 Apple이 제공하는 `-library` 형식을 사용해요.
+
+### Debug symbol도 release artifact로 관리해요
+
+crash를 symbolicate하려면 binary와 정확히 일치하는 dSYM이 필요해요. `.xcarchive` 원본과 dSYM을 release별로 보관하고, `xcodebuild -create-xcframework -help`에서 지원하는 `-debug-symbols <path>`로 해당 variant의 dSYM을 artifact에 포함할 수 있어요.
+
+debug symbol path는 반드시 앞선 `-framework` 또는 `-library` variant와 대응해야 해요. 임의로 다른 build의 dSYM을 섞으면 UUID가 맞지 않아 symbolication에 사용할 수 없어요.
+
+## XCFramework를 먼저 구조적으로 검증해요
+
+### Root metadata를 확인해요
+
+```bash
+plutil -p Build/ReadingSDK.xcframework/Info.plist
+```
+
+각 `AvailableLibraries` 항목에 다음 정보가 의도대로 있는지 봐요.
+
+- iOS와 iOS Simulator variant가 모두 있어요.
+- device와 simulator의 platform variant가 구분돼요.
+- 지원 architecture가 Release 정책과 맞아요.
+- `LibraryPath`가 실제 directory와 일치해요.
+
+### 각 main binary를 확인해요
+
+```bash
+file Build/ReadingSDK.xcframework/ios-arm64/ReadingSDK.framework/ReadingSDK
+
+file Build/ReadingSDK.xcframework/ios-arm64_x86_64-simulator/ReadingSDK.framework/ReadingSDK
+```
+
+directory identifier는 실제 artifact마다 달라질 수 있어요. `Info.plist`의 identifier를 먼저 확인하세요.
+
+### Swift module interface를 확인해요
+
+```text
+ReadingSDK.framework/Modules/ReadingSDK.swiftmodule/
+├── arm64-apple-ios.swiftinterface
+└── arm64-apple-ios.private.swiftinterface
+```
+
+배포할 public `.swiftinterface`가 생성됐는지 확인해요. 이 text file은 source 전체가 아니라 public API와 compiler가 import에 필요한 정보를 표현해요. `private` declaration body를 숨기는 보안 장치로 binary distribution을 선택하더라도 public API와 `@inlinable` body 등은 interface에서 볼 수 있다는 점을 고려해야 해요.
+
+### 실제 client app으로 두 destination을 build해요
+
+artifact directory만 검사해서는 link·embed 문제를 찾기 어려워요. 최소 client fixture를 만들어 다음을 모두 검증해요.
+
+1. iOS Simulator Debug 또는 Release build
+2. generic iOS device archive
+3. framework public API import와 실제 호출
+4. dynamic framework라면 final `.app/Frameworks`와 code signature
+5. 최소 지원 deployment target
+
+## Swift binary compatibility를 세 개념으로 구분해요
+
+“Swift 5부터 binary 호환이 된다”는 한 문장으로는 부족해요.
+
+| 개념              | 바뀔 수 있는 것                             | 보호하려는 경계                                                              |
+| ----------------- | ------------------------------------------- | ---------------------------------------------------------------------------- |
+| ABI stability     | OS의 Swift runtime·standard library version | compile된 App과 Swift runtime이 binary 수준에서 상호 작동해요.               |
+| module stability  | client가 사용하는 Swift compiler version    | 이전 compiler가 만든 textual `.swiftinterface`를 이후 compiler가 import해요. |
+| library evolution | framework의 허용된 implementation·API 변화  | 기존 binary client를 다시 compile하지 않고 새 library와 동작하게 해요.       |
+
+Apple platform의 Swift ABI 안정성과 “내 framework가 모든 변경에 binary compatible하다”는 말은 같지 않아요. library author는 library evolution mode를 켜고 public ABI를 지키는 versioning 정책을 운영해야 해요.
+
+### `.swiftmodule`은 빠르지만 compiler version에 묶일 수 있어요
+
+serialized `.swiftmodule`은 compiler 내부 data structure를 담으므로 생성한 compiler보다 다른 version이 읽지 못할 수 있어요.
+
+```text
+Module compiled with Swift X cannot be imported by the Swift Y compiler
+```
+
+### `.swiftinterface`는 public API를 text로 전달해요
+
+`BUILD_LIBRARY_FOR_DISTRIBUTION=YES`는 stable textual module interface를 만들어요. client compiler는 자신의 version에 맞는 compiled module이 없으면 이 interface를 parse해 새 module 정보를 만들 수 있어요.
+
+module stability가 있어도 target platform, architecture, deployment target과 dependency의 module compatibility가 맞아야 해요. textual interface가 모든 binary 호환 문제를 자동으로 해결하지는 않아요.
+
+### Library evolution은 flexibility와 최적화를 교환해요
+
+library evolution mode에서 non-`@frozen` public struct와 enum은 client가 exact memory layout을 고정해서 가정하지 않도록 resilience boundary를 만들어요. 그래서 허용된 stored property나 enum case 추가 같은 변화가 binary compatible할 수 있어요.
+
+```swift
+public enum ReadingState {
+  case idle
+  case reading
+}
+```
+
+client는 future case를 고려해 `@unknown default`를 처리해야 해요.
+
+```swift
+switch state {
+case .idle:
+  showIdle()
+case .reading:
+  showReading()
+@unknown default:
+  showFallback()
+}
+```
+
+`@frozen`은 layout이나 enum case 집합이 변하지 않는다고 public ABI에 약속해 client optimization 여지를 늘려요. 대신 stored property나 case를 추가·삭제·재정렬하기 어려워지므로 profiling 없이 배포 API에 습관적으로 붙이지 않아요. Swift Evolution의 [SE-0260 Library Evolution](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0260-library-evolution.md)이 허용되는 변화와 `@frozen` 계약을 자세히 설명해요.
+
+## Xcode project에 직접 통합해요
+
+1. `.xcframework`를 Project navigator로 추가해요.
+2. 사용할 target의 **Frameworks, Libraries, and Embedded Content**에 포함됐는지 확인해요.
+3. 내부 binary가 dynamic이면 **Embed & Sign**, static이면 product와 resource 방식에 맞는 Embed 설정을 사용해요.
+4. source에서 module을 import하고 public API를 호출해요.
+5. simulator 실행과 device archive를 모두 확인해요.
+
+```swift
+import ReadingSDK
+
+let progress = ReadingProgress(
+  completedPages: 42,
+  totalPages: 100
+)
+
+print(progress.ratio)
+```
+
+XCFramework 하나를 추가해도 Xcode가 현재 destination의 variant를 선택할 뿐, binary가 의존하는 모든 transitive framework를 임의로 찾아 embed해 주는 것은 아니에요. vendor는 dependency를 문서화하고 client는 package product와 final bundle을 확인해야 해요.
+
+## Swift Package Manager로 binary를 배포해요
+
+Apple의 [Distributing binary frameworks as Swift packages](https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages)는 local path 또는 remote ZIP의 XCFramework를 `binaryTarget`으로 선언하는 방법을 제공해요. Binary target은 Apple platform에서 사용할 수 있어요.
+
+`binaryTarget`의 `name`은 artifact가 공개하는 module 이름과 맞춰요. Package product 이름만 같고 실제 module 이름이 다르면 consumer의 `import ReadingSDK`가 실패할 수 있어요.
+
+### Local XCFramework
+
+```swift
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+  name: "ReadingSDKPackage",
+  platforms: [.iOS(.v17)],
+  products: [
+    .library(
+      name: "ReadingSDK",
+      targets: ["ReadingSDK"]
+    )
+  ],
+  targets: [
+    .binaryTarget(
+      name: "ReadingSDK",
+      path: "Binaries/ReadingSDK.xcframework"
+    )
+  ]
+)
+```
+
+### Remote ZIP
+
+XCFramework가 ZIP의 root에 오도록 압축하고 HTTPS URL로 배포해요.
+
+```swift
+.binaryTarget(
+  name: "ReadingSDK",
+  url: "https://example.com/releases/1.2.0/ReadingSDK.xcframework.zip",
+  checksum: "<swift package compute-checksum 결과>"
+)
+```
+
+checksum은 배포할 최종 ZIP을 기준으로 계산해요.
+
+```bash
+swift package compute-checksum ReadingSDK.xcframework.zip
+```
+
+ZIP을 다시 압축하면 binary 내용이 같아 보여도 archive byte가 바뀌어 checksum이 달라질 수 있어요. release URL을 immutable하게 운영하고 version마다 새 checksum을 manifest에 기록해요.
+
+### Source wrapper와 binary target을 함께 사용할 수 있어요
+
+public API를 source target으로 감싸고 내부에서 binary target에 의존하게 만들면 import 이름과 adapter code를 관리할 수 있어요.
+
+```swift
+.target(
+  name: "ReadingSDKClient",
+  dependencies: ["ReadingSDKBinary"]
+),
+.binaryTarget(
+  name: "ReadingSDKBinary",
+  url: "https://example.com/ReadingSDKBinary.zip",
+  checksum: "..."
+)
+```
+
+source wrapper가 closed-source binary의 platform 제한을 없애 주는 것은 아니에요. binary target이 지원하는 destination 안에서만 build할 수 있어요.
+
+## Checksum과 code signature는 다른 위협을 막아요
+
+| 검증                       | 무엇을 확인하나요?                                                       | 한계                                                        |
+| -------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| SwiftPM checksum           | 내려받은 ZIP byte가 manifest에 선언한 값과 같은지 확인해요.              | manifest와 ZIP을 함께 바꾼 공격자의 신원을 판단하지 못해요. |
+| XCFramework code signature | artifact를 누가 sign했고 추가 뒤 signature가 바뀌지 않았는지 확인해요.   | signing identity를 신뢰할지는 consumer가 판단해야 해요.     |
+| App code signing           | 최종 app bundle의 executable code가 배포 identity와 일치하는지 확인해요. | 원래 SDK 공급망의 검토를 대신하지 않아요.                   |
+
+XCFramework를 배포 identity로 sign하려면 Apple 문서의 예처럼 실행할 수 있어요.
+
+```bash
+codesign --timestamp \
+  -s 'Apple Distribution: Example Company (TEAMID)' \
+  Build/ReadingSDK.xcframework
+```
+
+client는 Xcode File inspector에서 XCFramework의 signature와 signing team을 확인해요. Apple의 [Verifying the origin of your XCFrameworks](https://developer.apple.com/documentation/xcode/verifying-the-origin-of-your-xcframeworks)는 추가한 뒤 signature가 제거·변경되거나 다른 developer가 update에 sign하면 build system이 경고·오류로 알려 주는 흐름을 설명해요.
+
+signature가 유효하다는 사실만으로 SDK의 privacy·security가 안전하다는 뜻은 아니에요. official release channel, privacy manifest, dependency, entitlement 사용과 release note를 함께 검토해요.
+
+## Binary release를 versioning해요
+
+binary framework의 public API와 ABI는 배포 뒤 client와의 계약이 돼요.
+
+| 변경 예                                      | 일반적인 영향                                                    |
+| -------------------------------------------- | ---------------------------------------------------------------- |
+| private implementation 수정                  | public 동작 계약을 지키면 patch 후보예요.                        |
+| 새 public method·type 추가                   | source·binary compatible하게 설계했다면 minor 후보예요.          |
+| public function parameter나 symbol 이름 변경 | 기존 client가 symbol을 찾지 못해 major 변경이 필요할 수 있어요.  |
+| `@frozen` struct stored property 추가        | binary-incompatible해요.                                         |
+| 지원 platform·architecture 제거              | 기존 client build를 깨뜨릴 수 있으므로 breaking change로 다뤄요. |
+| dependency version·linkage 변경              | client의 link·embed와 app size에 영향을 주므로 명시해야 해요.    |
+
+Semantic Versioning 숫자만 올린다고 compatibility가 생기지는 않아요. release마다 이전 client fixture로 새 binary를 link·실행하고, API·ABI 검사 도구와 integration test로 계약을 확인해요.
+
+## XCFramework가 유용한 경우와 source package가 나은 경우
+
+### XCFramework가 유용해요
+
+- proprietary implementation을 source로 공개할 수 없어요.
+- C·C++·Objective-C를 포함한 긴 build 시간을 consumer에게 반복시키고 싶지 않아요.
+- vendor가 compiler option과 binary 품질을 통제해야 해요.
+- 여러 Apple platform variant를 하나의 signed artifact로 배포해야 해요.
+
+### Source Swift package를 먼저 검토해요
+
+- consumer가 source를 audit하고 debugger로 내부에 들어가야 해요.
+- 새로운 platform·architecture를 package 사용자 toolchain에서 즉시 build해야 해요.
+- library와 App이 항상 함께 compile되어 별도 ABI evolution이 필요 없어요.
+- binary artifact hosting, signing, checksum과 장기 호환성 운영 비용을 피하고 싶어요.
+
+Apple도 binary package가 artifact에 포함한 platform에만 한정되어 source package보다 portable하지 않다고 설명해요. 기술적으로 만들 수 있다는 이유만으로 XCFramework를 선택하지 말고 배포 제약이 실제 요구인지 먼저 확인해요.
+
+## 대표 오류와 진단 순서
+
+### `No matching library variant found`
+
+현재 platform·architecture에 맞는 entry가 root `Info.plist`에 없어요.
+
+1. client destination을 확인해요.
+2. `AvailableLibraries`의 platform, variant와 architecture를 확인해요.
+3. device와 simulator archive를 모두 생성했는지 확인해요.
+4. 오래된 architecture allowlist나 excluded architecture를 제거해요.
+
+### `building for iOS Simulator, but linking in object file built for iOS`
+
+architecture가 같더라도 platform이 다른 binary를 직접 link했어요. device와 simulator framework를 `lipo`로 합치지 말고 별도 variant로 XCFramework를 다시 만들어요.
+
+### `Module compiled with ... cannot be imported by ...`
+
+client compiler가 호환되는 `.swiftmodule`이나 stable `.swiftinterface`를 읽지 못했어요.
+
+1. `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`로 Release archive했는지 확인해요.
+2. 각 variant의 `Modules/<Name>.swiftmodule` 안에 public `.swiftinterface`가 있는지 봐요.
+3. interface가 import하는 binary dependency도 module-stable한지 확인해요.
+4. language feature가 너무 오래된 client compiler에서 parse 가능한지 지원 범위를 검토해요.
+
+### `Undefined symbols for architecture ...`
+
+variant 선택은 성공했지만 symbol implementation을 찾지 못했어요. public API와 actual binary version이 일치하는지, transitive static library가 누락되지 않았는지, binary가 symbol을 export하는지 확인해요. [컴파일과 링킹 문서](./build-compile-and-link)의 symbol 진단 순서를 적용해요.
+
+### `Library not loaded: @rpath/...`
+
+선택된 내부 product가 dynamic인데 final app에 embed되지 않았거나 run path·signature가 잘못됐어요. XCFramework root가 아니라 선택된 framework가 `.app/Frameworks`에 있는지 확인해요.
+
+### SwiftPM checksum mismatch
+
+서버의 ZIP byte와 `Package.swift` checksum이 달라요. download cache를 지우는 것으로 덮지 말고 release URL이 덮어써졌는지, CDN이 다른 content를 주는지, manifest가 올바른 version checksum을 가리키는지 확인해요.
+
+## Release 자동화 예시
+
+script를 만들 때는 단계별 output을 분리하고 실패 즉시 멈추게 해요.
+
+```text
+1. clean checkout과 고정 Xcode version 확인
+2. framework unit·integration test
+3. iOS device archive
+4. iOS Simulator archive
+5. XCFramework 생성
+6. variant·module interface·symbol 검사
+7. 최소 client simulator build와 device archive
+8. dSYM·license·privacy manifest 수집
+9. XCFramework signing
+10. ZIP 생성과 checksum 계산
+11. immutable release 업로드
+12. Package.swift version·checksum 갱신
+```
+
+archive와 XCFramework를 source repository에 무조건 commit하지 말고 release artifact storage를 사용해요. binary, dSYM, checksum, Xcode build version과 source commit을 같은 release record로 추적하면 crash와 compatibility 문제를 재현하기 쉬워요.
+
+## 배포 체크리스트
+
+- [ ] 지원할 platform, variant, architecture와 최소 OS를 문서화했나요?
+- [ ] device와 simulator를 각각 `-destination`으로 archive했나요?
+- [ ] `SKIP_INSTALL=NO`로 archive product에 framework가 들어갔나요?
+- [ ] Swift binary 배포 요구에 맞게 `BUILD_LIBRARY_FOR_DISTRIBUTION`을 결정했나요?
+- [ ] XCFramework가 static인지 dynamic인지 consumer에게 명시했나요?
+- [ ] public `.swiftinterface`와 generated interface를 검토했나요?
+- [ ] 각 variant의 binary type과 architecture를 `file`로 확인했나요?
+- [ ] simulator build와 generic device archive를 실제 client project로 검증했나요?
+- [ ] dynamic dependency의 embed·`@rpath`·signature를 확인했나요?
+- [ ] transitive dependency, license, privacy manifest와 entitlement 요구를 문서화했나요?
+- [ ] matching dSYM과 source commit을 release별로 보관했나요?
+- [ ] remote ZIP을 immutable하게 게시하고 checksum을 다시 검증했나요?
+- [ ] XCFramework signature와 공급 경로를 consumer가 확인할 수 있나요?
+
+## 자주 묻는 면접 질문
+
+### XCFramework와 universal framework의 차이는 무엇인가요?
+
+universal binary는 같은 platform의 여러 architecture slice를 하나의 Mach-O에 담아요. XCFramework는 iOS와 iOS Simulator처럼 platform environment가 다른 framework·library variant를 분리해 담고 metadata로 선택하게 해요. 한 XCFramework 내부의 한 variant가 universal binary일 수도 있어요.
+
+### XCFramework는 static인가요, dynamic인가요?
+
+둘 다 가능해요. XCFramework는 variant를 묶는 container이고 실제 linkage는 내부 framework나 library binary가 결정해요. Xcode는 destination에 맞는 variant를 고른 뒤 static 또는 dynamic 방식으로 link해요.
+
+### `BUILD_LIBRARY_FOR_DISTRIBUTION`은 무엇을 하나요?
+
+Swift framework target에서 module stability를 위한 `.swiftinterface`를 생성하고 library evolution mode를 켜 binary client와 compiler·release version 경계를 유지하도록 해요. 그 대가로 resilience를 위한 간접 접근과 API 제약이 생길 수 있어, 항상 함께 build하는 source dependency에는 기본값처럼 켜지 않아요.
+
+### ABI stability와 module stability의 차이는 무엇인가요?
+
+ABI stability는 이미 compile된 binary와 runtime·library가 호출 규약과 layout 수준에서 동작하는 계약이고, module stability는 다른 Swift compiler가 library의 public API interface를 읽어 client source를 compile할 수 있게 하는 계약이에요. binary framework 배포에는 둘 다 관련되지만 해결하는 단계가 달라요.
+
+### SwiftPM checksum과 XCFramework signing이 모두 필요한 이유는 무엇인가요?
+
+checksum은 manifest가 가리킨 ZIP과 download한 byte가 같은지 검증하고, code signature는 artifact의 signer identity와 이후 변경 여부를 확인해요. 하나는 content 일치, 다른 하나는 provenance와 integrity에 가까워 서로 대체하지 않아요.
+
+## 참고 자료
+
+- [Creating a multiplatform binary framework bundle - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)
+- [Distributing binary frameworks as Swift packages - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages)
+- [Verifying the origin of your XCFrameworks - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/verifying-the-origin-of-your-xcframeworks)
+- [Creating a static framework - Apple Developer Documentation](https://developer.apple.com/documentation/xcode/creating-a-static-framework)
+- [Binary Frameworks in Swift - WWDC19](https://developer.apple.com/videos/play/wwdc2019/416/)
+- [Distribute binary frameworks as Swift packages - WWDC20](https://developer.apple.com/videos/play/wwdc2020/10147/)
+- [Library Evolution in Swift - Swift.org](https://www.swift.org/blog/library-evolution/)
+- [ABI Stability and More - Swift.org](https://www.swift.org/blog/abi-stability-and-more/)
+- [SE-0260 Library Evolution for Stable ABIs - Swift Evolution](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0260-library-evolution.md)


### PR DESCRIPTION
## Summary

XCFramework를 단독 개념으로 설명하지 않고 Swift source가 compile·link되는 과정, static·dynamic framework의 연결 방식, platform variant를 묶어 배포하는 XCFramework까지 하나의 학습 흐름으로 정리합니다.

## Changes

- `빌드와 바이너리 배포` 문서 섹션과 상단 내비게이션을 추가했습니다.
- compiler, object file, module, symbol, linker, Mach-O와 `dyld`의 책임 및 단계별 오류 진단을 문서화했습니다.
- library·framework·XCFramework를 구분하고 static·dynamic linking의 embed, launch, size, resource와 ABI tradeoff를 비교했습니다.
- iOS device·simulator archive와 `xcodebuild -create-xcframework` 명령, static library와 header packaging을 설명했습니다.
- ABI stability, module stability, library evolution과 `BUILD_LIBRARY_FOR_DISTRIBUTION`의 적용 범위를 구분했습니다.
- Xcode·Swift Package Manager 통합, checksum·code signature·dSYM, release 검증과 troubleshooting checklist를 추가했습니다.
- Apple Developer, Swift.org, Swift Evolution과 LLVM 공식 자료를 본문과 참고 자료에 연결했습니다.

## Testing

- `npm run format`
- `npm run lint`
- `npm run build`
- `git diff --check`
- 생성된 Rspress 페이지와 상단 내비게이션 문자열 확인

## Related Issues

Closes #55

## Notes

- 주제별 책임과 학습 순서를 분리하기 위해 문서를 컴파일·링킹, 정적·동적 프레임워크, XCFramework의 3개 페이지로 구성했습니다.
- XCFramework가 static·dynamic을 결정하는 형식이 아니라 platform·architecture variant를 묶는 container라는 점을 중심으로 설명했습니다.
