### PR TITLE
[#57] Realm Swift 로컬 데이터베이스 학습 문서 섹션을 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -24,6 +24,12 @@
     "position": "left"
   },
   {
+    "text": "Realm Swift",
+    "link": "/guide/realm-swift/index",
+    "activeMatch": "/guide/realm-swift/",
+    "position": "left"
+  },
+  {
     "text": "테스트",
     "link": "/guide/testing/xctest-unit-testing",
     "activeMatch": "/guide/testing/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -21,6 +21,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "realm-swift",
+    "label": "Realm Swift"
+  },
+  {
+    "type": "dir-section-header",
     "name": "testing",
     "label": "테스트"
   },

--- a/docs/guide/realm-swift/_meta.json
+++ b/docs/guide/realm-swift/_meta.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "custom-link",
+    "label": "Realm Swift 시작하기",
+    "link": "/guide/realm-swift/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "데이터 모델과 CRUD",
+    "link": "/guide/realm-swift/models-and-crud"
+  },
+  {
+    "type": "custom-link",
+    "label": "쿼리와 변경 관찰",
+    "link": "/guide/realm-swift/queries-and-observation"
+  },
+  {
+    "type": "custom-link",
+    "label": "운영과 전환",
+    "link": "/guide/realm-swift/configuration-migration-and-security",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "구성·마이그레이션·보안",
+        "link": "/guide/realm-swift/configuration-migration-and-security"
+      },
+      {
+        "type": "custom-link",
+        "label": "Atlas Device Sync 종료와 전환",
+        "link": "/guide/realm-swift/atlas-device-sync-eol"
+      }
+    ]
+  }
+]

--- a/docs/guide/realm-swift/atlas-device-sync-eol.md
+++ b/docs/guide/realm-swift/atlas-device-sync-eol.md
@@ -1,0 +1,283 @@
+---
+title: Atlas Device Sync 종료와 Realm 전환 가이드
+description: MongoDB Atlas Device SDK 종료 범위와 Realm Swift v20의 로컬 전용 변화를 구분하고 기존 Sync 앱의 인증, 동기화, 충돌 해결 전환 절차를 설계합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Atlas Device Sync 종료와 Realm 전환 가이드
+
+> 면접용 한 줄 요약: **Atlas Device SDK는 기기 내 Realm과 Atlas Device Sync로 구성됐지만 Sync·App Services는 2025년 9월 30일 종료됐고, Realm Swift v20에는 로컬 데이터베이스 API만 남았습니다.**
+
+사용자가 제시한 [MongoDB Atlas Device SDK for Swift 문서](https://www.mongodb.com/ko-kr/docs/atlas/device-sdks/sdk/swift/)에는 로컬 Realm과 Device Sync가 함께 설명돼 있습니다. 이 문서는 과거 구조와 API를 이해하는 자료로는 유용하지만, Sync·App Services 예제를 현재 새 프로젝트의 시작 절차로 사용하면 안 돼요.
+
+## 이름과 제품 범위를 시간순으로 정리해요
+
+```text
+Realm Mobile Database
+        │ MongoDB 인수 이후
+        ▼
+Realm SDK / MongoDB Realm
+        │ 2023년 명칭 변경
+        ▼
+Atlas Device SDK
+   ├─ 기기 내 Realm database
+   └─ Atlas Device Sync + App Services 연동
+        │ 2024년 9월 deprecated
+        │ 2025년 9월 30일 EOL
+        ▼
+현재 Realm Swift community v20
+   └─ 기기 내 로컬 Realm database만 제공
+```
+
+[MongoDB 공식 종료 안내](https://www.mongodb.com/docs/atlas/device-sdks/deprecation/)는 Atlas Device SDK가 두 부분으로 구성됐다고 설명합니다.
+
+1. **On-device database**: open source community project로 계속 존재해요.
+2. **Atlas Device Sync**: deprecated된 뒤 2025년 9월 30일 end-of-life에 도달했어요.
+
+Realm Swift [`v20.0.0` release note](https://github.com/realm/realm-swift/releases/tag/v20.0.0)도 모든 Atlas App Services·Atlas Device Sync 기능을 제거했다고 명시합니다. 즉 service 종료와 client API 제거가 모두 일어났어요.
+
+## 지금 남은 기능과 종료된 기능을 분리해요
+
+| 기능                        | 현재 Realm Swift v20 | 설명                                                     |
+| --------------------------- | -------------------- | -------------------------------------------------------- |
+| 로컬 Realm file             | 사용 가능            | 기기 안에 객체를 저장해요.                               |
+| `Object`, `@Persisted`      | 사용 가능            | 로컬 schema를 정의해요.                                  |
+| CRUD·query·notification     | 사용 가능            | 로컬 data를 쓰고 live result를 관찰해요.                 |
+| SwiftUI property wrapper    | 사용 가능            | 로컬 Realm 변경을 View와 연결해요.                       |
+| local migration·encryption  | 사용 가능            | file schema와 at-rest 보안을 관리해요.                   |
+| Atlas Device Sync           | 제거·종료            | Atlas와 기기 사이 자동 동기화가 없어요.                  |
+| App Services Authentication | 제거·종료            | `App`, `Credentials`, `User` login 흐름이 없어요.        |
+| Functions의 SDK 직접 호출   | 제거                 | client에서 Realm SDK로 function을 호출할 수 없어요.      |
+| Rules·Roles 기반 Sync 권한  | 제거·종료            | 새 backend의 authorization을 별도로 구현해야 해요.       |
+| Sync subscription·session   | 제거                 | flexible sync query subscription과 session API가 없어요. |
+
+:::warning v10 pin은 서비스 수명을 연장하지 않아요
+`v20.0.0` release note는 기존 Device Sync 사용자가 `v10`에 고정하라고 안내했습니다. 이는 제거된 symbol을 사용하는 기존 source를 당장 build하기 위한 version 선택이지, 이미 EOL에 도달한 Atlas Device Sync와 App Services가 계속 제공된다는 뜻이 아닙니다.
+:::
+
+## codebase에서 과거 Sync 의존성을 찾아요
+
+다음 symbol이나 개념이 보이면 로컬 Realm만 사용하는 앱이 아닐 가능성이 큽니다.
+
+| 찾을 대상                   | 과거 책임                     | 전환 시 필요한 새 책임            |
+| --------------------------- | ----------------------------- | --------------------------------- |
+| `App(id:)`                  | App Services app 연결         | 새 backend client 구성            |
+| `Credentials`               | App Services 인증 credential  | OAuth/OIDC 또는 선택한 인증 SDK   |
+| `User`·`currentUser`        | login session과 user identity | 새 인증 session과 account model   |
+| `flexibleSyncConfiguration` | synced Realm 구성             | local Realm 구성 + 별도 pull/push |
+| `subscriptions`             | device에 내려받을 query set   | server API query·cursor 정책      |
+| `SyncSession`               | upload/download·error 상태    | network queue·retry·monitoring    |
+| `AsymmetricObject`          | Atlas로 write-only ingest     | 명시적 upload endpoint·ack 처리   |
+| App Services Rules·Roles    | server data authorization     | backend의 인증·인가 검사          |
+
+Xcode의 Find navigator에서 이름만 검색하지 말고 다음 흐름도 추적하세요.
+
+```text
+로그인 성공
+  └─> user configuration 생성
+       └─> Realm async open
+            ├─> subscription 갱신
+            ├─> progress 표시
+            └─> client reset·sync error 처리
+```
+
+type 이름을 wrapper 뒤에 숨긴 codebase라면 composition root, repository 구현, login/logout, background refresh와 test double까지 확인해야 합니다.
+
+## 전환 목표를 세 가지 중 먼저 선택해요
+
+### 1. 완전한 로컬 앱으로 전환
+
+여러 device·server 공유가 더 이상 필요 없다면 Sync 의존성을 제거하고 local configuration으로 엽니다.
+
+```swift
+var configuration = Realm.Configuration.defaultConfiguration
+configuration.schemaVersion = 3
+let realm = try Realm(configuration: configuration)
+```
+
+가장 단순하지만 계정 간 복원, web console 수정, 여러 device 동기화 기능은 사라집니다. 기존 Atlas data를 언제 어떻게 기기로 내려받을지와 logout 시 local data 정책도 필요해요.
+
+### 2. Realm은 로컬 저장소로 유지하고 별도 backend와 동기화
+
+Realm의 query·notification·오프라인 저장은 유지하되 networking과 sync protocol을 앱·server가 직접 책임집니다.
+
+```text
+SwiftUI / UIKit
+      │
+      ▼
+Local Realm ── Outbox ──> 새 Backend API ──> Server Database
+      ▲                         │
+      └──── cursor 기반 Pull ───┘
+```
+
+이 경로는 UI 변경을 최소화할 수 있지만 과거 Device Sync가 맡았던 retry, ordering, conflict resolution, auth, access control과 observability를 새로 설계해야 해요.
+
+### 3. local database까지 교체
+
+SwiftData, Core Data, SQLite 계층 또는 새 sync solution의 database로 옮길 수 있습니다. package 유지보수 위험을 줄일 수 있지만 model, query, observation, migration과 test가 모두 영향을 받아요. `Object`를 feature 전체에 직접 노출한 앱일수록 교체 비용이 커집니다.
+
+도입 당시의 편의보다 앞으로 3~5년의 OS 지원 범위, 팀 역량, offline 요구와 vendor support를 기준으로 선택하세요.
+
+## 직접 동기화한다면 Outbox부터 설계해요
+
+network 요청을 먼저 보내고 성공하면 Realm을 바꾸는 방식은 offline UX가 약하고 process 종료 사이에 상태를 잃기 쉽습니다. local 변경과 upload 의도를 같은 transaction에 기록하는 Outbox pattern을 사용할 수 있어요.
+
+```swift
+import Foundation
+import RealmSwift
+
+enum MutationOperation: String, PersistableEnum {
+  case create
+  case update
+  case delete
+}
+
+final class PendingMutation: Object {
+  @Persisted(primaryKey: true) var id: ObjectId
+  @Persisted(indexed: true) var entityID = ""
+  @Persisted var operation = MutationOperation.update
+  @Persisted var payload = Data()
+  @Persisted var createdAt = Date()
+  @Persisted var retryCount = 0
+}
+
+struct BookMutationPayload: Codable, Sendable {
+  let id: String
+  let title: String
+  let progress: Int
+  let clientRevision: Int
+}
+```
+
+```swift
+func updateBookAndEnqueue(
+  book: Book,
+  title: String,
+  progress: Int,
+  encoder: JSONEncoder,
+  realm: Realm
+) throws {
+  let payload = BookMutationPayload(
+    id: book.id.stringValue,
+    title: title,
+    progress: progress,
+    clientRevision: Int(book.updatedAt.timeIntervalSince1970)
+  )
+  let encoded = try encoder.encode(payload)
+
+  try realm.write {
+    book.title = title
+    book.progress = progress
+    book.updatedAt = Date()
+
+    let mutation = PendingMutation()
+    mutation.entityID = book.id.stringValue
+    mutation.operation = .update
+    mutation.payload = encoded
+    realm.add(mutation)
+  }
+}
+```
+
+local object update와 `PendingMutation` 추가가 한 transaction이므로 둘 중 하나만 남지 않습니다. upload worker는 다음 순서로 동작할 수 있어요.
+
+1. 오래된 pending mutation을 제한된 batch로 읽어요.
+2. mutation ID를 idempotency key로 server에 전송해요.
+3. server가 revision과 결과를 응답해요.
+4. 성공을 확인한 transaction에서 Outbox 항목을 삭제하고 server revision을 저장해요.
+5. 실패하면 backoff, network 도달 가능성, 인증 갱신과 최대 재시도 정책을 적용해요.
+
+Outbox만 추가한다고 완전한 Sync가 되지는 않습니다. server 변경을 가져오는 inbox/pull, delete tombstone, ordering과 충돌 해결이 함께 필요해요.
+
+## Pull은 cursor와 원자적 적용이 필요해요
+
+```text
+GET /changes?cursor=abc
+        │
+        ├─ upserts [BookPayload]
+        ├─ deletes [BookID]
+        └─ nextCursor def
+                │
+                ▼
+Realm.write {
+  upsert 모두 적용
+  tombstone 삭제 적용
+  cursor = def 저장
+}
+```
+
+data 적용과 `nextCursor` 저장을 같은 transaction에 넣으면 process가 중간에 종료돼도 일부 data만 반영한 채 다음 cursor로 넘어가지 않습니다. response가 너무 크면 server cursor를 더 작은 page로 쪼개고 page마다 원자적으로 적용해요.
+
+## 충돌 정책은 코드보다 먼저 문장으로 정의해요
+
+| 정책              | 장점                                     | 위험                                           |
+| ----------------- | ---------------------------------------- | ---------------------------------------------- |
+| server wins       | 구현이 단순하고 중앙 정책이 명확해요.    | offline 사용자의 변경을 잃을 수 있어요.        |
+| client wins       | 사용자가 방금 한 변경을 유지하기 쉬워요. | 오래된 client가 새 server 값을 덮을 수 있어요. |
+| last write wins   | timestamp 비교가 간단해요.               | device clock 차이와 동시 수정에 약해요.        |
+| revision compare  | stale write를 server가 거부할 수 있어요. | conflict UI·retry logic이 필요해요.            |
+| field-level merge | 독립 field 변경을 보존할 수 있어요.      | schema와 규칙이 복잡해져요.                    |
+
+“가장 최근 값”이 무엇을 뜻하는지 server sequence인지 device time인지 명확히 해야 합니다. 금액·재고처럼 손실되면 안 되는 data는 client의 자동 last-write-wins보다 server transaction과 domain command가 적합해요.
+
+## 인증과 인가를 따로 이전해요
+
+MongoDB 종료 안내는 Device SDK를 통한 Authentication and User Management도 더 이상 제공되지 않는다고 설명합니다. 새 인증 provider를 연결했다고 data 보안이 완성되는 것은 아니에요.
+
+```text
+Authentication: 이 요청을 보낸 사용자는 누구인가?
+Authorization: 이 사용자가 이 Book을 읽거나 수정할 수 있는가?
+```
+
+- access·refresh token은 Realm 일반 property보다 Keychain 보관을 우선해요.
+- server는 client가 보낸 `ownerID`를 신뢰하지 말고 인증 token의 subject와 비교해요.
+- logout 시 local Realm, encryption key, Outbox와 background task를 어떻게 정리할지 결정해요.
+- token 만료 중 Outbox 요청이 실패하면 재로그인 전까지 보존할지 사용자에게 알릴지 정해요.
+- 과거 Rules·Roles에 있던 조건을 backend authorization test로 옮겨요.
+
+## EOL 이후 전환 순서
+
+현재는 종료일이 지난 상태이므로 새 Sync traffic이 계속된다고 가정하지 말고 보유한 client·server data와 backup부터 확인합니다.
+
+1. **동결**: Sync 관련 dependency와 server 설정을 변경하기 전에 source, schema, App Services 설정과 backup을 보존해요.
+2. **목록화**: 인증, Sync, Function, Rules·Roles, Trigger 의존성을 기능별로 찾아요.
+3. **data source 결정**: Atlas, device Realm, export 중 무엇을 migration의 기준 원본으로 삼을지 정해요.
+4. **목표 architecture 선택**: local-only, Realm+custom sync, local database 교체 중 하나를 결정해요.
+5. **인증·인가 선행**: 새 identity와 server permission을 먼저 검증해요.
+6. **dual-read 또는 export/import 검증**: record 수, primary key, 관계와 삭제 상태를 대조해요.
+7. **client 전환**: feature flag와 단계적 rollout으로 새 경로를 활성화해요.
+8. **관찰**: upload 지연, conflict, auth 실패, data 불일치 지표를 수집해요.
+9. **제거**: 충분한 rollback 기간 뒤에 v10 Sync code와 secret·설정을 삭제해요.
+
+이미 종료된 service에서 export하지 못했다면 client device에 남은 Realm file, Atlas backup과 조직의 MongoDB support 계약을 확인하세요. 가능한 복구 범위를 문서 없이 추측해 기존 파일을 덮어쓰지 않습니다.
+
+## 전환 체크리스트
+
+- [ ] local Realm API와 제거된 Sync API를 source에서 구분했나요?
+- [ ] `v10` 고정이 EOL service를 되살리지 않는다는 점을 공유했나요?
+- [ ] App Services 인증·Functions·Rules·Roles 의존성을 모두 찾았나요?
+- [ ] migration의 기준 data source와 record 대조 방법이 있나요?
+- [ ] custom sync라면 Outbox, cursor, tombstone, retry와 idempotency를 설계했나요?
+- [ ] domain별 conflict policy를 server와 client가 같은 의미로 구현하나요?
+- [ ] token은 Keychain에 저장하고 server authorization을 별도로 검증하나요?
+- [ ] rollback 기간과 Sync code 제거 조건을 정의했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Realm Swift v20에서도 MongoDB Atlas에 연결할 수 있나요?
+
+Realm SDK가 제공하던 Atlas Device Sync·App Services 연결 API로는 할 수 없습니다. v20은 로컬 Realm 데이터베이스 기능만 남겼어요. Atlas를 server database로 계속 사용하려면 직접 관리하는 backend API 같은 별도 연결 계층이 필요합니다.
+
+### Realm을 local cache로 유지하면 Device Sync와 같은가요?
+
+아니요. local Realm은 persistence와 query·notification을 제공할 뿐 upload/download, 인증, 권한, retry, conflict resolution과 client reset을 자동 제공하지 않습니다. 이 책임을 새 architecture에서 명시적으로 구현해야 해요.
+
+## 참고 자료
+
+- [MongoDB Atlas Device SDK for Swift 문서](https://www.mongodb.com/ko-kr/docs/atlas/device-sdks/sdk/swift/)
+- [MongoDB Atlas Device SDK 종료 안내](https://www.mongodb.com/docs/atlas/device-sdks/deprecation/)
+- [MongoDB Atlas App Services 종료 안내](https://www.mongodb.com/docs/atlas/app-services/deprecation/)
+- [Realm Swift v20.0.0 release note](https://github.com/realm/realm-swift/releases/tag/v20.0.0)
+- [Realm Swift community 브랜치](https://github.com/realm/realm-swift/tree/community)
+- [Realm Swift 공식 저장소](https://github.com/realm/realm-swift)

--- a/docs/guide/realm-swift/configuration-migration-and-security.md
+++ b/docs/guide/realm-swift/configuration-migration-and-security.md
@@ -1,0 +1,385 @@
+---
+title: Realm 구성·마이그레이션·보안과 동시성
+description: Realm Configuration으로 파일과 스키마를 분리하고 migration, in-memory 테스트, AES 암호화와 Keychain, actor 격리를 운영 수준으로 설계합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Realm 구성·마이그레이션·보안과 동시성
+
+> 면접용 한 줄 요약: **`Realm.Configuration`은 파일 위치·스키마·migration·암호화의 identity이며, managed Realm 객체는 생성된 executor에 격리하므로 ID나 Sendable DTO를 actor 경계로 전달해야 합니다.**
+
+Realm API로 저장에 성공하는 것과 출시 후 안전하게 운영하는 것은 다른 문제예요. 앱 update에서 schema가 변하고, 암호화 key를 잃을 수 있으며, test가 운영 파일을 열거나 actor가 잘못된 managed object를 받을 수 있습니다. 이 문제들의 출발점이 `Realm.Configuration`입니다.
+
+## configuration이 결정하는 범위를 확인해요
+
+| 설정                    | 결정하는 것                              | 틀렸을 때 생기는 문제                            |
+| ----------------------- | ---------------------------------------- | ------------------------------------------------ |
+| `fileURL`               | 어떤 Realm 파일을 열지                   | 사용자·환경의 데이터가 섞여요.                   |
+| `inMemoryIdentifier`    | 파일 없이 공유할 memory Realm의 identity | test 상태가 섞이거나 너무 빨리 사라져요.         |
+| `objectTypes`           | 파일 schema에 포함할 model subset        | 필요한 type이 없거나 불필요한 schema가 늘어요.   |
+| `schemaVersion`         | 현재 앱 schema version                   | schema mismatch로 열기에 실패해요.               |
+| `migrationBlock`        | 과거 data를 새 schema로 변환하는 방법    | update 후 기존 사용자의 파일만 열리지 않아요.    |
+| `encryptionKey`         | 파일 암호화·복호화 key                   | key가 다르면 기존 파일을 열 수 없어요.           |
+| `shouldCompactOnLaunch` | open 시 파일을 compact할 조건            | 시작 시간이 길어지거나 파일이 불필요하게 커져요. |
+
+configuration은 앱 시작 뒤 여기저기서 즉흥적으로 바꾸기보다 composition root에서 먼저 만들고 store에 주입하세요.
+
+## 기본 파일 대신 목적이 드러나는 위치를 정해요
+
+```swift
+import Foundation
+import RealmSwift
+
+func makeLibraryConfiguration() throws -> Realm.Configuration {
+  let fileManager = FileManager.default
+  let applicationSupport = try fileManager.url(
+    for: .applicationSupportDirectory,
+    in: .userDomainMask,
+    appropriateFor: nil,
+    create: true
+  )
+  let directory = applicationSupport.appendingPathComponent(
+    "LibraryDatabase",
+    isDirectory: true
+  )
+
+  try fileManager.createDirectory(
+    at: directory,
+    withIntermediateDirectories: true
+  )
+
+  var configuration = Realm.Configuration.defaultConfiguration
+  configuration.fileURL = directory.appendingPathComponent("library.realm")
+  configuration.objectTypes = [Author.self, Book.self, BookNote.self]
+  return configuration
+}
+```
+
+개발·staging·운영 또는 로그인 사용자별로 파일을 나눈다면 이름만 다르게 하지 말고 **어떤 data가 어느 Realm에 속하는지** 정책을 문서화하세요. 로그아웃할 때 파일을 삭제할지, 오프라인 기록을 유지할지, 새 사용자가 이전 사용자의 파일을 열 수 없는지도 결정해야 합니다.
+
+App와 extension이 같은 Realm을 열어야 한다면 App Group container URL을 `fileURL`로 사용하고 두 target에 동일한 App Group entitlement를 설정할 수 있습니다. 이때 model version, Realm SDK version, encryption key 접근과 file protection 정책도 두 process에서 같아야 해요. 단순히 `.realm` 본 파일만 공유 folder로 복사하는 방식은 피합니다.
+
+## schema가 바뀌면 version을 올려요
+
+Realm 파일은 설치된 앱 version이 아니라 **마지막으로 적용된 schema version**을 기억합니다. configuration에 지정하지 않으면 version `0`이에요.
+
+```text
+앱 1.0: schemaVersion 1 ── title, progress, lastOpenedAt
+앱 1.1: schemaVersion 2 ── status 추가
+앱 2.0: schemaVersion 3 ── lastOpenedAt → updatedAt 이름 변경
+```
+
+```swift
+func makeMigratingConfiguration() -> Realm.Configuration {
+  var configuration = Realm.Configuration.defaultConfiguration
+  configuration.schemaVersion = 3
+  configuration.migrationBlock = { migration, oldSchemaVersion in
+    if oldSchemaVersion < 2 {
+      migration.enumerateObjects(ofType: Book.className()) {
+        _, newObject in
+        newObject?["status"] = ReadingStatus.unread.rawValue
+      }
+    }
+
+    if oldSchemaVersion < 3 {
+      migration.renameProperty(
+        onType: Book.className(),
+        from: "lastOpenedAt",
+        to: "updatedAt"
+      )
+    }
+  }
+  return configuration
+}
+```
+
+### migration block은 누적 경로여야 해요
+
+`oldSchemaVersion`이 바로 이전 version이라고 가정하면 오랫동안 update하지 않은 사용자가 실패합니다.
+
+```swift
+if oldSchemaVersion < 2 {
+  // v1 → v2에 필요한 변환
+}
+
+if oldSchemaVersion < 3 {
+  // v1 또는 v2 → v3에 필요한 변환
+}
+```
+
+각 조건을 독립적으로 두면 v1 사용자는 두 변환을 순서대로 받고 v2 사용자는 두 번째만 받습니다. `else if`나 서로 nested된 version 조건 때문에 중간 단계를 건너뛰지 않게 하세요.
+
+| schema 변경                        | version 증가 | migration logic                                   |
+| ---------------------------------- | ------------ | ------------------------------------------------- |
+| optional property 추가             | 필요         | 보통 자동, 기존 값은 `nil`                        |
+| property 제거                      | 필요         | schema에서 자동 제거 가능                         |
+| required property 추가             | 필요         | 기존 row의 초기값 지정                            |
+| property 이름 변경                 | 필요         | `renameProperty` 사용                             |
+| type 변경·field 합치기             | 필요         | old/new object를 enumerate해 변환                 |
+| `Object`를 `EmbeddedObject`로 변경 | 필요         | 각 embedded object가 정확히 한 부모를 갖도록 정리 |
+
+:::danger 운영 앱에서 `deleteRealmIfMigrationNeeded`를 켜지 않아요
+이 option은 schema mismatch가 생기면 사용자 데이터를 삭제하고 새 파일을 만듭니다. disposable fixture나 개발 build에는 편리할 수 있지만 운영 migration을 대신할 수 없어요.
+:::
+
+## migration을 fixture로 검증해요
+
+새 model로 빈 Realm을 여는 test만으로는 기존 사용자 update를 검증할 수 없습니다.
+
+1. 실제 과거 schema version별 작은 Realm fixture를 준비해요.
+2. 현재 migration configuration으로 fixture의 복사본을 열어요.
+3. row 수, primary key, 관계와 변환된 값을 검증해요.
+4. 가장 오래 지원하는 version에서 최신 version으로 바로 이동하는 test를 넣어요.
+5. migration 실패 시 원본을 보존하고 사용자가 취할 복구 경로를 정해요.
+
+출시 전에는 production과 같은 file protection, encryption key와 data volume에서도 시간을 측정하세요. migration은 보통 Realm을 처음 여는 시점에 실행되므로 main thread에서 무거운 변환을 시작하면 첫 화면이 멈출 수 있습니다.
+
+## test에서는 configuration을 주입해요
+
+```swift
+import RealmSwift
+import XCTest
+
+func makeTestConfiguration(
+  identifier: String = UUID().uuidString
+) -> Realm.Configuration {
+  var configuration = Realm.Configuration(
+    inMemoryIdentifier: identifier
+  )
+  configuration.objectTypes = [Author.self, Book.self, BookNote.self]
+  return configuration
+}
+
+final class LibraryStoreTests: XCTestCase {
+  func testCreateBook() throws {
+    let configuration = makeTestConfiguration()
+    let store = try LibraryStore(configuration: configuration)
+
+    let id = try store.createBook(
+      title: "Realm Testing",
+      authorName: "Swift-KR"
+    )
+
+    let realm = try Realm(configuration: configuration)
+    XCTAssertNotNil(
+      realm.object(ofType: Book.self, forPrimaryKey: id)
+    )
+  }
+}
+```
+
+in-memory Realm은 같은 identifier를 가진 instance가 하나라도 살아 있는 동안 data를 유지하고, 모두 해제되면 사라집니다. 병렬 test가 같은 global default identifier를 공유하지 않도록 test마다 고유 configuration을 만들고 명시적으로 주입하세요.
+
+## 파일 암호화는 64-byte key로 시작해요
+
+Realm 공식 가이드는 64-byte key를 configuration에 전달해 file을 AES-256으로 암호화하고 무결성을 확인한다고 설명합니다.
+
+```swift
+import RealmSwift
+import Security
+
+func generateRealmEncryptionKey() throws -> Data {
+  var key = Data(count: 64)
+  let status = key.withUnsafeMutableBytes { buffer in
+    guard let baseAddress = buffer.baseAddress else {
+      return errSecParam
+    }
+    return SecRandomCopyBytes(
+      kSecRandomDefault,
+      buffer.count,
+      baseAddress
+    )
+  }
+
+  guard status == errSecSuccess else {
+    throw RealmKeyError.security(status)
+  }
+  return key
+}
+
+enum RealmKeyError: Error {
+  case security(OSStatus)
+  case invalidKeyData
+}
+```
+
+이 key를 `UserDefaults`, plist, source code에 저장하면 앱 bundle이나 container를 읽은 공격자에게 같이 노출됩니다. Keychain에 저장하고 매번 같은 key를 꺼내야 해요.
+
+```swift
+struct RealmEncryptionKeyStore {
+  private let service = "io.swift-kr.realm"
+  private let account = "library-database-key"
+
+  func loadOrCreate() throws -> Data {
+    let readQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne
+    ]
+
+    var item: CFTypeRef?
+    let readStatus = SecItemCopyMatching(
+      readQuery as CFDictionary,
+      &item
+    )
+
+    if readStatus == errSecSuccess {
+      guard let key = item as? Data, key.count == 64 else {
+        throw RealmKeyError.invalidKeyData
+      }
+      return key
+    }
+
+    guard readStatus == errSecItemNotFound else {
+      throw RealmKeyError.security(readStatus)
+    }
+
+    let key = try generateRealmEncryptionKey()
+    let insertQuery: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account,
+      kSecAttrAccessible as String:
+        kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+      kSecValueData as String: key
+    ]
+    let insertStatus = SecItemAdd(insertQuery as CFDictionary, nil)
+
+    guard insertStatus == errSecSuccess else {
+      throw RealmKeyError.security(insertStatus)
+    }
+    return key
+  }
+}
+```
+
+```swift
+let key = try RealmEncryptionKeyStore().loadOrCreate()
+var configuration = makeMigratingConfiguration()
+configuration.encryptionKey = key
+let realm = try Realm(configuration: configuration)
+```
+
+### 암호화에서 놓치기 쉬운 조건
+
+- 처음부터 encrypted file로 만들어야 해요. 기존 평문 Realm에 key만 추가하면 열리지 않습니다.
+- 이후 open마다 정확히 같은 64-byte key가 필요해요.
+- key를 잃으면 Realm file을 복구할 수 없으므로 재로그인·server 복원 가능 여부에 맞춘 정책이 필요해요.
+- 암호화는 device가 unlock된 뒤 memory에 있는 data, screenshot, log, network 전송까지 자동 보호하지 않아요.
+- App Group에서 extension도 열면 두 target의 Keychain access group과 accessibility를 함께 설계해야 해요.
+- Realm 공식 가이드는 encrypted Realm의 read·write가 평문보다 느릴 수 있다고 안내하므로 실제 기기에서 측정해요.
+
+## file protection과 background 실행을 함께 봐요
+
+iOS Data Protection 때문에 device가 잠긴 동안 Realm file 접근이 실패할 수 있습니다. background task나 extension이 첫 unlock 전에도 data를 읽어야 하는지 먼저 판단하세요.
+
+보호 수준을 낮추기 전에 다음 순서로 검토합니다.
+
+1. 잠긴 동안 정말 Realm 접근이 필요한가요?
+2. 작업을 unlock 이후로 미룰 수 있나요?
+3. 최소한의 별도 파일·queue만 다른 보호 수준으로 둘 수 있나요?
+4. Realm encryption과 Keychain accessibility가 같은 시점에 key 접근을 허용하나요?
+
+Realm은 보조 파일을 만들 수 있으므로 protection attribute를 변경해야 한다면 본 파일 하나가 아니라 공식 가이드처럼 parent directory의 정책을 검토해요.
+
+## Swift Concurrency에서는 Realm을 actor에 격리해요
+
+Realm Swift `v20`의 Swift 6 API는 현재 actor를 추론하는 `Realm.open(configuration:)`을 제공합니다. 하나의 actor가 Realm과 write를 소유하면 임의의 queue 전환보다 경계가 명확해져요.
+
+```swift
+import RealmSwift
+
+struct BookSummary: Sendable {
+  let id: String
+  let title: String
+  let progress: Int
+}
+
+actor LibraryRealmActor {
+  private let realm: Realm
+
+  init(
+    configuration: Realm.Configuration = .defaultConfiguration
+  ) async throws {
+    realm = try await Realm.open(configuration: configuration)
+  }
+
+  func markAsFinished(id: String) async throws {
+    guard let objectID = try? ObjectId(string: id),
+          let book = realm.object(
+            ofType: Book.self,
+            forPrimaryKey: objectID
+          ) else {
+      return
+    }
+
+    try await realm.asyncWrite {
+      book.progress = 100
+      book.status = .finished
+      book.updatedAt = Date()
+    }
+  }
+
+  func readingBookSummaries() -> [BookSummary] {
+    realm.objects(Book.self)
+      .where { $0.status == .reading }
+      .map {
+        BookSummary(
+          id: $0.id.stringValue,
+          title: $0.title,
+          progress: $0.progress
+        )
+      }
+  }
+}
+```
+
+`asyncWrite`는 write lock을 기다리는 동안 현재 task를 suspend하고 disk I/O를 background worker에서 처리합니다. 그렇다고 복잡한 closure 계산이 자동으로 무료가 되거나 같은 Realm file에 여러 write가 동시에 commit되는 것은 아니에요. transaction은 여전히 serialize됩니다.
+
+### actor 경계로 managed object를 직접 넘기지 않아요
+
+```text
+MainActor의 Book ──X──> Background actor
+
+대신
+Book.id 문자열 ───────> 목적지 Realm에서 다시 query
+BookSummary DTO ──────> 화면에 필요한 값만 전달
+ThreadSafeReference ─> 필요한 특수 상황에서 생성·resolve
+```
+
+Realm object는 일반적인 `Sendable` 값이 아닙니다. 기본 키를 전달해 목적지 actor가 자기 Realm에서 다시 찾거나 immutable `Sendable` DTO를 만들어 전달하세요. `ThreadSafeReference`도 제공되지만 version을 유지하는 비용과 resolve 생명주기를 이해해야 하므로 app-wide 전달 모델의 기본값으로 쓰지는 않습니다.
+
+## 운영 체크리스트
+
+- [ ] Realm을 열기 전에 한 곳에서 configuration을 완성하나요?
+- [ ] 환경·사용자·App Group별 file identity가 명확한가요?
+- [ ] 가장 오래 지원하는 schema fixture에서 최신 migration을 검증했나요?
+- [ ] 운영 build에서 `deleteRealmIfMigrationNeeded`가 꺼져 있나요?
+- [ ] encryption key를 64-byte secure random으로 만들고 Keychain에 저장하나요?
+- [ ] key 상실, device 잠금과 backup·복구 정책이 있나요?
+- [ ] 병렬 test마다 고유한 in-memory configuration을 주입하나요?
+- [ ] Realm과 managed object가 한 actor에 격리되고 경계에는 ID·DTO를 사용하나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### schema version과 앱 version은 같은가요?
+
+아니요. 앱 version은 배포 binary의 release를 나타내고 Realm schema version은 파일 구조의 migration 단계를 나타냅니다. UI만 바뀐 앱 release에서는 schema version을 올릴 필요가 없고, 한 앱 release에서 schema가 바뀌면 더 높은 version과 필요한 migration을 제공해야 합니다.
+
+### `asyncWrite`를 쓰면 모든 Realm 동시성 문제가 해결되나요?
+
+아니요. write lock을 기다리는 동안 task를 block하지 않는 장점은 있지만 managed object의 actor 격리, notification 수명, transaction 크기와 단일 파일의 serialized write 규칙은 그대로 고려해야 합니다.
+
+## 참고 자료
+
+- [Realm 구성과 파일 열기 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/realm-files/configure-and-open-a-realm.md)
+- [Realm schema 변경 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/model-data/change-an-object-model.md)
+- [Realm 암호화 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/realm-files/encrypt-a-realm.md)
+- [Realm test·debug 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/test-and-debug.md)
+- [Realm Swift Concurrency 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/use-realm-with-actors.md)
+- [`Realm.open`과 `asyncWrite` API source](https://github.com/realm/realm-swift/blob/community/RealmSwift/Realm.swift)
+- [Apple Keychain Services](https://developer.apple.com/documentation/security/keychain-services)
+- [Apple Data Protection](https://support.apple.com/guide/security/data-protection-overview-secf6276da8a/web)

--- a/docs/guide/realm-swift/index.md
+++ b/docs/guide/realm-swift/index.md
@@ -1,0 +1,197 @@
+---
+title: Swift로 시작하는 Realm 데이터베이스
+description: Realm Swift의 현재 지원 범위를 확인하고 설치, 객체 모델, 로컬 파일, 쓰기 트랜잭션과 첫 CRUD까지 단계적으로 시작합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Swift로 시작하는 Realm 데이터베이스
+
+> 면접용 한 줄 요약: **Realm Swift는 Swift 객체 모델을 기기 안의 Realm 파일에 직접 저장하고, 쿼리 결과와 객체의 변경을 실시간으로 관찰할 수 있는 오픈 소스 객체 데이터베이스입니다.**
+
+Realm은 서버 데이터베이스의 Swift 클라이언트가 아니라 앱 프로세스 안에서 실행되는 **로컬 데이터베이스**예요. `Object`를 상속한 모델과 `@Persisted` 속성을 스키마로 사용하고, `Realm` 인스턴스가 파일·트랜잭션·쿼리의 경계가 됩니다.
+
+```text
+SwiftUI / UIKit
+      │
+      ├─ Object + @Persisted ── 객체 스키마
+      ├─ Results + observe ──── live query와 변경 알림
+      └─ Realm.write ────────── 원자적인 쓰기 트랜잭션
+                    │
+                    ▼
+              로컬 .realm 파일
+```
+
+## 가장 먼저 현재 지원 범위를 확인해요
+
+:::warning Realm Swift v20은 로컬 데이터베이스 전용이에요
+Realm Swift [`v20.0.0`](https://github.com/realm/realm-swift/releases/tag/v20.0.0)부터 Atlas App Services와 Atlas Device Sync API가 모두 제거됐습니다. MongoDB의 [Atlas Device SDK 종료 안내](https://www.mongodb.com/docs/atlas/device-sdks/deprecation/)에 따르면 Device Sync는 2025년 9월 30일 종료됐지만, 기기 안에서 동작하는 Realm 데이터베이스는 오픈 소스 프로젝트로 남았습니다.
+
+이 섹션의 코드는 현재 `community` 브랜치와 `v20` 로컬 API를 기준으로 합니다. `App`, `Credentials`, `User`, `flexibleSyncConfiguration`을 사용하는 예전 Sync 코드는 현재 Realm 시작 예제로 사용하지 않아요.
+:::
+
+Realm Swift 저장소의 기본 브랜치는 현재 [`community`](https://github.com/realm/realm-swift/tree/community)입니다. [`v20.0.4` 릴리스](https://github.com/realm/realm-swift/releases/tag/v20.0.4)는 Realm이 더 이상 MongoDB가 공식 배포하는 제품이 아니며 사전 빌드 binary도 code signing되지 않는다고 알립니다. 새 제품에 도입할 때는 기능만 보지 말고 최근 release, 보안 수정, 지원 Xcode 범위와 팀의 유지보수 계획도 함께 평가하세요.
+
+## 먼저 알아둘 용어
+
+| 용어               | 의미                                                                               |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| Realm              | `Realm.Configuration`에 따라 하나의 로컬 Realm 파일을 여는 접근 객체예요.          |
+| Realm file         | 객체와 스키마가 저장되는 `.realm` 파일이에요. 보조 파일도 함께 생성될 수 있습니다. |
+| Object             | Realm이 관리할 수 있는 참조 타입 모델의 기반 클래스예요.                           |
+| `@Persisted`       | 속성을 Realm 스키마에 포함시키는 property wrapper예요.                             |
+| managed object     | Realm에 추가되어 특정 Realm·executor의 생명주기에 연결된 객체예요.                 |
+| unmanaged object   | 아직 Realm에 추가하지 않은 일반 Swift 객체 상태예요.                               |
+| write transaction  | 여러 변경을 전부 반영하거나 전부 취소하는 원자적 쓰기 경계예요.                    |
+| `Results<Element>` | 쿼리 조건을 표현하고 Realm 변경에 따라 자동 갱신되는 collection이에요.             |
+| notification token | 변경 관찰의 수명을 나타내며 유지하지 않으면 관찰이 중단되는 token이에요.           |
+| schema version     | 앱의 객체 모델 구조가 몇 번째 상태인지 나타내는 증가하는 정수예요.                 |
+
+## 다른 저장 방식과 무엇이 다른가요?
+
+| 선택지         | 잘 맞는 데이터                                     | 특징                                                            |
+| -------------- | -------------------------------------------------- | --------------------------------------------------------------- |
+| `UserDefaults` | 테마, 정렬 방식 같은 작은 설정값                   | key-value 설정 저장소이며 대량 객체 검색용이 아니에요.          |
+| 파일·`Codable` | 문서, export 파일, 한 덩어리 JSON                  | 형식과 읽기·쓰기 시점을 직접 관리해요.                          |
+| SwiftData      | Apple 플랫폼의 객체 그래프와 SwiftUI 앱            | 시스템 프레임워크이며 iOS 17 이상을 중심으로 설계돼요.          |
+| Core Data      | 복잡한 객체 그래프와 Apple 생태계의 오랜 운영 자산 | 변경 추적·migration·persistent store를 세밀하게 제어해요.       |
+| SQLite         | SQL과 table·index를 직접 통제할 관계형 데이터      | 가장 낮은 계층의 제어가 가능하지만 mapping 코드가 늘 수 있어요. |
+| Realm Swift    | 객체 모델, 오프라인 저장, live query가 중요한 앱   | 외부 package이며 객체 API와 변경 알림을 기본 제공해요.          |
+
+Realm은 “서버 동기화가 필요해서”가 아니라 **로컬 객체 저장과 반응형 변경 관찰이 요구 사항에 맞을 때** 선택합니다. Apple 전용 신제품이라면 SwiftData도 함께 prototype하고, 장기 유지보수와 dependency 위험까지 비교하세요.
+
+## 1단계: Swift Package Manager로 설치해요
+
+Xcode에서 **File > Add Package Dependencies**를 열고 공식 저장소 URL을 입력합니다.
+
+```text
+https://github.com/realm/realm-swift
+```
+
+Swift 앱 target에는 `RealmSwift` product만 연결하세요. `Realm`은 Objective-C API product이므로 Swift target에서 두 product를 동시에 직접 연결할 필요가 없습니다.
+
+```swift
+import RealmSwift
+```
+
+새 프로젝트라면 `v20` release 범위를 선택하고, 선택한 tag의 Xcode·OS 호환 범위는 [Realm Swift Releases](https://github.com/realm/realm-swift/releases)와 `Package.swift`에서 확인합니다. 기존 Sync 앱은 version을 올리기 전에 [Atlas Device Sync 종료와 전환](/guide/realm-swift/atlas-device-sync-eol)을 먼저 읽어야 해요.
+
+## 2단계: 첫 객체 모델을 정의해요
+
+```swift
+import Foundation
+import RealmSwift
+
+enum ReadingStatus: String, PersistableEnum {
+  case unread
+  case reading
+  case finished
+}
+
+final class Book: Object {
+  @Persisted(primaryKey: true) var id: ObjectId
+  @Persisted(indexed: true) var title = ""
+  @Persisted var authorName = ""
+  @Persisted var status = ReadingStatus.unread
+  @Persisted var progress = 0
+  @Persisted var updatedAt = Date()
+}
+```
+
+- 클래스 이름은 Realm table에 대응합니다.
+- `@Persisted`를 붙인 속성만 파일에 저장돼요.
+- 기본 키는 객체를 빠르게 찾고 upsert하는 식별자이며 한 모델에 하나만 둘 수 있습니다.
+- index는 동등 비교가 잦은 속도의 읽기를 개선하지만 쓰기 비용과 파일 크기를 늘려요.
+- `PersistableEnum`은 Realm이 지원하는 raw type을 가진 enum을 저장하게 해요.
+
+## 3단계: Realm을 열고 한 번의 흐름을 실행해요
+
+```swift
+import RealmSwift
+
+func runFirstRealmExample() throws {
+  let realm = try Realm()
+
+  let book = Book()
+  book.title = "The Swift Programming Language"
+  book.authorName = "Apple"
+
+  try realm.write {
+    realm.add(book)
+  }
+
+  let readingBooks = realm.objects(Book.self).where {
+    $0.status == .reading
+  }
+
+  try realm.write {
+    book.status = .reading
+    book.progress = 20
+    book.updatedAt = Date()
+  }
+
+  print("읽는 중인 책: \(readingBooks.count)권")
+}
+```
+
+여기서 중요한 순서는 다음과 같아요.
+
+```text
+unmanaged Book 생성
+      │ realm.add(book)
+      ▼
+managed Book ──> write 안에서만 변경 ──> Results가 자동 갱신
+```
+
+`book`은 `realm.add(book)` 이후 managed object가 됩니다. 그 뒤 persisted 속성을 `write` 밖에서 바꾸면 예외가 발생해요. 반대로 `Results`는 한 번 복사한 배열이 아니라 Realm의 현재 상태를 보여 주는 live collection이라, `book.status`를 바꾼 뒤 `readingBooks.count`도 갱신됩니다.
+
+:::tip 실제 앱에서는 `try!`를 기본값으로 두지 않아요
+공식 quick start는 흐름을 짧게 보여 주려고 `try!`를 사용하지만, 파일 열기·migration·write는 실패할 수 있습니다. 앱 경계에서는 `throws`, `do-catch`, 오류 화면과 복구 정책을 사용하세요.
+:::
+
+## Realm 파일은 어디에 있나요?
+
+기본 Realm의 위치는 configuration에서 확인합니다.
+
+```swift
+let configuration = Realm.Configuration.defaultConfiguration
+print(configuration.fileURL?.path ?? "in-memory Realm")
+```
+
+경로 문자열을 코드에 고정하지 마세요. Realm은 `.realm` 본 파일 외에도 lock과 관리용 보조 파일을 만들 수 있으므로 backup·삭제·App Group 공유를 설계할 때는 파일 하나만 임의로 이동하지 않습니다. 파일 위치, 암호화와 migration은 [구성·마이그레이션·보안](/guide/realm-swift/configuration-migration-and-security)에서 자세히 다룹니다.
+
+## 다섯 페이지를 이 순서로 읽어요
+
+1. 이 페이지에서 Realm의 현재 범위와 첫 저장을 확인해요.
+2. [데이터 모델과 CRUD](/guide/realm-swift/models-and-crud)에서 관계, managed 객체와 transaction을 연결해요.
+3. [쿼리와 변경 관찰](/guide/realm-swift/queries-and-observation)에서 live `Results`, UIKit batch update와 SwiftUI wrapper를 배워요.
+4. [구성·마이그레이션·보안](/guide/realm-swift/configuration-migration-and-security)에서 파일, schema version, 암호화, 테스트와 actor 경계를 운영 수준으로 정리해요.
+5. [Atlas Device Sync 종료와 전환](/guide/realm-swift/atlas-device-sync-eol)에서 예전 MongoDB SDK 문서와 현재 로컬 Realm을 구분해요.
+
+## 도입 전 체크리스트
+
+- [ ] Realm을 로컬 데이터베이스로 선택한 이유를 SwiftData·Core Data와 비교했나요?
+- [ ] `v20`에는 Atlas App Services와 Device Sync가 없다는 점을 확인했나요?
+- [ ] 지원 Xcode·OS와 최근 release·보안 유지보수 상태를 확인했나요?
+- [ ] Realm 객체가 UI와 domain 전체로 무제한 퍼지지 않도록 계층 경계를 정했나요?
+- [ ] schema migration과 암호화 key 복구 정책을 출시 전에 테스트했나요?
+- [ ] listener와 Realm 인스턴스의 수명을 화면·feature 수명에 맞췄나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Realm은 ORM인가요?
+
+Realm은 SQLite 위에 얹는 ORM이 아니라 자체 storage engine과 파일 형식을 가진 객체 데이터베이스입니다. Swift 객체처럼 보이는 API를 제공하지만 managed object는 일반 값 타입이 아니라 Realm의 현재 데이터와 연결된 live proxy에 가깝습니다.
+
+### Realm을 쓰면 서버와 자동으로 동기화되나요?
+
+아니요. 현재 Realm Swift `v20`은 로컬 데이터베이스 기능만 제공합니다. 과거의 Atlas Device Sync는 종료됐고 API도 제거됐으므로, 서버 동기화가 필요하면 별도의 backend·인증·충돌 해결 방식을 설계해야 합니다.
+
+## 참고 자료
+
+- [Realm Swift 공식 저장소](https://github.com/realm/realm-swift)
+- [Realm Swift community 브랜치](https://github.com/realm/realm-swift/tree/community)
+- [Realm Swift Quick Start](https://github.com/realm/realm-swift/blob/community/docs/guides/quick-start.md)
+- [Realm Swift Releases](https://github.com/realm/realm-swift/releases)
+- [MongoDB Atlas Device SDK for Swift 문서](https://www.mongodb.com/ko-kr/docs/atlas/device-sdks/sdk/swift/)
+- [MongoDB Atlas Device SDK 종료 안내](https://www.mongodb.com/docs/atlas/device-sdks/deprecation/)

--- a/docs/guide/realm-swift/models-and-crud.md
+++ b/docs/guide/realm-swift/models-and-crud.md
@@ -1,0 +1,335 @@
+---
+title: Realm 데이터 모델과 CRUD
+description: Object와 EmbeddedObject, Persisted 속성, 관계와 collection을 모델링하고 managed 객체의 생명주기와 쓰기 트랜잭션을 이해해 CRUD를 구현합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Realm 데이터 모델과 CRUD
+
+> 면접용 한 줄 요약: **Realm 모델은 `Object`와 `@Persisted`로 스키마를 선언하며, Realm에 추가된 managed 객체의 변경은 반드시 하나의 원자적 `write` transaction 안에서 수행합니다.**
+
+## 먼저 모델링 용어를 구분해요
+
+| 용어                 | 의미                                                                         |
+| -------------------- | ---------------------------------------------------------------------------- |
+| schema               | Realm 파일에 어떤 object type과 property가 존재하는지 정의한 구조예요.       |
+| primary key          | 같은 object type 안에서 각 객체를 유일하게 식별하는 값이에요.                |
+| to-one relationship  | 한 객체가 다른 객체 하나를 참조하는 optional property예요.                   |
+| to-many relationship | `List`, `MutableSet`, `Map`으로 여러 값을 연결하는 관계예요.                 |
+| embedded object      | 부모에 소유되어 독립적으로 존재할 수 없는 중첩 객체예요.                     |
+| backlink             | 다른 객체가 자신을 가리키는 관계를 역방향으로 조회하는 `LinkingObjects`예요. |
+| managed object       | Realm에 들어가 파일의 row와 연결된 객체예요.                                 |
+| invalidated object   | 삭제됐거나 Realm이 무효화되어 더 이상 안전하게 읽을 수 없는 객체예요.        |
+
+## 완성할 독서 기록 모델을 먼저 봐요
+
+```swift
+import Foundation
+import RealmSwift
+
+enum ReadingStatus: String, PersistableEnum {
+  case unread
+  case reading
+  case finished
+}
+
+final class BookNote: EmbeddedObject {
+  @Persisted var text = ""
+  @Persisted var createdAt = Date()
+}
+
+final class Author: Object {
+  @Persisted(primaryKey: true) var id: ObjectId
+  @Persisted(indexed: true) var name = ""
+  @Persisted(originProperty: "author") var books: LinkingObjects<Book>
+}
+
+final class Book: Object {
+  @Persisted(primaryKey: true) var id: ObjectId
+  @Persisted(indexed: true) var title = ""
+  @Persisted var status = ReadingStatus.unread
+  @Persisted var progress = 0
+  @Persisted var author: Author?
+  @Persisted var tags = List<String>()
+  @Persisted var notes = List<BookNote>()
+  @Persisted var updatedAt = Date()
+
+  var progressText: String {
+    "\(progress)%"
+  }
+}
+```
+
+이 모델에는 관계가 세 종류 있어요.
+
+```text
+Author <──────────── Book
+   ▲     backlink      │ author: Author?       to-one
+   │                   │
+   └─ books            ├─ tags: List<String>   primitive collection
+                       └─ notes: List<BookNote> owned embedded objects
+```
+
+`progressText`에는 `@Persisted`가 없으므로 계산할 때만 존재하고 파일에는 저장되지 않습니다. 모델에서 하나라도 `@Persisted` 선언 방식을 사용하면 wrapper가 없는 속성은 자동으로 스키마에서 제외돼요.
+
+## `Object`와 `EmbeddedObject`는 수명이 달라요
+
+`Author`와 `Book`은 독립적으로 query·삭제할 수 있는 `Object`입니다. `BookNote`는 특정 `Book` 안에 소유되는 `EmbeddedObject`예요.
+
+| 질문                                      | `Object` | `EmbeddedObject`              |
+| ----------------------------------------- | -------- | ----------------------------- |
+| 독립 query 대상인가요?                    | 예       | 아니요. 부모를 통해 접근해요. |
+| primary key를 가질 수 있나요?             | 예       | 아니요.                       |
+| 여러 부모가 같은 객체를 공유할 수 있나요? | 예       | 아니요. 한 부모에만 속해요.   |
+| 부모에서 관계를 제거하면 자동 삭제되나요? | 아니요   | 예                            |
+
+주소, 주문 항목의 당시 snapshot, 책에 완전히 소유된 메모처럼 부모 없이 의미가 없는 값은 embedded object가 잘 맞습니다. 여러 책이 공유하는 저자처럼 독립 식별과 재사용이 필요하면 일반 `Object`로 모델링하세요.
+
+## property의 저장 의미를 의도적으로 정해요
+
+### optional과 기본값
+
+```swift
+final class Profile: Object {
+  @Persisted(primaryKey: true) var id: ObjectId
+  @Persisted var nickname = "이름 없음"  // required String
+  @Persisted var biography: String?       // optional String
+  @Persisted var age = 0                  // required Int
+  @Persisted var height: Double?          // optional Double
+}
+```
+
+`""`와 `nil`은 의미가 달라요. 값이 아직 없음을 표현해야 하면 optional을 사용하고, business상 반드시 존재해야 하면 의미 있는 기본값이나 생성 경로의 검증을 마련합니다. Realm schema의 required 여부만으로 domain 유효성 검사가 모두 해결되지는 않아요.
+
+### primary key
+
+```swift
+@Persisted(primaryKey: true) var id: ObjectId
+```
+
+- object type마다 하나만 선언할 수 있어요.
+- 같은 Realm의 같은 type 안에서 값이 유일해야 해요.
+- managed 객체가 된 뒤 primary key를 직접 변경할 수 없어요.
+- 값 자체를 바꾸려면 기존 객체를 삭제하고 새 객체를 만들어야 해요.
+
+서버 ID가 없다면 `ObjectId.generate()` 또는 기본 `ObjectId` 값을 사용할 수 있습니다. 임의의 제목이나 배열 index처럼 바뀌거나 충돌할 값을 식별자로 쓰지 마세요.
+
+### index
+
+```swift
+@Persisted(indexed: true) var title = ""
+```
+
+index는 equality와 `IN` query를 빠르게 할 수 있지만 모든 쓰기에서 index도 갱신하고 파일 공간을 사용합니다. “검색할 것 같다”는 추측으로 모든 field에 붙이지 말고 실제 query와 Instruments 측정을 근거로 추가하세요. Realm은 string, integer, boolean, `Date`, `UUID`, `ObjectId`, `AnyRealmValue` 등에 index를 지원합니다.
+
+## collection의 의미도 서로 달라요
+
+| Realm collection          | 성질                                                                  | 예시                        |
+| ------------------------- | --------------------------------------------------------------------- | --------------------------- |
+| `List<Element>`           | 순서와 중복을 허용해요.                                               | 독서 메모, 직접 정렬한 항목 |
+| `MutableSet<Element>`     | 순서가 없고 중복을 허용하지 않아요.                                   | 고유한 category 집합        |
+| `Map<Value>`              | `String` key로 value를 찾는 dictionary 형태예요.                      | locale별 제목               |
+| `LinkingObjects<Element>` | 다른 object의 관계를 역방향으로 보여 주는 read-only collection이에요. | 저자의 모든 책              |
+
+Realm collection 자체도 managed 상태에서는 write 안에서만 수정합니다.
+
+```swift
+try realm.write {
+  book.tags.append("Swift")
+  book.tags.append(objectsIn: ["iOS", "Database"])
+
+  let note = BookNote()
+  note.text = "write transaction을 다시 읽기"
+  book.notes.append(note)
+}
+```
+
+## unmanaged에서 managed로 바뀌는 순간을 이해해요
+
+```swift
+let book = Book()
+book.title = "Realm Guide"       // 아직 unmanaged: 자유롭게 변경
+print(book.realm == nil)          // true
+
+try realm.write {
+  realm.add(book)
+}
+
+print(book.realm === realm)       // true
+
+try realm.write {
+  book.progress = 30              // managed: write 안에서 변경
+}
+```
+
+같은 Swift 변수지만 `realm.add` 전후의 규칙이 다릅니다.
+
+| 상태      | persisted 속성 변경                | 다른 executor로 전달         | 삭제 후 접근                |
+| --------- | ---------------------------------- | ---------------------------- | --------------------------- |
+| unmanaged | 일반 객체처럼 가능                 | 직접 설계한 값이라면 가능    | 해당 없음                   |
+| managed   | 같은 Realm의 `write` 안에서만 가능 | 객체 그대로 전달하지 않아요. | `isInvalidated`를 확인해요. |
+
+managed object는 Realm 파일의 현재 version을 보는 live reference입니다. actor나 queue 경계를 넘길 때는 primary key 또는 별도 `Sendable` DTO를 전달하고 목적지의 Realm에서 다시 query하는 방식을 우선하세요.
+
+## 쓰기 트랜잭션은 원자적인 변경 단위예요
+
+```swift
+enum ReadingError: Error {
+  case invalidProgress
+}
+
+func updateProgress(
+  of book: Book,
+  to progress: Int,
+  in realm: Realm
+) throws {
+  guard 0...100 ~= progress else {
+    throw ReadingError.invalidProgress
+  }
+
+  try realm.write {
+    book.progress = progress
+    book.status = progress == 100 ? .finished : .reading
+    book.updatedAt = Date()
+  }
+}
+```
+
+closure가 성공하면 세 속성이 함께 commit됩니다. closure가 throw하면 transaction은 취소되고 중간 변경을 남기지 않아요. 같은 Realm file에는 한 번에 하나의 write transaction만 열 수 있고 nested write도 허용되지 않습니다.
+
+transaction을 너무 잘게 쪼개면 lock·commit 비용이 늘고, 너무 크게 묶으면 다른 쓰기가 오래 기다립니다. 사용자가 인식하는 하나의 business operation을 기본 경계로 삼고, 대량 import는 batch 크기를 측정하세요.
+
+## CRUD를 하나의 store로 모아봐요
+
+```swift
+import RealmSwift
+
+final class LibraryStore {
+  private let realm: Realm
+
+  init(configuration: Realm.Configuration = .defaultConfiguration) throws {
+    realm = try Realm(configuration: configuration)
+  }
+
+  @discardableResult
+  func createBook(title: String, authorName: String) throws -> ObjectId {
+    let author = Author()
+    author.name = authorName
+
+    let book = Book()
+    book.title = title
+    book.author = author
+
+    try realm.write {
+      realm.add(book)
+    }
+
+    return book.id
+  }
+
+  func books(status: ReadingStatus? = nil) -> Results<Book> {
+    let allBooks = realm.objects(Book.self)
+    guard let status else {
+      return allBooks.sorted(byKeyPath: "updatedAt", ascending: false)
+    }
+
+    return allBooks
+      .where { $0.status == status }
+      .sorted(byKeyPath: "updatedAt", ascending: false)
+  }
+
+  func updateProgress(id: ObjectId, progress: Int) throws {
+    guard let book = realm.object(ofType: Book.self, forPrimaryKey: id) else {
+      return
+    }
+
+    try realm.write {
+      book.progress = min(max(progress, 0), 100)
+      book.status = book.progress == 100 ? .finished : .reading
+      book.updatedAt = Date()
+    }
+  }
+
+  func upsert(_ draft: Book) throws {
+    try realm.write {
+      realm.add(draft, update: .modified)
+    }
+  }
+
+  func deleteBook(id: ObjectId) throws {
+    guard let book = realm.object(ofType: Book.self, forPrimaryKey: id) else {
+      return
+    }
+
+    try realm.write {
+      realm.delete(book)
+    }
+  }
+}
+```
+
+`upsert`의 `.modified`는 같은 primary key 객체가 있으면 전달된 속성을 갱신하고, 없으면 추가합니다. API 응답 전체를 무조건 upsert하기 전에 서버에 없는 local-only field가 덮어써지는지 mapping 정책을 확인하세요.
+
+### delete는 기본적으로 cascade delete가 아니에요
+
+`Book`을 삭제하면 그 안의 `BookNote` embedded objects는 함께 삭제됩니다. 그러나 연결된 일반 `Author`는 남아요.
+
+```swift
+try realm.write {
+  let author = book.author
+  realm.delete(book)
+
+  if let author, author.books.isEmpty {
+    realm.delete(author)
+  }
+}
+```
+
+“참조가 없어지면 저자도 지운다”는 것은 Realm의 기본 규칙이 아니라 앱의 business rule입니다. 어느 관계가 소유이고 어느 관계가 공유인지 모델 단계에서 명시하세요.
+
+### 객체가 삭제되면 reference도 무효화돼요
+
+```swift
+let selectedBook = realm.object(ofType: Book.self, forPrimaryKey: id)
+
+try realm.write {
+  if let selectedBook {
+    realm.delete(selectedBook)
+  }
+}
+
+if selectedBook?.isInvalidated == true {
+  print("이미 삭제된 객체입니다.")
+}
+```
+
+화면이 managed object를 오래 보관한다면 다른 화면·notification에서 삭제될 수 있음을 고려해야 합니다. 화면 식별자는 primary key로 유지하고 필요할 때 query하거나, 관찰 wrapper가 삭제 상태를 처리하도록 설계하세요.
+
+## 모델링과 CRUD 체크리스트
+
+- [ ] 독립 수명이 필요한 모델과 부모에 소유되는 embedded model을 구분했나요?
+- [ ] to-one relationship을 optional로 선언했나요?
+- [ ] primary key가 안정적이고 유일하며 변경되지 않나요?
+- [ ] index를 실제 equality query가 많은 속성에만 추가했나요?
+- [ ] managed object의 모든 변경을 같은 Realm의 `write`로 묶었나요?
+- [ ] 일반 object 관계의 delete policy를 business rule로 구현했나요?
+- [ ] Realm 객체 대신 ID·DTO가 계층과 actor 경계를 넘도록 설계했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### managed object와 일반 Swift class는 어떻게 다른가요?
+
+managed object는 Realm file의 row와 연결된 live object입니다. Realm이 관리하는 persisted 속성은 transaction과 executor 규칙을 따르고, 다른 write가 반영되면 같은 reference의 값도 갱신될 수 있습니다. 일반 class처럼 임의의 thread에서 자유롭게 수정하는 객체가 아니에요.
+
+### `Object`와 `EmbeddedObject` 중 무엇을 선택하나요?
+
+독립 query·식별·여러 부모의 공유가 필요하면 `Object`, 부모 없이 존재할 수 없고 부모와 함께 삭제돼야 하면 `EmbeddedObject`를 선택합니다. embedded object는 primary key를 가질 수 없고 한 부모에만 속합니다.
+
+## 참고 자료
+
+- [Realm 객체 모델 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/model-data/object-models.md)
+- [Realm 관계 모델 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/model-data/relationships.md)
+- [Realm CRUD 공식 가이드](https://github.com/realm/realm-swift/tree/community/docs/guides/crud)
+- [`Persisted` API source](https://github.com/realm/realm-swift/blob/community/RealmSwift/PersistedProperty.swift)
+- [`Object` API source](https://github.com/realm/realm-swift/blob/community/RealmSwift/Object.swift)

--- a/docs/guide/realm-swift/queries-and-observation.md
+++ b/docs/guide/realm-swift/queries-and-observation.md
@@ -1,0 +1,333 @@
+---
+title: Realm 쿼리와 변경 관찰
+description: Results의 lazy·live 특성, 타입 안전 where와 정렬을 이해하고 NotificationToken, UIKit batch update, SwiftUI property wrapper로 변경을 반영합니다.
+pageType: doc-wide
+outline: false
+---
+
+# Realm 쿼리와 변경 관찰
+
+> 면접용 한 줄 요약: **Realm의 `Results`는 query 결과를 복사한 배열이 아니라 조건을 유지한 live collection이며, observation은 초기 결과와 삭제·삽입·수정 index를 전달해 UI를 증분 갱신합니다.**
+
+## 먼저 `Results`의 정체를 이해해요
+
+```swift
+let realm = try Realm()
+
+let readingBooks = realm.objects(Book.self).where {
+  $0.status == .reading
+}
+```
+
+`readingBooks`는 query를 실행한 순간의 `[Book]` snapshot이 아닙니다.
+
+- query는 필요할 때 평가되며 result 전체를 즉시 Swift array로 복사하지 않아요.
+- 같은 executor에서 Realm이 최신 version으로 이동하면 결과도 자동으로 갱신돼요.
+- `Results` 안의 element도 managed live object예요.
+- 정렬하지 않으면 business상 의미 있는 순서를 보장한다고 가정하면 안 돼요.
+
+```text
+조건: status == reading
+          │
+Realm v1 ─┼─> [A, B]
+          │ write: C.status = reading
+Realm v2 ─┴─> [A, B, C]  같은 Results가 새 상태를 표시
+```
+
+`Array(readingBooks)`로 바꿔도 배열 구조만 복사할 뿐 내부 `Book` reference는 여전히 managed object입니다. actor 경계나 영구 snapshot이 필요하면 원하는 scalar를 별도 `Sendable` struct로 복사하세요.
+
+## 타입 안전 `where`로 query해요
+
+```swift
+func searchBooks(
+  in realm: Realm,
+  keyword: String,
+  minimumProgress: Int
+) -> Results<Book> {
+  realm.objects(Book.self)
+    .where {
+      $0.title.contains(keyword, options: .caseInsensitive) &&
+        $0.progress >= minimumProgress &&
+        $0.status != .finished
+    }
+    .sorted(byKeyPath: "updatedAt", ascending: false)
+}
+```
+
+Swift query API는 property와 비교 값의 type을 compiler가 검사할 수 있다는 장점이 있습니다. 문자열 기반 predicate도 지원하지만, 새 코드는 표현 가능한 범위에서 `where`를 먼저 사용하세요.
+
+```swift
+let legacyStyle = realm.objects(Book.self).filter(
+  "title CONTAINS[c] %@ AND progress >= %d",
+  keyword,
+  minimumProgress
+)
+```
+
+문자열 predicate는 복잡한 기존 `NSPredicate`를 옮기기 쉽지만 오타와 property rename을 compile time에 잡기 어렵습니다. 사용자 입력을 query format 문자열 자체에 직접 이어 붙이지 말고 placeholder argument로 전달해요.
+
+## filter와 sort의 책임을 분리해요
+
+```swift
+let recentReadingBooks = realm.objects(Book.self)
+  .where {
+    $0.status == .reading && $0.progress.between(1...99)
+  }
+  .sorted(by: [
+    SortDescriptor(keyPath: "updatedAt", ascending: false),
+    SortDescriptor(keyPath: "title", ascending: true)
+  ])
+```
+
+| 연산       | 질문                                   | 예시                              |
+| ---------- | -------------------------------------- | --------------------------------- |
+| filter     | 어떤 객체를 포함할까요?                | 읽는 중이고 진도가 1~99인가?      |
+| sort       | 포함된 객체를 어떤 순서로 보여 줄까요? | 최근 수정 순, 같은 날짜면 제목 순 |
+| projection | 어떤 field만 화면 모델로 옮길까요?     | id, 제목, 진도만 DTO로 변환       |
+
+검색 화면에서 query text가 바뀔 때마다 Realm 전체를 `[Book]`으로 복사한 뒤 Swift `filter`를 돌리기보다 Realm query로 조건을 내려보내세요. 다만 짧은 목록의 UI-only 후처리는 가독성과 측정 결과에 따라 Swift collection 연산을 사용할 수 있습니다.
+
+## live result가 snapshot과 다른 순간을 확인해요
+
+```swift
+let results = realm.objects(Book.self).where {
+  $0.status == .reading
+}
+
+let countBeforeWrite = results.count
+
+let book = Book()
+book.title = "Realm Internals"
+book.status = .reading
+
+try realm.write {
+  realm.add(book)
+}
+
+let countAfterWrite = results.count
+print(countBeforeWrite, countAfterWrite)
+```
+
+같은 executor에서 실행한 local write는 같은 Realm과 result에 반영됩니다. 다른 executor나 process의 변경은 해당 Realm이 refresh되거나 run loop를 통해 auto-refresh된 뒤 보입니다. “database file이 바뀌었다”와 “이 Realm instance가 그 version으로 이동했다”를 구분하세요.
+
+## `NotificationToken`으로 collection 변경을 관찰해요
+
+```swift
+final class ReadingBooksObserver {
+  private let results: Results<Book>
+  private var token: NotificationToken?
+
+  init(realm: Realm) {
+    results = realm.objects(Book.self)
+      .where { $0.status == .reading }
+      .sorted(byKeyPath: "updatedAt", ascending: false)
+  }
+
+  func start(onChange: @escaping () -> Void) {
+    token = results.observe { change in
+      switch change {
+      case .initial:
+        onChange()
+
+      case .update(
+        _,
+        let deletions,
+        let insertions,
+        let modifications
+      ):
+        print("삭제: \(deletions)")
+        print("삽입: \(insertions)")
+        print("수정: \(modifications)")
+        onChange()
+
+      case .error(let error):
+        assertionFailure("Realm observation error: \(error)")
+      }
+    }
+  }
+
+  func stop() {
+    token?.invalidate()
+    token = nil
+  }
+
+  deinit {
+    token?.invalidate()
+  }
+}
+```
+
+token을 local variable로만 만들고 함수가 끝나게 두면 관찰도 끝날 수 있어요. feature·view model·view controller처럼 관찰 책임을 가진 객체가 token을 강하게 보관하고, 수명이 끝날 때 `invalidate()`합니다.
+
+### 전체 Realm, collection, object 관찰은 정보량이 달라요
+
+| 관찰 대상         | 전달 정보                         | 적합한 경우                       |
+| ----------------- | --------------------------------- | --------------------------------- |
+| `realm.observe`   | Realm에 write가 commit됐다는 사실 | 전체 cache 무효화 같은 넓은 신호  |
+| `results.observe` | initial, 삭제·삽입·수정 index     | 목록을 증분 갱신할 때             |
+| `object.observe`  | 변경된 property 또는 삭제         | 상세 화면의 특정 객체를 추적할 때 |
+
+필요보다 넓은 범위를 관찰하면 관련 없는 write에도 UI 작업이 발생합니다. object·collection observation에는 `keyPaths`를 지정해 관심 property만 좁힐 수도 있어요.
+
+## UIKit 목록은 diff index를 순서대로 적용해요
+
+```swift
+import RealmSwift
+import UIKit
+
+final class ReadingBooksViewController: UITableViewController {
+  private let realm = try! Realm()
+  private lazy var books = realm.objects(Book.self)
+    .where { $0.status == .reading }
+    .sorted(byKeyPath: "updatedAt", ascending: false)
+  private var token: NotificationToken?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    token = books.observe { [weak self] changes in
+      guard let self else { return }
+
+      switch changes {
+      case .initial:
+        tableView.reloadData()
+
+      case .update(_, let deletions, let insertions, let modifications):
+        tableView.performBatchUpdates {
+          tableView.deleteRows(
+            at: deletions.map { IndexPath(row: $0, section: 0) },
+            with: .automatic
+          )
+          tableView.insertRows(
+            at: insertions.map { IndexPath(row: $0, section: 0) },
+            with: .automatic
+          )
+          tableView.reloadRows(
+            at: modifications.map { IndexPath(row: $0, section: 0) },
+            with: .automatic
+          )
+        }
+
+      case .error(let error):
+        assertionFailure(error.localizedDescription)
+      }
+    }
+  }
+
+  override func tableView(
+    _ tableView: UITableView,
+    numberOfRowsInSection section: Int
+  ) -> Int {
+    books.count
+  }
+
+  override func tableView(
+    _ tableView: UITableView,
+    cellForRowAt indexPath: IndexPath
+  ) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(
+      withIdentifier: "BookCell",
+      for: indexPath
+    )
+    let book = books[indexPath.row]
+    var content = cell.defaultContentConfiguration()
+    content.text = book.title
+    content.secondaryText = "\(book.progress)%"
+    cell.contentConfiguration = content
+    return cell
+  }
+}
+```
+
+Realm 공식 가이드는 collection change를 **삭제 → 삽입 → 수정** 순서로 적용하라고 안내합니다. index는 이전 notification과 이번 notification 사이의 변화에 맞춰 계산되므로, 별도 array를 다른 순서로 먼저 바꾸거나 callback 밖의 오래된 index와 섞지 마세요.
+
+고빈도 변경에서는 모든 notification마다 복잡한 animation을 실행하면 UI update가 밀릴 수 있습니다. update 빈도, batch 크기와 main thread 시간을 Instruments로 측정하고 필요하면 표시 주기를 조절하거나 snapshot UI 계층을 둡니다.
+
+## SwiftUI에서는 `@ObservedResults`로 시작해요
+
+```swift
+import RealmSwift
+import SwiftUI
+
+struct ReadingBooksView: View {
+  @ObservedResults(
+    Book.self,
+    where: { $0.status == .reading },
+    sortDescriptor: SortDescriptor(
+      keyPath: "updatedAt",
+      ascending: false
+    )
+  ) private var books
+
+  var body: some View {
+    List {
+      ForEach(books, id: \.id) { book in
+        VStack(alignment: .leading) {
+          Text(book.title)
+          ProgressView(value: Double(book.progress), total: 100)
+        }
+      }
+      .onDelete(perform: $books.remove)
+    }
+    .toolbar {
+      Button("책 추가", action: addBook)
+    }
+  }
+
+  private func addBook() {
+    let book = Book()
+    book.title = "새 책"
+    book.status = .reading
+    $books.append(book)
+  }
+}
+```
+
+`@ObservedResults`는 query 결과 변경을 View invalidation과 연결하고 projected collection인 `$books`로 append·remove write를 편리하게 수행합니다. 간결하다는 이유로 모든 business rule을 View에 넣지는 마세요. 검증, 여러 object의 원자적 변경, 서버 outbox 기록처럼 하나의 operation으로 묶여야 하는 작업은 store나 actor의 method로 모읍니다.
+
+상세 화면에서 하나의 managed object를 수정해야 하면 `@ObservedRealmObject`를 사용할 수 있습니다. 다만 navigation path나 actor 경계를 Realm 객체 reference 자체로 채우기보다 primary key를 전달하고 목적지에서 query하는 방식이 삭제·executor 문제를 줄여요.
+
+## notification과 write의 순환을 피하세요
+
+```text
+write
+  └─> notification
+         └─> 같은 값을 다시 write
+                └─> notification ...
+```
+
+callback에서 받은 값을 그대로 다시 저장하면 불필요한 notification loop가 생길 수 있습니다.
+
+- 새 값이 기존 값과 실제로 다른지 먼저 검사해요.
+- UI에서 이미 반영한 write라면 `write(withoutNotifying:)`의 적용 가능성을 검토해요.
+- 복잡한 derived field는 notification callback보다 명시적인 domain operation에서 함께 갱신해요.
+- callback 안에서 nested write를 시작하지 않도록 write 책임을 분리해요.
+
+## query와 관찰 체크리스트
+
+- [ ] 결과 순서가 중요할 때 명시적으로 sort했나요?
+- [ ] 문자열 predicate에 사용자 문자열을 직접 이어 붙이지 않나요?
+- [ ] `Results`와 element가 live managed object임을 고려했나요?
+- [ ] observation 범위를 Realm보다 collection·object·key path로 좁힐 수 있나요?
+- [ ] token을 관찰 책임 객체가 유지하고 종료 시 invalidate하나요?
+- [ ] UIKit에서 삭제 → 삽입 → 수정 순서로 batch update하나요?
+- [ ] 고빈도 update의 main thread 비용을 실제 기기에서 측정했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `Results`와 `[Object]`는 어떻게 다른가요?
+
+`Results`는 Realm query를 표현하는 lazy·live collection이며 Realm이 새 version으로 이동하면 조건에 맞는 내용도 갱신됩니다. Swift array는 container의 element 구성을 복사하지만, `Array(results)`의 element가 managed Realm object라면 object 값까지 immutable snapshot이 되는 것은 아닙니다.
+
+### collection notification의 index로 무엇을 할 수 있나요?
+
+이전 결과와 새 결과 사이에 삭제·삽입·수정된 위치를 알 수 있어 `UITableView`와 `UICollectionView`를 전체 `reloadData()` 대신 batch update할 수 있습니다. Realm이 안내하는 삭제, 삽입, 수정 순서를 지키고 동일한 observed result를 data source로 사용해야 해요.
+
+## 참고 자료
+
+- [Realm 데이터 읽기 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/crud/read.md)
+- [Realm filter 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/crud/filter-data.md)
+- [Realm 변경 관찰 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/crud/react-to-changes.md)
+- [Realm SwiftUI 공식 가이드](https://github.com/realm/realm-swift/blob/community/docs/guides/swiftui.md)
+- [`Results` API source](https://github.com/realm/realm-swift/blob/community/RealmSwift/Results.swift)
+- [`RealmSwift.swiftUI` API source](https://github.com/realm/realm-swift/blob/community/RealmSwift/SwiftUI.swift)


### PR DESCRIPTION
## Summary

Realm Swift의 객체 데이터베이스 구조와 로컬 CRUD·변경 관찰·운영 설정을 단계적으로 설명하고, MongoDB Atlas Device Sync 종료 이후의 현재 지원 범위와 전환 기준까지 하나의 학습 흐름으로 정리합니다.

## Changes

- `Realm Swift` 상단 내비게이션과 한국어 사이드바 섹션을 추가했습니다.
- Realm Swift `community` 브랜치와 `v20`을 기준으로 Swift Package Manager 설치, 첫 모델과 CRUD를 문서화했습니다.
- `Object`, `EmbeddedObject`, `@Persisted`, primary key, index, `List`, `LinkingObjects`와 managed/unmanaged 객체의 생명주기를 설명했습니다.
- write transaction, upsert, 삭제와 embedded·일반 관계의 cascade 차이를 완성형 `LibraryStore` 예제로 연결했습니다.
- `Results`의 lazy·live 특성, 타입 안전 `where`, `NotificationToken`, UIKit batch update와 `@ObservedResults`를 정리했습니다.
- `Realm.Configuration`, 파일 분리, 누적 schema migration, in-memory test, Realm AES 암호화와 Keychain key 보관을 문서화했습니다.
- Swift 6의 `Realm.open`, `asyncWrite`, actor 격리와 ID·`Sendable` DTO 전달 원칙을 설명했습니다.
- Atlas Device Sync·App Services가 2025년 9월 30일 종료됐고 Realm Swift `v20`에는 로컬 기능만 남았음을 별도 문서로 구분했습니다.
- 기존 Sync 앱을 위한 의존성 점검, local-only·custom sync·database 교체 선택지와 Outbox·cursor·conflict·인증 전환 절차를 추가했습니다.
- Realm Swift 공식 저장소와 MongoDB Atlas Device SDK·종료 공식 문서를 본문과 참고 자료에 연결했습니다.

## Testing

- `npm run format`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Rspress build 산출물에서 Realm 5개 페이지 생성 확인

## Related Issues

Closes #57

## Notes

- 문서 수는 시작하기, 모델·CRUD, 쿼리·변경 관찰, 구성·마이그레이션·보안, Atlas Device Sync 종료와 전환의 5개로 구성했습니다.
- MongoDB의 기존 Swift SDK 문서는 역사적·전환 맥락으로 활용하고, 제거된 Sync API를 현재 권장 방식으로 안내하지 않습니다.
