### PR TITLE
[#63] Network 프레임워크 학습 섹션을 추가한다

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -24,6 +24,12 @@
     "position": "left"
   },
   {
+    "text": "네트워크",
+    "link": "/guide/network/index",
+    "activeMatch": "/guide/network/",
+    "position": "left"
+  },
+  {
     "text": "Realm Swift",
     "link": "/guide/realm-swift/index",
     "activeMatch": "/guide/realm-swift/",

--- a/docs/guide/_meta.json
+++ b/docs/guide/_meta.json
@@ -21,6 +21,11 @@
   },
   {
     "type": "dir-section-header",
+    "name": "network",
+    "label": "네트워크"
+  },
+  {
+    "type": "dir-section-header",
     "name": "realm-swift",
     "label": "Realm Swift"
   },

--- a/docs/guide/network/_meta.json
+++ b/docs/guide/network/_meta.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "custom-link",
+    "label": "Network 시작하기",
+    "link": "/guide/network/index"
+  },
+  {
+    "type": "custom-link",
+    "label": "연결과 데이터 송수신",
+    "link": "/guide/network/connections-and-data",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "NWConnection과 메시지 경계",
+        "link": "/guide/network/connections-and-data"
+      },
+      {
+        "type": "custom-link",
+        "label": "Swift Concurrency 네트워킹",
+        "link": "/guide/network/swift-concurrency"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "네트워크 경로 관찰",
+    "link": "/guide/network/path-monitoring"
+  },
+  {
+    "type": "custom-link",
+    "label": "Bonjour와 로컬 네트워크",
+    "link": "/guide/network/bonjour-and-local-network"
+  }
+]

--- a/docs/guide/network/bonjour-and-local-network.md
+++ b/docs/guide/network/bonjour-and-local-network.md
@@ -1,0 +1,274 @@
+---
+title: Swift로 이해하는 Bonjour와 로컬 네트워크
+description: NWBrowser와 NWListener로 Bonjour 서비스를 탐색·광고하고 발견한 엔드포인트에 연결하는 흐름을 설명합니다. 로컬 네트워크 권한, TLS 신뢰, 객체 수명과 실기기 검증 기준을 정리합니다.
+---
+
+# Swift로 이해하는 Bonjour와 로컬 네트워크
+
+> **면접 답변 한 줄 요약:** Bonjour는 주소를 미리 알지 못하는 서비스를 이름과 타입으로 찾게 해 주며, Network의 Browser·Listener·Connection을 나눠 사용하면 탐색·광고·실제 통신과 권한·보안을 구분해 설계할 수 있어요.
+
+사용자에게 장비의 IP 주소와 포트를 직접 입력하게 하면 주소가 바뀔 때마다 설정을 수정해야 해요. Bonjour를 사용하면 서비스가 자신을 알리고 앱이 그 서비스를 찾아 연결할 수 있어요.
+
+이 문서는 iOS 17+, Swift 6 언어 모드의 `NWBrowser`·`NWListener` 예제예요. iOS 26의 `NetworkBrowser`·`NetworkListener`는 [Swift Concurrency 문서](./swift-concurrency.md)에서 비교해요.
+
+## 먼저 알아둘 용어
+
+| 용어         | 쉬운 뜻                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------- |
+| Bonjour      | 기기와 서비스가 로컬 네트워크에서 서로를 발견하도록 돕는 기술 묶음이에요.                           |
+| mDNS·DNS-SD  | mDNS는 로컬 이름을 찾는 방식이고, DNS-SD는 DNS 레코드로 서비스의 종류와 위치를 발견하는 방식이에요. |
+| 서비스 타입  | `_swiftkr._tcp`처럼 “무슨 통신 규칙을 어떤 전송 방식으로 제공하는가”를 나타내요.                    |
+| 광고·탐색    | 광고는 서비스의 존재를 알리는 동작, 탐색은 원하는 타입의 서비스를 찾는 동작이에요.                  |
+| TXT 레코드   | 서비스의 버전·기능 같은 작은 부가 정보를 전달하는 키-값 데이터예요. 비밀이나 신원 증명이 아니에요.  |
+| Entitlement  | 앱의 코드 서명에 포함되는 기능 권한이에요. 사용자에게 묻는 개인정보 접근 허용과는 달라요.           |
+| TLS identity | 서버가 TLS에서 사용할 인증서와 개인 키의 조합이에요.                                                |
+
+탐색·광고·연결의 경계, 서비스 목록의 수명, 권한 설명, TLS 신뢰와 실기기 시험을 배워요.
+
+## 세 가지 객체의 역할을 나눠요
+
+[Apple의 네트워킹 API 선택 가이드](https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api)는 Bonjour 광고·탐색·연결에 Network를 권장해요.
+
+```text
+서버 앱                                  클라이언트 앱
+NWListener + service ── Bonjour 광고 ──→ NWBrowser
+       │                                  │ 발견된 서비스 목록
+       │                                  ↓ 사용자가 선택
+       └── 새 NWConnection 수락 ←──── NWConnection(to: endpoint)
+                       ↕ 실제 메시지 송수신
+```
+
+Browser는 서버에 로그인하거나 업무 데이터를 읽는 객체가 아니에요. Listener는 검색 목록이 아니라 새 연결을 받는 객체예요. 발견됐다는 사실은 **현재 연결 성공이나 신뢰할 수 있는 장비임을 보장하지 않아요**.
+
+### IP 주소를 저장하는 대신 서비스 엔드포인트를 사용해요
+
+서비스 발견 결과를 IP 주소 문자열로 바꿔 영구 저장하기보다, 선택한 `NWBrowser.Result.endpoint`로 연결해요. 이름 해석과 주소 선택을 시스템에 맡길 수 있어요.
+
+같은 표시 이름을 사용하는 서비스가 있을 수 있으므로 이름 문자열만으로 목록의 ID를 만들지도 않아요. 아래 예제는 엔드포인트를 항목의 ID로 사용해요.
+
+## 검색 목록을 관찰 가능한 모델로 만들어요
+
+Observation은 모델의 상태 변경을 UI에서 관찰하는 Swift 기능이에요. 모델은 MainActor에 격리하고, Network 콜백은 `Task { @MainActor ... }`로 전달해요.
+
+중지 직전에 예약된 콜백이 나중에 실행될 수 있으므로, `generation`이라는 실행 식별자로 오래된 탐색 결과를 무시해요.
+
+```swift
+import Foundation
+import Network
+import Observation
+
+struct DiscoveredDevice: Identifiable, Sendable {
+    let endpoint: NWEndpoint
+    var id: NWEndpoint { endpoint }
+
+    var name: String {
+        if case .service(let name, _, _, _) = endpoint { return name }
+        return endpoint.debugDescription
+    }
+}
+
+@MainActor
+@Observable
+final class DeviceBrowser {
+    private(set) var devices: [DiscoveredDevice] = []
+    private(set) var message = "검색 버튼을 눌러 주세요"
+    @ObservationIgnored private var browser: NWBrowser?
+    @ObservationIgnored private var generation = UUID()
+
+    func start() {
+        stop()
+        let token = UUID()
+        generation = token
+        let browser = NWBrowser(
+            for: .bonjour(type: "_swiftkr._tcp", domain: nil), using: .tcp
+        )
+        self.browser = browser
+        message = "장비를 찾는 중"
+
+        browser.stateUpdateHandler = { [weak self] state in
+            Task { @MainActor [weak self] in
+                guard let self, self.generation == token else { return }
+                switch state {
+                case .ready:
+                    self.message = "검색 중 — 결과가 없을 수도 있어요"
+                case .waiting(let error):
+                    self.message = "검색 대기: \(error)"
+                case .failed(let error):
+                    self.stop()
+                    self.message = "검색 실패: \(error)"
+                case .cancelled:
+                    self.stop()
+                default:
+                    break
+                }
+            }
+        }
+        browser.browseResultsChangedHandler = { [weak self] results, _ in
+            let devices = results.map { DiscoveredDevice(endpoint: $0.endpoint) }
+                .sorted { $0.name < $1.name }
+            Task { @MainActor [weak self] in
+                guard let self, self.generation == token else { return }
+                self.devices = devices
+            }
+        }
+        browser.start(queue: DispatchQueue(label: "swiftkr.device-browser"))
+    }
+
+    func stop() {
+        generation = UUID()
+        browser?.cancel()
+        browser = nil
+        devices = []
+        message = "검색이 중지됐어요"
+    }
+}
+```
+
+이 모델은 새 결과 집합으로 목록을 교체해 사라진 서비스도 반영해요. 결과를 계속 append만 하면 중복되거나 이미 사라진 장비가 남을 수 있어요. 같은 탐색 안에서 아주 빈번한 업데이트의 엄격한 순서 보장이 필요하다면 이벤트를 하나의 직렬 소비 경로로 전달하는 설계를 추가해요.
+
+Browser의 `.tcp`는 탐색 조건이지 실제 업무 연결을 암호화하는 설정이 아니에요. 연결을 만들 때는 서버와 맞는 TLS 등 별도의 파라미터가 필요해요.
+
+### 화면에서 검색 시점을 사용자에게 맡겨요
+
+SwiftUI는 상태에 따라 화면을 선언하는 Apple UI 프레임워크예요. 아래 화면은 검색 버튼으로 탐색을 시작하고, 선택한 엔드포인트를 호출자에게 넘겨요.
+
+```swift
+import SwiftUI
+import Network
+
+@MainActor
+struct DevicePicker: View {
+    @State private var model = DeviceBrowser()
+    let onSelect: (NWEndpoint) -> Void
+
+    var body: some View {
+        List {
+            Text(model.message)
+            Button("장비 검색") { model.start() }
+            ForEach(model.devices) { device in
+                Button(device.name) {
+                    model.stop()
+                    onSelect(device.endpoint)
+                }
+            }
+        }
+        .onDisappear { model.stop() }
+    }
+}
+```
+
+호출자는 [NWConnection 예제](./connections-and-data.md)의 `DeviceReader.read(endpoint:)`처럼 선택한 서비스에 연결해요. 발견과 연결 사이에도 서비스가 종료될 수 있으므로 연결 실패를 처리해야 해요. 검색 결과가 없어도 곧바로 권한 거부로 단정하지 않아요.
+
+## 서버는 identity를 갖춘 Listener로 광고해요
+
+다음 함수는 **광고와 연결 수락을 구성하는 부분**이에요. 실제 명령 파싱·응답·접속별 시간 제한은 `onConnection`으로 전달받은 연결의 소유자가 구현해요. 앞 문서의 줄바꿈 규칙을 사용한다면 서버도 동일하게 읽고 응답해야 해요.
+
+```swift
+import Foundation
+import Network
+import Security
+
+func startDeviceAdvertisement(
+    identity: sec_identity_t,
+    onState: @escaping @Sendable (NWListener.State) -> Void,
+    onConnection: @escaping @Sendable (NWConnection) -> Void
+) throws -> NWListener {
+    let tls = NWProtocolTLS.Options()
+    sec_protocol_options_set_local_identity(tls.securityProtocolOptions, identity)
+    let parameters = NWParameters(tls: tls, tcp: NWProtocolTCP.Options())
+    let listener = try NWListener(using: parameters, on: .any)
+    listener.service = NWListener.Service(name: "SwiftKR 온도계", type: "_swiftkr._tcp")
+    listener.newConnectionLimit = 8
+    listener.stateUpdateHandler = onState
+    listener.newConnectionHandler = onConnection
+    listener.start(queue: DispatchQueue(label: "swiftkr.device-listener"))
+    return listener
+}
+```
+
+호출자는 반환된 Listener를 보관하고, 서버 기능을 종료할 때 `cancel()`해요. `onConnection`으로 받은 연결도 따로 보관하고 상태 핸들러를 설치한 뒤 `start(queue:)`해야 해요. **Listener의 취소와 이미 수락한 연결의 종료를 같은 것으로 보지 않고**, 각 연결도 명시적으로 정리해요.
+
+`.any`는 시스템이 사용 가능한 포트를 선택하게 해요. 클라이언트는 번호를 하드코딩하지 않고 광고된 서비스 엔드포인트로 연결해요. Listener가 준비되기 전에는 포트나 서비스 등록이 완료됐다고 가정하지 않아요. `newConnectionLimit` 외에도 앱의 동시 처리량·요청 크기·유휴 시간 제한을 설계해요.
+
+### 인증서 검증을 끄지 않고 신뢰를 준비해요
+
+[`Creating an Identity for Local Network TLS`](https://developer.apple.com/documentation/network/creating-an-identity-for-local-network-tls)는 서버 identity와 클라이언트 신뢰 체인을 준비하는 방법을 설명해요. 위 함수는 이미 안전하게 준비한 identity를 인자로 받으며 개인 키를 코드에 넣지 않아요.
+
+개발 인증서라서 연결이 실패한다면 인증서의 신뢰 체인과 접속 이름을 확인해요. 무조건 `true`를 반환하는 인증서 검증 콜백으로 해결하지 않아요. Bonjour 표시 이름·TXT 레코드는 누구나 주장할 수 있는 정보이므로 장비 인증이나 사용자 권한을 대신할 수 없어요.
+
+TLS는 통신 보안이고, 사용자 계정의 권한 검사와 메시지 유효성 검사는 앱 프로토콜의 책임이에요. 로컬 네트워크라서 신뢰할 수 있다고 가정하지 않아요.
+
+## Info.plist의 설명과 서비스 타입을 준비해요
+
+앱 타깃의 Info 설정에 다음 값을 추가해요. `_swiftkr._tcp`는 예제용 서비스 타입이므로 실제 앱의 광고·탐색 코드와 일치시켜요.
+
+```xml
+<key>NSLocalNetworkUsageDescription</key>
+<string>같은 네트워크의 온도 장비를 찾아 측정값을 읽습니다.</string>
+<key>NSBonjourServices</key>
+<array>
+    <string>_swiftkr._tcp</string>
+</array>
+```
+
+[`NSLocalNetworkUsageDescription`](https://developer.apple.com/documentation/bundleresources/information-property-list/nslocalnetworkusagedescription)은 접근 이유를 사용자에게 설명하고, [`NSBonjourServices`](https://developer.apple.com/documentation/bundleresources/information-property-list/nsbonjourservices)는 사용하는 Bonjour 서비스 타입을 선언해요. 둘 다 그 자체로 접근을 허용해 주는 스위치는 아니에요.
+
+Apple의 [TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)에 따르면 iOS의 로컬 네트워크 개인정보 보호는 iOS 14부터 적용돼요. 앱의 실제 로컬 작업을 계기로 시스템이 사용자에게 물어보므로, 기능과 무관하게 앱 시작 직후 검색을 켜기보다 사용자가 “장비 검색”을 선택한 시점에 시작하는 구성을 권장해요.
+
+미결정 상태에서 첫 작업이 먼저 실패할 수 있어요. 한 번의 실패로 영구 거부라고 단정하지 않고 대기·다시 검색·설정 안내를 제공해요. 검색 중지와 앱의 다른 기능 이용도 가능하게 해요.
+
+### 로컬 권한과 multicast entitlement는 달라요
+
+Info.plist에 선언한 특정 타입의 일반 Bonjour 탐색·광고를 한다고 언제나 multicast entitlement까지 필요한 것은 아니에요. 직접 UDP multicast·broadcast를 사용하거나 임의의 서비스 타입을 폭넓게 찾는 작업은 별도의 요건을 확인해야 해요. [TN3179의 Multicast operations](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#Multicast-operations)를 기준으로 실제 작업을 분류해요.
+
+macOS의 App Sandbox에서 요구하는 네트워크 capability도 사용자에게 받는 로컬 네트워크 접근 허용과 다른 층의 설정이에요. 플랫폼마다 권한·서명·실행 환경을 나눠 확인해요.
+
+## 실패 원인을 하나의 권한 값으로 합치지 않아요
+
+| 현상                   | 먼저 구분할 내용                                                          |
+| ---------------------- | ------------------------------------------------------------------------- |
+| 검색 결과가 없음       | 서버가 광고 중인지, 서비스 타입이 같은지, 같은 네트워크에서 탐색 가능한지 |
+| Browser가 `.waiting`   | 관련 오류와 정책 제한 여부, 사용자 응답 전인지                            |
+| 발견했지만 연결 실패   | 서비스 종료, 접속 파라미터, 방화벽, TLS 신뢰                              |
+| 연결했지만 응답이 없음 | 양쪽 메시지 형식, 요청 처리 상태, 수신 루프와 시간 제한                   |
+
+TN3179는 범용적인 로컬 네트워크 허용 상태 조회 API가 없다고 설명해요. 특정 Bonjour 작업의 `kDNSServiceErr_PolicyDenied`나 해당 로컬 연결의 `unsatisfiedReason == .localNetworkDenied`처럼 **그 작업이 제공하는 단서**를 사용해요. `NWPathMonitor`의 일반 경로 상태를 권한 조회 결과로 바꾸지 않아요.
+
+## 실기기에서 검증해요
+
+권한 창은 iOS Simulator에서 검증할 수 없으므로 실제 iPhone·iPad를 사용해요. Mac의 커맨드라인 도구가 통신에 성공한 결과도 iOS 앱의 권한 동작을 증명하지 않아요.
+
+다음 시나리오를 구분해서 시험해요.
+
+1. 서버의 서비스 광고와 실제 요청·응답을 각각 확인해요.
+2. 처음 허용, 거부, 설정에서 변경 후 다시 검색을 확인해요.
+3. 서버가 없는 상태와 같은 이름의 여러 서비스가 있는 상태를 확인해요.
+4. 탐색 중지 직후 늦은 콜백과 화면 재진입을 확인해요.
+5. 잘못된 인증서·메시지·무응답을 별도로 시험해요.
+6. 서버와 클라이언트의 객체·작업이 종료될 때 연결도 정리되는지 확인해요.
+
+Bonjour를 이용해 앱이 백그라운드에서도 무제한 서버로 동작할 수 있다고 가정하지 않아요. 앱 수명과 허용된 백그라운드 실행 범위는 별도 제약이에요. 공용 웹 서버만 호출하는 앱에는 이 탐색 기능 자체가 필요하지 않을 수 있어요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Bonjour에서 발견한 이름을 로그인 증명으로 사용할 수 있나요
+
+아니에요. 발견은 위치와 서비스 정보를 얻는 과정이지 신원 인증이 아니에요. TLS 신뢰와 앱 수준의 장비·사용자 인증이 필요해요.
+
+### Listener를 취소하면 모든 클라이언트 작업도 끝나나요
+
+기존 NWListener와 수락한 NWConnection은 각각 수명을 관리해야 해요. 새 연결 수락을 멈추는 것과 기존 연결을 취소하는 것을 별도로 처리해요.
+
+### 검색 결과가 없으면 권한이 거부된 건가요
+
+그렇게 단정할 수 없어요. 광고 중인 서비스가 없거나 서비스 타입·네트워크가 다를 수 있어요. 실제 작업의 상태와 오류를 확인해 원인을 구분해요.
+
+## 참고 자료
+
+- [Apple Developer — NWBrowser](https://developer.apple.com/documentation/network/nwbrowser)
+- [Apple Developer — NWListener](https://developer.apple.com/documentation/network/nwlistener)
+- [Apple Developer — TN3151: Choosing the right networking API](https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api)
+- [Apple Developer — TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)
+- [Apple Developer — NSBonjourServices](https://developer.apple.com/documentation/bundleresources/information-property-list/nsbonjourservices)
+- [Apple Developer — NSLocalNetworkUsageDescription](https://developer.apple.com/documentation/bundleresources/information-property-list/nslocalnetworkusagedescription)
+- [Apple Developer — Creating an Identity for Local Network TLS](https://developer.apple.com/documentation/network/creating-an-identity-for-local-network-tls)

--- a/docs/guide/network/connections-and-data.md
+++ b/docs/guide/network/connections-and-data.md
@@ -1,0 +1,388 @@
+---
+title: Swift로 이해하는 NWConnection과 메시지 경계
+description: NWConnection의 연결 상태, TLS 설정과 송수신 완료의 의미를 설명하고 TCP 수신 조각을 한 줄 메시지로 복원하는 예제에 크기 제한·시간 제한·취소·테스트를 연결합니다.
+---
+
+# Swift로 이해하는 NWConnection과 메시지 경계
+
+> **면접 답변 한 줄 요약:** NWConnection은 연결 상태와 송수신을 비동기 콜백으로 제공하며, TCP를 사용할 때 앱은 수신된 바이트 조각에서 메시지 경계를 복원하고 오류·종료·취소를 처리해야 해요.
+
+장비가 `temperature=23.5`라는 문자열을 보냈는데 앱에서 앞부분만 보이거나 두 응답이 붙어 보일 수 있어요. TCP에서는 이상 현상이 아니에요. **한 번 보낸 데이터가 한 번의 수신으로 그대로 돌아온다고 가정한 코드**를 고쳐야 해요.
+
+이 문서는 iOS 17+, Swift 6 언어 모드를 기준으로 기존 `NWConnection` API를 설명해요. API 자체는 iOS 12부터 사용할 수 있어요. iOS 26 전용 비동기 연결 API는 [별도 문서](./swift-concurrency.md)에서 다뤄요.
+
+## 먼저 알아둘 용어
+
+| 용어                  | 쉬운 뜻                                                                       |
+| --------------------- | ----------------------------------------------------------------------------- |
+| 바이트 스트림         | 순서가 있는 바이트의 연속이에요. 앱이 보낸 덩어리의 구분선은 보존하지 않아요. |
+| 프레이밍(Framing)     | 바이트 흐름에서 메시지의 시작과 끝을 정하는 규칙이에요.                       |
+| 콜백                  | 나중에 상태나 결과가 생겼을 때 시스템이 호출할 함수예요.                      |
+| EOF(End of File)      | 이 문서에서는 상대의 송신이 끝나 더 받을 바이트가 없는 상태를 뜻해요.         |
+| 반쪽 종료(Half-close) | TCP의 송신 방향만 닫는 동작이에요. 연결 전체 취소와 달라요.                   |
+| MainActor             | UI 상태 등 지정한 작업을 직렬로 격리하는 Swift의 전역 액터예요.               |
+
+여기서는 연결 상태, 송수신 완료의 의미, 메시지 복원, 작업 수명, 독립적인 파서 테스트를 순서대로 확인해요.
+
+## 연결은 생성 직후부터 준비된 상태가 아니에요
+
+아래 코드는 TLS로 보호되는 연결을 구성해요. 목적지에는 실제로 해당 포트에서 동작하는 TLS 서버가 필요해요.
+
+```swift
+import Network
+
+func makeSecureConnection(host: NWEndpoint.Host,
+                          port: NWEndpoint.Port) -> NWConnection {
+    NWConnection(host: host, port: port, using: .tls)
+}
+```
+
+`.tls`는 TLS와 TCP를 사용하는 구성이에요. `.tcp`로 바꾸면 암호화 없는 TCP가 되므로 실서비스 연결 오류를 피하려고 바꾸지 않아요. HTTP 서버에 연결했다면 TLS 위에서 HTTP 규칙도 지켜야 해요. 웹 API 호출에는 [URLSession](./index.md)을 먼저 사용해요.
+
+[`NWConnection.State`](https://developer.apple.com/documentation/network/nwconnection/state-swift.enum)의 상태를 구분해요.
+
+| 상태              | 의미와 처리                                                                      |
+| ----------------- | -------------------------------------------------------------------------------- |
+| `.setup`          | 생성됐지만 아직 시작하지 않았어요.                                               |
+| `.preparing`      | 주소 해석·연결·프로토콜 준비가 진행 중이에요.                                    |
+| `.waiting(error)` | 현재 조건에서 연결할 수 없어 기다려요. 즉시 영구 실패로 단정하지 않아요.         |
+| `.ready`          | 연결을 사용해 데이터를 주고받을 수 있어요. 서버 업무의 성공이라는 뜻은 아니에요. |
+| `.failed(error)`  | 연결이 실패했어요. 필요하면 정책에 따라 새 연결을 만들어요.                      |
+| `.cancelled`      | 연결이 취소됐어요. 같은 인스턴스를 다시 시작하는 용도로 사용하지 않아요.         |
+
+`stateUpdateHandler`를 설치하고 `start(queue:)`를 호출해요. 콜백이 실행되는 큐와 앱 상태가 격리되는 액터는 별개의 개념이므로, 아래 전체 예제는 콜백에서 MainActor로 명시적으로 이동해요.
+
+## send 한 번과 receive 한 번은 짝이 아니에요
+
+다음과 같은 처리는 UTF-8 문자열 하나조차 안전하게 복원하지 못해요.
+
+```swift
+import Foundation
+import Network
+
+func receiveOneChunkIncorrectly(on connection: NWConnection) {
+    connection.receive(minimumIncompleteLength: 1,
+                       maximumLength: 4096) { data, _, _, _ in
+        guard let data else { return }
+        print(String(decoding: data, as: UTF8.self))
+        // 잘못된 가정: 이 조각이 응답 메시지 전체라고 생각해요.
+    }
+}
+```
+
+한글 한 글자의 바이트도 여러 수신에 나뉠 수 있어요. 조각마다 문자열로 바꾸면 아직 완성되지 않은 UTF-8을 잘못 해석할 수 있어요. 두 메시지가 한 조각에 들어오는 경우도 처리하지 못해요.
+
+[`receive`](<https://developer.apple.com/documentation/network/nwconnection/receive(minimumincompletelength:maximumlength:completion:)>)는 **호출 한 번당 완료 콜백 한 번**을 예약해요. 계속 받으려면 결과를 처리한 다음 다시 호출해야 해요. `maximumLength`는 이번 수신 조각의 상한이지, 전체 메시지의 상한이 아니에요.
+
+## 먼저 한 줄 프로토콜의 규칙을 정해요
+
+예제에서는 양쪽이 다음 규칙을 사용한다고 가정해요.
+
+- 메시지는 UTF-8이고 줄바꿈 바이트 `0x0A`로 끝나요.
+- 본문에는 줄바꿈을 넣지 않아요. 최대 본문 크기는 4,096바이트예요.
+- 요청은 `READ\n`, 응답은 예를 들어 `temperature=23.5\n`이에요.
+- 요청 하나에 응답 한 줄을 받은 뒤 클라이언트가 연결을 닫아요.
+
+실제로 `\`와 `n` 두 문자를 보내는 것이 아니라 줄바꿈 바이트를 보내요. 바이너리 데이터에는 길이 헤더 같은 다른 프레이밍이 더 적합할 수 있어요. 양쪽의 규칙은 반드시 같아야 해요.
+
+다음 파서는 네트워크와 무관한 값 타입이에요. 바이트를 누적하고 줄이 완성된 시점에만 문자열로 바꿔요.
+
+```swift
+import Foundation
+
+enum LineProtocolError: Error, Equatable {
+    case tooLong
+    case invalidUTF8
+    case incompleteLine
+}
+
+struct LineDecoder {
+    let maximumBytes: Int
+    private var pending: [UInt8] = []
+
+    init(maximumBytes: Int = 4096) {
+        precondition(maximumBytes > 0)
+        self.maximumBytes = maximumBytes
+    }
+
+    mutating func append(_ chunk: Data) throws -> [String] {
+        var lines: [String] = []
+        for byte in chunk {
+            if byte == 0x0A {
+                guard let line = String(bytes: pending, encoding: .utf8) else {
+                    throw LineProtocolError.invalidUTF8
+                }
+                lines.append(line)
+                pending.removeAll(keepingCapacity: true)
+            } else {
+                guard pending.count < maximumBytes else {
+                    throw LineProtocolError.tooLong
+                }
+                pending.append(byte)
+            }
+        }
+        return lines
+    }
+
+    func finish() throws {
+        guard pending.isEmpty else {
+            throw LineProtocolError.incompleteLine
+        }
+    }
+}
+```
+
+분리된 한 메시지와 합쳐진 여러 메시지를 모두 다뤄요. 줄바꿈 없이 계속 보내는 상대가 메모리를 무한히 늘리지 못하도록 누적 크기를 제한해요. 파싱 오류 뒤에는 이 파서를 계속 사용하지 않고 연결을 종료하는 정책을 선택해요.
+
+## 연결·취소·시간 제한까지 묶어요
+
+아래 `LineRequest`는 **한 번만 사용하는 요청 객체**예요. 앞의 파서와 함께 넣으면 컴파일할 수 있어요. 콜백은 MainActor에서 전달되며, 동시에 겹친 종료 원인 중 첫 결과만 호출자에게 전달해요.
+
+```swift
+import Foundation
+import Network
+
+enum LineRequestError: Error {
+    case invalidRequest
+    case alreadyStarted
+    case endedBeforeResponse
+    case timedOut
+}
+
+@MainActor
+final class LineRequest {
+    private let connection: NWConnection
+    private var decoder = LineDecoder()
+    private var started = false
+    private var finished = false
+    private var sent = false
+    private var deadlineTask: Task<Void, Never>?
+    private var completion: ((Result<String, any Error>) -> Void)?
+
+    init(endpoint: NWEndpoint, parameters: NWParameters = .tls) {
+        connection = NWConnection(to: endpoint, using: parameters)
+    }
+
+    func start(command: String = "READ", timeout: Duration = .seconds(10),
+               completion: @escaping (Result<String, any Error>) -> Void) {
+        guard !started, !finished else {
+            completion(.failure(LineRequestError.alreadyStarted))
+            return
+        }
+        started = true
+        self.completion = completion
+        guard !command.contains("\n"), command.utf8.count <= 4096 else {
+            finish(.failure(LineRequestError.invalidRequest))
+            return
+        }
+        let payload = Data((command + "\n").utf8)
+
+        connection.stateUpdateHandler = { [weak self] state in
+            Task { @MainActor [weak self] in
+                guard let self, !self.finished else { return }
+                switch state {
+                case .ready:
+                    guard !self.sent else { return }
+                    self.sent = true
+                    self.receiveNext()
+                    self.connection.send(content: payload,
+                                         completion: .contentProcessed { [weak self] error in
+                        guard let error else { return }
+                        Task { @MainActor [weak self] in
+                            self?.finish(.failure(error))
+                        }
+                    })
+                case .failed(let error):
+                    self.finish(.failure(error))
+                case .cancelled:
+                    self.finish(.failure(CancellationError()))
+                default:
+                    break // waiting에서는 전체 시간 제한까지 기다려요.
+                }
+            }
+        }
+
+        deadlineTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: timeout)
+                self?.finish(.failure(LineRequestError.timedOut))
+            } catch {
+                // 정상 종료나 사용자 취소로 시간 제한 작업도 취소됐어요.
+            }
+        }
+        connection.start(queue: .main)
+    }
+
+    func cancel() {
+        finish(.failure(CancellationError()))
+    }
+
+    private func receiveNext() {
+        connection.receive(minimumIncompleteLength: 1,
+                           maximumLength: 4096) { [weak self] data, _, isComplete, error in
+            Task { @MainActor [weak self] in
+                guard let self, !self.finished else { return }
+                do {
+                    if let data, let line = try self.decoder.append(data).first {
+                        self.finish(.success(line))
+                        return
+                    }
+                    if let error {
+                        self.finish(.failure(error))
+                    } else if isComplete {
+                        try self.decoder.finish()
+                        self.finish(.failure(LineRequestError.endedBeforeResponse))
+                    } else {
+                        self.receiveNext()
+                    }
+                } catch {
+                    self.finish(.failure(error))
+                }
+            }
+        }
+    }
+
+    private func finish(_ result: Result<String, any Error>) {
+        guard !finished else { return }
+        finished = true
+        deadlineTask?.cancel()
+        deadlineTask = nil
+        connection.cancel()
+        let callback = completion
+        completion = nil
+        callback?(result)
+    }
+
+    deinit {
+        deadlineTask?.cancel()
+        connection.cancel()
+    }
+}
+```
+
+`.waiting`에서는 연결 조건이 개선될 가능성을 남겨 두되 전체 시간 제한은 유지해요. 이 10초는 서버와 사용자 경험에 맞춰 정할 **예제의 정책**이지 Network의 기본 시간 제한이 아니에요. 완료 콜백에서 오류를 받아 재시도하려면 새 `LineRequest`를 만들어요.
+
+수신 데이터와 종료 표시가 함께 올 수 있어 데이터를 먼저 파싱해요. 첫 완성 줄을 받으면 성공으로 마치며, 이후 추가 줄을 처리하는 스트리밍 클라이언트는 아니에요. 응답을 받은 뒤 데이터베이스 반영까지 보장하려면 별도 업무 응답 규칙이 필요해요.
+
+### 호출자가 요청 객체의 수명을 유지해요
+
+지역 변수로 만들고 즉시 버리지 말고 화면의 모델이나 서비스가 보관해요. 아래는 호출 방식만 보여주는 소유자예요.
+
+```swift
+import Network
+
+@MainActor
+final class DeviceReader {
+    private var request: LineRequest?
+    private(set) var message = "대기 중"
+
+    func read(endpoint: NWEndpoint) {
+        request?.cancel()
+        let next = LineRequest(endpoint: endpoint)
+        request = next
+        next.start { [weak self] result in
+            switch result {
+            case .success(let line): self?.message = line
+            case .failure(let error): self?.message = String(describing: error)
+            }
+            self?.request = nil
+        }
+    }
+
+    func stop() {
+        request?.cancel()
+        request = nil
+    }
+}
+```
+
+UI 관찰 코드는 생략했어요. UIKit의 화면 종료나 SwiftUI에서 작업을 소유한 계층의 종료 정책에 맞춰 `stop()`을 호출해요. 단순히 화면이 잠시 가려졌다는 이유만으로 언제나 취소해야 하는 것은 아니에요.
+
+## 송신 완료·수신 완료·업무 완료를 구분해요
+
+[`send`](<https://developer.apple.com/documentation/network/nwconnection/send(content:contentcontext:iscomplete:completion:)-5ecuz>)의 완료는 상대 앱이 요청을 처리했다는 업무 응답이 아니에요.
+
+| 신호                     | 알 수 있는 것                              | 알 수 없는 것                            |
+| ------------------------ | ------------------------------------------ | ---------------------------------------- |
+| `.contentProcessed(nil)` | 연결이 송신 데이터를 오류 없이 처리했어요. | 상대의 저장·결제 등 업무 완료            |
+| TCP 수신의 `isComplete`  | 수신 콘텐츠/스트림이 완료됐어요.           | 방금 받은 조각 하나가 앱 메시지 하나인지 |
+| 앱이 정한 성공 응답      | 합의한 프로토콜의 성공 조건이 충족됐어요.  | 그 프로토콜에 포함하지 않은 후속 작업    |
+
+`send`의 기본 `isComplete: true`는 송신 콘텐츠 컨텍스트의 완료 표시예요. TCP에서 그 값만으로 줄바꿈이 삽입되거나 상대 수신이 메시지별로 나뉘지 않아요. 송신 방향을 닫으려면 `.finalMessage` 같은 최종 컨텍스트의 의미를 확인해요. `cancel()`은 정상적인 업무 종료 응답을 대신하지 않아요.
+
+UDP에서는 메시지 단위 API인 [`receiveMessage`](<https://developer.apple.com/documentation/network/nwconnection/receivemessage(completion:)>)를 검토해요. 데이터그램 경계가 있다고 전달이나 순서까지 보장되지는 않으며, 이 TCP 한 줄 파서를 그대로 적용할 필요도 없어요.
+
+## 파서는 네트워크 없이 테스트해요
+
+Swift Testing은 `@Test`와 `#expect`로 기대 결과를 표현하는 Apple의 테스트 도구예요. 테스트 타깃에서 파서 타입을 볼 수 있게 한 뒤 아래 코드를 실행해요.
+
+```swift
+import Foundation
+import Testing
+
+@Test func fragmentedUTF8AndCombinedLines() throws {
+    var decoder = LineDecoder()
+    let bytes = Array("온도=23.5\nOK\n".utf8)
+    #expect(try decoder.append(Data(bytes.prefix(1))).isEmpty)
+    #expect(try decoder.append(Data(bytes.dropFirst(1))) == ["온도=23.5", "OK"])
+    try decoder.finish()
+}
+
+@Test func oversizedLineIsRejected() throws {
+    var decoder = LineDecoder(maximumBytes: 3)
+    #expect(throws: LineProtocolError.tooLong) {
+        try decoder.append(Data("1234".utf8))
+    }
+}
+
+@Test func unfinishedLineIsRejected() throws {
+    var decoder = LineDecoder()
+    _ = try decoder.append(Data("partial".utf8))
+    #expect(throws: LineProtocolError.incompleteLine) {
+        try decoder.finish()
+    }
+}
+
+@Test func invalidUTF8IsRejected() throws {
+    var decoder = LineDecoder()
+    #expect(throws: LineProtocolError.invalidUTF8) {
+        try decoder.append(Data([0xFF, 0x0A]))
+    }
+}
+```
+
+이 테스트는 네트워크 속도에 의존하지 않아요. 실제 연결의 인증서 오류, 시간 제한, 상대 종료와 사용자 취소는 별도의 통합 테스트로 확인해야 해요. 한 번에 한 조각만 오는 서버로만 시험하면 스트림 처리 버그를 놓칠 수 있어요.
+
+## 적용 순서를 정리해요
+
+1. 상대의 프로토콜과 TLS 구성을 확인해요.
+2. 메시지 경계와 크기 제한을 먼저 구현하고 테스트해요.
+3. 콜백을 설치한 뒤 연결을 시작해요.
+4. 상태·송수신·시간 제한 중 어느 경로에서도 한 번만 완료되게 해요.
+5. 소유자가 객체를 보관하고 필요할 때 취소하게 해요.
+6. 재시도는 새 연결과 중복 처리 방지 정책을 함께 설계해요.
+
+큰 파일을 한 줄로 받거나, 많은 연결의 파싱을 MainActor에 모으는 구조에는 이 예제가 적합하지 않아요. 이때는 스트리밍 형식과 별도 데이터 처리 격리 영역을 설계해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### TCP에서도 메시지가 분리되나요
+
+TCP는 바이트 순서를 제공하지만 앱 메시지의 경계를 보존하지 않아요. 구분자·길이 헤더·고정 길이 등 양쪽이 합의한 프레이밍이 필요해요.
+
+### maximumLength만 설정하면 큰 메시지 공격을 막을 수 있나요
+
+아니에요. 한 번의 수신량만 제한하므로 누적 버퍼와 전체 메시지 크기도 제한해야 해요. 메시지가 끝나지 않는 경우를 위해 시간 제한도 필요해요.
+
+### 송신 완료 콜백에서 저장 성공 화면을 보여도 되나요
+
+상대 앱의 저장 성공을 뜻하지 않아요. 저장 여부를 나타내는 응답, 요청 식별자, 실패 후 재시도의 중복 처리 규칙을 앱 프로토콜로 정해야 해요.
+
+## 참고 자료
+
+- [Apple Developer — NWConnection](https://developer.apple.com/documentation/network/nwconnection)
+- [Apple Developer — NWConnection.State](https://developer.apple.com/documentation/network/nwconnection/state-swift.enum)
+- [Apple Developer — receive(minimumIncompleteLength:maximumLength:completion:)](<https://developer.apple.com/documentation/network/nwconnection/receive(minimumincompletelength:maximumlength:completion:)>)
+- [Apple Developer — send(content:contentContext:isComplete:completion:)](<https://developer.apple.com/documentation/network/nwconnection/send(content:contentcontext:iscomplete:completion:)-5ecuz>)
+- [Apple Developer — receiveMessage(completion:)](<https://developer.apple.com/documentation/network/nwconnection/receivemessage(completion:)>)
+- [WWDC25 — Use structured concurrency with Network framework](https://developer.apple.com/videos/play/wwdc2025/250/)

--- a/docs/guide/network/index.md
+++ b/docs/guide/network/index.md
@@ -1,0 +1,160 @@
+---
+title: Swift로 이해하는 Network 프레임워크
+description: Apple Network 프레임워크의 역할을 URLSession과 비교하고 TCP·UDP·TLS·QUIC, 연결과 경로의 차이, 기존 API와 iOS 26 비동기 API의 학습 순서를 설명합니다.
+---
+
+# Swift로 이해하는 Network 프레임워크
+
+> **면접 답변 한 줄 요약:** Network는 앱이 직접 정한 통신 규칙에 맞춰 연결과 데이터 송수신을 구성하는 Apple 프레임워크로, 전송 방식과 보안을 조합하면서 이름 해석과 연결 상태 처리를 시스템에 맡길 수 있어요.
+
+상품 목록을 웹 서버에서 받아오는 일과 근처 장비에 직접 명령을 보내는 일은 모두 네트워킹이지만, 필요한 API는 같지 않아요. 이 섹션은 [Apple Network 공식 문서](https://developer.apple.com/documentation/network)를 출발점으로 **언제 Network가 필요하고, 어떻게 연결·데이터·수명을 다루는지** 설명해요.
+
+기본 Swift 문법을 아는 독자를 대상으로 해요. 코드는 학습용으로 작성한 예제이며 Apple 샘플의 번역본은 아니에요. HTTP 클라이언트 전체 구현이나 VPN 개발은 이번 범위에 포함하지 않아요.
+
+## 먼저 알아둘 네트워크 용어
+
+| 용어                               | 쉬운 뜻                                                                                               |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 프로토콜                           | 통신하는 양쪽이 합의한 데이터 형식과 처리 순서예요. 여기서는 Swift의 `protocol` 선언과 구별해요.      |
+| 엔드포인트(Endpoint)               | 연결의 한쪽 끝이에요. 호스트 이름과 포트, 또는 발견한 서비스로 나타낼 수 있어요.                      |
+| 포트(Port)                         | 같은 기기 안에서 어느 서비스와 통신할지 구분하는 번호예요.                                            |
+| HTTP·HTTPS                         | 웹 요청과 응답의 규칙이에요. HTTPS는 HTTP 통신을 TLS로 보호해요.                                      |
+| TCP(Transmission Control Protocol) | 순서 있는 바이트 흐름을 제공하는 전송 프로토콜이에요. 앱 메시지의 경계는 별도로 정해야 해요.          |
+| UDP(User Datagram Protocol)        | 개별 데이터그램 단위로 보내는 전송 프로토콜이에요. 전달·순서를 보장하지 않아요.                       |
+| TLS(Transport Layer Security)      | 통신 내용을 암호화하고 상대의 신원을 검증하는 보안 프로토콜이에요.                                    |
+| QUIC                               | UDP 위에서 암호화된 연결과 여러 스트림 등을 제공하는 전송 프로토콜이에요. HTTP/3도 이를 사용해요.     |
+| DNS(Domain Name System)            | 호스트 이름을 네트워크 주소와 연결하는 체계예요.                                                      |
+| 경로(Path)                         | 현재 통신에 사용할 수 있는 네트워크 조건과 인터페이스의 정보를 나타내요. 서버의 응답 결과와는 달라요. |
+
+이 섹션에서는 다음 내용을 배워요.
+
+- HTTP 요청과 직접 연결을 구분하는 기준
+- 연결 상태와 송수신 완료의 의미
+- TCP에서 메시지를 나누는 방법
+- 기존 콜백 API와 Swift Concurrency API의 차이
+- 네트워크 상태 관찰과 로컬 서비스 탐색
+
+## HTTP 요청에는 먼저 URLSession을 검토해요
+
+`Foundation`은 데이터·날짜·URL 처리 등 기본 기능을 제공하는 Apple 프레임워크예요. 그 안의 `URLSession`은 URL 기반 리소스를 요청하는 API예요.
+
+웹 API를 호출하려고 소켓 연결을 직접 열고 HTTP 문자열을 조립하면, 응답 파싱 외에도 인증·리다이렉트·캐시·취소 등을 떠안게 돼요. Apple의 [Network 개요](https://developer.apple.com/documentation/network)는 HTTP와 URL 기반 리소스에는 URLSession을 계속 사용하라고 안내해요.
+
+아래는 HTTPS 응답을 검사하고 Swift 값으로 변환하는 최소 예제예요. `Codable`은 값을 외부 데이터로 인코딩하고 다시 디코딩할 수 있게 하는 Swift 프로토콜 조합이에요.
+
+```swift
+import Foundation
+
+struct DeviceStatus: Codable, Sendable {
+    let name: String
+    let isOnline: Bool
+}
+
+enum HTTPStatusError: Error {
+    case invalidResponse
+    case unsuccessful(Int)
+}
+
+func fetchDeviceStatus(from url: URL) async throws -> DeviceStatus {
+    let (data, response) = try await URLSession.shared.data(from: url)
+    guard let http = response as? HTTPURLResponse else {
+        throw HTTPStatusError.invalidResponse
+    }
+    guard (200..<300).contains(http.statusCode) else {
+        throw HTTPStatusError.unsuccessful(http.statusCode)
+    }
+    return try JSONDecoder().decode(DeviceStatus.self, from: data)
+}
+```
+
+호출자는 자신이 운영하는 HTTPS API의 URL을 전달해요. `async`는 작업이 기다리는 동안 실행을 양보할 수 있다는 뜻이며, 성공이나 백그라운드 실행을 보장한다는 뜻은 아니에요. `Sendable`은 값을 동시성 경계 너머로 안전하게 전달할 수 있음을 나타내요.
+
+이 예제는 연결 오류뿐 아니라 HTTP 오류 상태도 검사해요. 응답 크기 제한, 인증, 재시도 정책, 캐시와 화면 연결은 서비스 요구에 맞춰 추가해야 해요. Network로 옮긴다고 이런 앱 정책이 자동으로 생기지는 않아요.
+
+## Network가 필요한 질문은 따로 있어요
+
+아래 선택 기준은 [TN3151: Choosing the right networking API](https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api)의 권장 사항을 학습 순서에 맞춰 정리한 것이에요.
+
+| 하고 싶은 일                             | 먼저 검토할 API                       | 이유                                                                                                       |
+| ---------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| HTTP·HTTPS API 호출, URL 리소스 다운로드 | `URLSession`                          | HTTP의 상위 기능을 제공해요.                                                                               |
+| 앱이 중단되어도 이어질 HTTP 파일 전송    | URLSession의 background session       | 직접 연결과 다른 시스템 전송 수명이 필요해요.                                                              |
+| 자체 TCP·UDP·QUIC 프로토콜               | Network의 연결 API                    | 바이트·메시지와 프로토콜 구성을 직접 다뤄요.                                                               |
+| 새 WebSocket 구현                        | Network를 우선 검토                   | Apple은 특별한 이유가 없으면 새 WebSocket 코드에 Network를 권장해요. URLSessionWebSocketTask도 선택지예요. |
+| 근처 서비스 광고·탐색·연결               | Network의 Listener·Browser·Connection | Bonjour 탐색 결과를 연결에 사용할 수 있어요.                                                               |
+
+HTTP/3를 사용하고 싶다는 이유만으로 QUIC 연결을 직접 구현하지 않아요. **HTTP/3 클라이언트는 URLSession, 자체 QUIC 프로토콜은 Network**로 목적을 구분해요. 크로스플랫폼 라이브러리 같은 제약이 없다면 Apple 플랫폼에서 TCP를 직접 다룰 때도 BSD 소켓보다 Network를 먼저 검토해요.
+
+Network와 **Network Extension**도 다른 프레임워크예요. Network가 앱의 통신에 초점을 둔다면, Network Extension은 VPN·필터 등 네트워크 기능을 확장하는 제공자 구현을 다뤄요. 이름이 비슷하다고 같은 설정이나 권한을 요구하지는 않아요.
+
+## 엔드포인트·프로토콜·정책을 나눠 생각해요
+
+같은 목적지에 연결하더라도 무엇으로 통신하고 어떤 조건을 허용할지 따로 정해요.
+
+```text
+NWEndpoint        어디로?  → 서비스 이름 또는 호스트·포트
+프로토콜 구성     어떻게?  → 메시지 형식 → TLS → TCP → IP
+연결 파라미터     어떤 조건? → 비용·저데이터 모드·인터페이스 제약
+                          ↓
+                 Connection의 연결·송수신
+```
+
+`NWEndpoint`는 목적지, `NWParameters`는 프로토콜과 정책을 담아요. Network에 호스트 이름을 전달하면 시스템이 주소 해석과 연결 시도를 처리해요. 앱이 DNS를 먼저 조회하고 IPv4 주소 하나를 고정하는 설계는 IPv6나 네트워크 변화에 불리할 수 있어요.
+
+`TLS`를 골랐다고 HTTP가 되는 것은 아니에요. TLS 위에서 주고받을 메시지 규칙은 여전히 양쪽이 합의해야 해요. 반대로 `.tcp`는 암호화를 켜는 설정이 아니에요. 실서비스에서는 인증서 검증을 유지하는 TLS나 보안이 포함된 전송 구성을 사용해요.
+
+## API 세대와 배포 대상을 구분해요
+
+[WWDC25](https://developer.apple.com/videos/play/wwdc2025/250/)는 기존 API를 유지하면서 Swift의 구조적 동시성에 맞춘 API를 소개했어요. 구조적 동시성은 부모·자식 작업의 수명과 취소를 정해진 범위에서 관리하는 방식이에요.
+
+| 역할           | 기존 Swift API            | 새로운 Swift API                                    |
+| -------------- | ------------------------- | --------------------------------------------------- |
+| 연결·송수신    | `NWConnection` — iOS 12+  | `NetworkConnection` — iOS 26+                       |
+| 연결 수락      | `NWListener` — iOS 12+    | `NetworkListener` — iOS 26+                         |
+| 서비스 탐색    | `NWBrowser` — iOS 13+     | `NetworkBrowser` — iOS 26+                          |
+| 앱의 경로 관찰 | `NWPathMonitor` — iOS 12+ | 같은 타입이 iOS 17+에서 `AsyncSequence`도 지원해요. |
+
+기존 타입을 모두 폐기된 API로 부르거나, `async/await` 문법을 썼다는 이유로 iOS 26 API라고 판단하지 않아요. 각 심벌의 도입 버전을 확인해야 해요. 이 섹션은 **일반 예제는 iOS 17+, 신규 연결 API 예제는 iOS 26+**, Swift 6 언어 모드와 기본 액터 격리 `nonisolated`를 기준으로 해요.
+
+watchOS는 저수준 네트워킹에 별도 제약이 있어요. iOS 예제를 그대로 확장하지 말고 [TN3135: Low-level networking on watchOS](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos)를 확인해요.
+
+## 어떤 문서부터 읽으면 좋을까요
+
+| 문서                                                      | 확인할 질문                                                        |
+| --------------------------------------------------------- | ------------------------------------------------------------------ |
+| [NWConnection과 메시지 경계](./connections-and-data.md)   | 연결 상태, 수신 반복, TCP 조각을 어떻게 처리하나요?                |
+| [Swift Concurrency 네트워킹](./swift-concurrency.md)      | iOS 26에서는 연결과 작업 수명이 어떻게 연결되나요?                 |
+| [네트워크 경로 관찰](./path-monitoring.md)                | 연결 상태 표시와 실제 요청 성공을 어떻게 구분하나요?               |
+| [Bonjour와 로컬 네트워크](./bonjour-and-local-network.md) | 주소를 모르는 서비스는 어떻게 찾고, 권한·보안은 어떻게 준비하나요? |
+
+## 적용 순서를 정리해요
+
+1. 상대가 사용하는 프로토콜과 앱의 최소 OS 버전을 확인해요.
+2. HTTP 기능인지, 직접 제어할 연결인지 먼저 결정해요.
+3. 메시지 경계·최대 크기·응답 규칙을 양쪽에서 합의해요.
+4. 연결 실패·취소·시간 제한·재시도의 책임을 정해요.
+5. 로컬 네트워크 권한과 TLS 신뢰 구성을 준비해요.
+6. 실제 네트워크 시험과 데이터 처리 단위 테스트를 나눠 검증해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Network가 URLSession보다 더 좋은 API인가요
+
+우열보다 다루는 계층이 달라요. HTTP 기능은 URLSession에 맡기고, 자체 전송 규칙이나 장비 통신처럼 직접 연결 제어가 필요할 때 Network를 검토해요.
+
+### NWConnection과 NetworkConnection은 이름만 다른가요
+
+아니에요. 상태·완료 콜백 중심의 API와, 타입으로 프로토콜 구성을 표현하고 비동기 작업과 수명을 연결하는 API라는 차이가 있어요. 지원 OS도 확인해야 해요.
+
+### 네트워크 경로가 정상이라면 서버에 연결할 수 있나요
+
+그것만으로는 알 수 없어요. DNS, TLS, 서버 장애나 인증 실패는 실제 요청에서 발생할 수 있어요. 경로 정보는 관찰·정책에 쓰고 실제 작업의 성공은 그 작업의 결과로 판단해요.
+
+## 참고 자료
+
+- [Apple Developer — Network](https://developer.apple.com/documentation/network)
+- [Apple Developer — TN3151: Choosing the right networking API](https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api)
+- [Apple Developer — URLSession](https://developer.apple.com/documentation/foundation/urlsession)
+- [WWDC25 — Use structured concurrency with Network framework](https://developer.apple.com/videos/play/wwdc2025/250/)
+- [Apple Developer — NWPathMonitor](https://developer.apple.com/documentation/network/nwpathmonitor)
+- [Apple Developer — TN3135: Low-level networking on watchOS](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos)

--- a/docs/guide/network/path-monitoring.md
+++ b/docs/guide/network/path-monitoring.md
@@ -1,0 +1,277 @@
+---
+title: Swift로 이해하는 NWPathMonitor와 네트워크 경로
+description: NWPathMonitor로 경로 상태와 데이터 비용을 관찰하고 실제 요청 성공과 구분합니다. 콜백·AsyncSequence·SwiftUI 예제, 저데이터 모드 정책과 테스트 방법을 설명합니다.
+---
+
+# Swift로 이해하는 NWPathMonitor와 네트워크 경로
+
+> **면접 답변 한 줄 요약:** NWPathMonitor는 앱에서 사용할 수 있는 네트워크 경로의 변화를 알려 주는 관찰자이며, 서버 성공 여부를 미리 보장하는 검사기가 아니라 상태 표시와 전송 정책을 돕는 도구예요.
+
+화면 위에 “오프라인”을 표시하거나 데이터 비용이 큰 환경에서 자동 다운로드를 미루고 싶을 수 있어요. 이때 필요한 정보와 실제 서버 요청의 성공 여부를 하나의 `isConnected` 값으로 합치면 오해가 생겨요.
+
+예제 기준은 iOS 17+, Swift 6 언어 모드예요. `NWPathMonitor`는 iOS 12부터, `isConstrained`는 iOS 13부터, 비동기 시퀀스 지원은 iOS 17부터 사용할 수 있어요.
+
+## 먼저 알아둘 용어
+
+| 용어                | 쉬운 뜻                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 경로(Path)          | 통신에 사용할 수 있는 네트워크의 조건과 인터페이스 정보예요.                                               |
+| 인터페이스          | Wi-Fi·셀룰러·유선처럼 네트워크로 통하는 통로예요.                                                          |
+| expensive           | 셀룰러나 개인용 핫스팟처럼 시스템이 비용이 크다고 판단한 경로예요. 실제 요금표나 속도 측정값이 아니에요.   |
+| constrained         | 사용자가 저데이터 모드를 켠 경로예요. 단순히 신호가 약하다는 뜻이 아니에요.                                |
+| preflight 검사      | 실제 요청 전에 성공할지를 별도 정보로 미리 판단하는 방식이에요.                                            |
+| Observation·SwiftUI | Observation은 읽은 모델 상태의 변경을 추적하고, SwiftUI는 그 상태에 따라 화면을 선언하는 Apple 기술이에요. |
+
+경로의 의미, 잘못된 사전 검사, 콜백과 비동기 관찰, UI 연결, 데이터 정책과 테스트를 순서대로 설명해요.
+
+## 경로·연결·서버 응답은 서로 다른 정보예요
+
+[`NWPath.Status`](https://developer.apple.com/documentation/network/nwpath/status-swift.enum)의 상태를 다음처럼 읽어요.
+
+| 값                    | 의미                                                     | 주의점                                                            |
+| --------------------- | -------------------------------------------------------- | ----------------------------------------------------------------- |
+| `.satisfied`          | 연결과 데이터 전송에 사용할 수 있는 경로예요.            | 특정 호스트의 DNS·TLS·서버·인증 성공은 보장하지 않아요.           |
+| `.requiresConnection` | 현재는 경로가 없지만 연결을 시작하면 활성화될 수 있어요. | 이 상태를 보고 모든 요청을 차단하면 활성화 기회도 막을 수 있어요. |
+| `.unsatisfied`        | 현재 조건을 만족하는 경로가 없어요.                      | 영구적인 장애라는 뜻은 아니에요.                                  |
+
+기본 `NWPathMonitor()`는 앱 관점의 경로를 관찰해요. 특정 연결은 파라미터와 목적지가 다르므로 `NWConnection.currentPath`·`pathUpdateHandler` 등 그 연결의 정보가 필요할 수 있어요.
+
+`NWPathMonitor(requiredInterfaceType: .wifi)`는 **Wi-Fi에 한정한 관찰자**예요. 이 모니터가 불만족 상태라고 셀룰러까지 사용할 수 없다는 뜻은 아니에요. [`usesInterfaceType`](<https://developer.apple.com/documentation/network/nwpath/usesinterfacetype(_:)>)도 경로가 해당 통로를 사용할 수 있는지 확인하는 API이지 Wi-Fi 이름(SSID)이나 실제 전송 속도를 얻는 API가 아니에요.
+
+## 요청 전에 모든 작업을 차단하지 않아요
+
+아래 코드는 상태값이 최신이고, 경로가 정상이어야만 요청을 시작할 수 있다고 가정해요.
+
+```swift
+// 권장하지 않는 제어 흐름이에요.
+func loadOnlyWhenPreflightAllows(isConnected: Bool, load: () -> Void) {
+    guard isConnected else { return }
+    load()
+}
+```
+
+관찰값을 읽은 다음 실제 연결을 시작하기 전에도 네트워크는 바뀔 수 있어요. 앱 시작 직후 아직 첫 경로 업데이트가 오지 않았을 수도 있어요. 반대로 `.satisfied` 상태에서도 서버는 실패할 수 있어요.
+
+사용자가 요청한 작업은 해당 API로 시도하고 실제 오류를 처리하는 흐름을 기본으로 삼아요. 경로 정보로 상태 안내나 불필요한 자동 작업을 조절하는 것은 별도의 정책이에요. Apple의 [TN3151](https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api)도 이름으로 연결하고 시스템의 연결 동작을 활용하도록 권장해요.
+
+## UI에서 사용할 작은 값으로 변환해요
+
+테스트에서 실제 `NWPath`를 마음대로 생성하거나 네트워크를 바꾸는 대신, 앱이 사용할 정보만 값 타입으로 옮겨요. 초기 상태는 오프라인이 아니라 **아직 모름**으로 표현해요.
+
+```swift
+import Network
+
+enum PathAvailability: Sendable, Equatable {
+    case unknown, available, needsConnection, unavailable
+}
+
+struct NetworkSnapshot: Sendable, Equatable {
+    let availability: PathAvailability
+    let isExpensive: Bool
+    let isConstrained: Bool
+
+    static let unknown = NetworkSnapshot(
+        availability: .unknown, isExpensive: false, isConstrained: false
+    )
+
+    init(availability: PathAvailability, isExpensive: Bool, isConstrained: Bool) {
+        self.availability = availability
+        self.isExpensive = isExpensive
+        self.isConstrained = isConstrained
+    }
+
+    init(path: NWPath) {
+        switch path.status {
+        case .satisfied: availability = .available
+        case .requiresConnection: availability = .needsConnection
+        case .unsatisfied: availability = .unavailable
+        @unknown default: availability = .unknown
+        }
+        isExpensive = path.isExpensive
+        isConstrained = path.isConstrained
+    }
+}
+```
+
+`Sendable`은 이 값이 동시성 경계 너머로 전달될 수 있음을 나타내요. 초기 비용 플래그의 `false`만 따로 읽어 무료 경로라고 판단하지 않고 `availability`와 함께 해석해요.
+
+## 기존 콜백 API는 소유자가 시작과 종료를 관리해요
+
+콜백 방식은 작업을 받을 큐와 핸들러를 설정해요. 다음 함수가 반환하는 모니터는 호출자가 보관하고 필요 없을 때 `cancel()`해야 해요.
+
+```swift
+import Foundation
+import Network
+
+func makeCallbackMonitor(
+    onChange: @escaping @Sendable (NetworkSnapshot) -> Void
+) -> NWPathMonitor {
+    let monitor = NWPathMonitor()
+    monitor.pathUpdateHandler = { path in
+        onChange(NetworkSnapshot(path: path))
+    }
+    monitor.start(queue: DispatchQueue(label: "swiftkr.path-monitor"))
+    return monitor
+}
+```
+
+이 콜백은 MainActor 콜백이 아니에요. UI 상태를 바꾸려면 MainActor로 전달해야 해요. 화면을 다시 열 때 취소한 인스턴스를 재사용하는 대신 새 모니터로 새 관찰 수명을 시작해요.
+
+## iOS 17부터는 for await로 직접 관찰할 수 있어요
+
+[`NWPathMonitor.Iterator`](https://developer.apple.com/documentation/network/nwpathmonitor/iterator)는 iOS 17부터 제공돼요. 기존 콜백을 반드시 직접 `AsyncStream`으로 감싸야 하는 것은 아니에요.
+
+아래 모델은 호출한 비동기 작업이 살아 있는 동안 경로를 관찰해요. `defer`에서 이 호출이 만든 모니터만 정리하므로, 다음 관찰의 모니터를 잘못 취소하지 않아요.
+
+```swift
+import Network
+import Observation
+
+@MainActor
+@Observable
+final class NetworkStatusModel {
+    private(set) var snapshot = NetworkSnapshot.unknown
+
+    var message: String {
+        switch snapshot.availability {
+        case .unknown: "네트워크 상태 확인 중"
+        case .unavailable: "현재 사용할 수 있는 경로가 없어요"
+        case .needsConnection: "연결을 시작하면 경로가 활성화될 수 있어요"
+        case .available:
+            snapshot.isConstrained ? "저데이터 모드예요" : "사용 가능한 경로가 있어요"
+        }
+    }
+
+    func observe() async {
+        let monitor = NWPathMonitor()
+        defer { monitor.cancel() }
+        for await path in monitor {
+            guard !Task.isCancelled else { break }
+            snapshot = NetworkSnapshot(path: path)
+        }
+    }
+}
+```
+
+비동기 반복을 사용할 때는 `pathUpdateHandler`와 `start(queue:)`를 함께 설치하지 않아요. 모니터 하나를 두 가지 소비 방식으로 동시에 다루지 않도록 수명을 단순하게 유지해요.
+
+SwiftUI 화면에서는 모델을 `@State`에 보관하고 `.task`에서 직접 기다려요. 여기서 `@State`는 View의 값이 다시 만들어져도 같은 화면 정체성의 저장소를 유지하고, `.task`는 화면 수명에 연결된 비동기 작업을 시작해요.
+
+```swift
+import SwiftUI
+
+@MainActor
+struct NetworkStatusView: View {
+    @State private var model = NetworkStatusModel()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(model.message)
+            Text("실제 요청의 성공 여부는 요청 결과로 확인해요.")
+                .font(.caption)
+        }
+        .task { await model.observe() }
+    }
+}
+```
+
+이 예제는 화면마다 모델을 소유하고 한 관찰 작업을 연결해요. 앱 전체의 공통 배너라면 화면마다 새 모니터를 늘리지 말고 앱 범위의 소유자가 모델을 공유하는 구성을 검토해요. 취소 신호가 오더라도 실제 정리는 비동기 작업이 취소에 반응하며 이루어져요.
+
+## 자동 다운로드 정책을 요청 정책과 분리해요
+
+다음 정책은 **미리 받아 두는 선택적 데이터**에만 적용해요. 사용자가 직접 누른 핵심 요청을 무조건 차단하는 용도가 아니에요.
+
+```swift
+enum PrefetchDecision: Equatable {
+    case waitForPath, deferForCost, allowed
+}
+
+func prefetchDecision(for snapshot: NetworkSnapshot) -> PrefetchDecision {
+    guard snapshot.availability == .available else { return .waitForPath }
+    if snapshot.isConstrained || snapshot.isExpensive { return .deferForCost }
+    return .allowed
+}
+```
+
+[`isExpensive`](https://developer.apple.com/documentation/network/nwpath/isexpensive)와 [`isConstrained`](https://developer.apple.com/documentation/network/nwpath/isconstrained)는 다른 정보예요. 비용이 큰 경로가 반드시 저데이터 모드인 것도, Wi-Fi가 언제나 비용이 낮은 것도 아니에요.
+
+실제 전송의 제약은 가능하면 전송 API에도 전달해요. HTTP 자동 다운로드라면 URLSession 설정을 사용할 수 있어요.
+
+```swift
+import Foundation
+
+func makePrefetchSession() -> URLSession {
+    let configuration = URLSessionConfiguration.default
+    configuration.waitsForConnectivity = true
+    configuration.allowsExpensiveNetworkAccess = false
+    configuration.allowsConstrainedNetworkAccess = false
+    configuration.timeoutIntervalForResource = 300
+    return URLSession(configuration: configuration)
+}
+```
+
+이 세션은 비용·저데이터 모드 제약을 만족하는 연결을 기다리도록 구성한 예시예요. `waitsForConnectivity`는 연결 수립 단계의 대기 정책이지 이미 전송 중인 연결 단절을 무제한 복구하는 옵션이 아니에요. 불필요해진 세션은 소유자가 `invalidateAndCancel()` 또는 적절한 종료 메서드로 정리해요.
+
+Network 직접 연결은 `NWParameters`의 관련 제약을 설정해요. 경로를 미리 읽고 비교하는 코드만으로 실제 전송이 같은 네트워크를 사용할 것이라고 보장할 수는 없어요.
+
+## 정책은 가짜 값으로 테스트해요
+
+아래 테스트는 실제 Wi-Fi나 셀룰러 환경 없이 실행할 수 있어요. Swift Testing 테스트 타깃에 앞의 값 타입과 정책 함수를 노출해요.
+
+```swift
+import Testing
+
+@Test func unknownPathDoesNotStartPrefetch() {
+    #expect(prefetchDecision(for: .unknown) == .waitForPath)
+}
+
+@Test func constrainedPathDefersPrefetch() {
+    let snapshot = NetworkSnapshot(
+        availability: .available, isExpensive: false, isConstrained: true
+    )
+    #expect(prefetchDecision(for: snapshot) == .deferForCost)
+}
+
+@Test func inexpensiveAvailablePathAllowsPrefetch() {
+    let snapshot = NetworkSnapshot(
+        availability: .available, isExpensive: false, isConstrained: false
+    )
+    #expect(prefetchDecision(for: snapshot) == .allowed)
+}
+```
+
+이 테스트는 운영 정책만 검증해요. 실제 장비에서 Wi-Fi↔셀룰러 전환, 저데이터 모드, 개인용 핫스팟, 앱 복귀와 관찰 종료를 별도로 시험해야 해요. 공유기 연결은 유지한 채 인터넷만 끊긴 상황도 확인하면 “Wi-Fi면 요청 성공”이라는 가정을 찾기 좋아요.
+
+## 적용 순서를 정리해요
+
+1. 경로 안내가 필요한 이유를 정해요. 필요 없다면 모니터 없이 요청 오류만 처리해도 돼요.
+2. 앱 전체인지 화면 단위인지 관찰의 소유 범위를 정해요.
+3. 첫 업데이트 전에는 알 수 없는 상태를 표시해요.
+4. UI 갱신과 전송 성공 판단을 분리해요.
+5. 비용 정책은 작은 값·함수로 분리하고 테스트해요.
+6. 취소·재관찰과 실제 네트워크 변화를 기기에서 확인해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### satisfied면 인터넷이 된다고 표시해도 되나요
+
+정확하게는 사용할 수 있는 경로가 있다는 뜻이에요. 목적지 서버까지의 성공을 확인한 것이 아니므로 UI 문구도 그 차이를 반영해야 해요.
+
+### isExpensive와 isConstrained는 같은 값인가요
+
+아니에요. 하나는 시스템이 판단한 네트워크 비용, 다른 하나는 저데이터 모드예요. 사용자 요청과 자동 다운로드의 정책도 따로 정할 수 있어요.
+
+### NWPathMonitor로 로컬 네트워크 권한을 조회할 수 있나요
+
+범용적인 권한 상태 조회 API로 사용할 수 없어요. 실제 로컬 작업의 오류와 앱의 권한 안내 흐름을 구분해 처리해야 해요. 자세한 내용은 [로컬 네트워크 문서](./bonjour-and-local-network.md)에서 다뤄요.
+
+## 참고 자료
+
+- [Apple Developer — NWPathMonitor](https://developer.apple.com/documentation/network/nwpathmonitor)
+- [Apple Developer — NWPathMonitor.Iterator](https://developer.apple.com/documentation/network/nwpathmonitor/iterator)
+- [Apple Developer — NWPath](https://developer.apple.com/documentation/network/nwpath)
+- [Apple Developer — isExpensive](https://developer.apple.com/documentation/network/nwpath/isexpensive)
+- [Apple Developer — isConstrained](https://developer.apple.com/documentation/network/nwpath/isconstrained)
+- [Apple Developer — URLSessionConfiguration.waitsForConnectivity](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/waitsforconnectivity)
+- [Apple Developer — TN3151](https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api)
+- [Apple Developer — TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)

--- a/docs/guide/network/swift-concurrency.md
+++ b/docs/guide/network/swift-concurrency.md
@@ -1,0 +1,341 @@
+---
+title: Swift로 이해하는 Network의 Swift Concurrency API
+description: iOS 26의 NetworkConnection·NetworkListener·NetworkBrowser를 기존 API와 비교하고 TLS·TLV·Coder 구성, 타입 안전한 메시지 교환, 작업 취소와 시간 제한을 설명합니다.
+---
+
+# Swift로 이해하는 Network의 Swift Concurrency API
+
+> **면접 답변 한 줄 요약:** iOS 26의 Network API는 프로토콜 구성을 타입으로 표현하고 송수신을 비동기 함수로 제공해, 연결과 메시지 처리를 Swift 작업의 수명 안에서 구성하게 해요.
+
+기존 콜백 코드를 단순히 `Task`로 감싸는 것과, 작업의 수명에 맞춰 설계된 API를 사용하는 것은 달라요. 이 문서에서는 **iOS 26+ / macOS 26+, Xcode 26 계열, Swift 6 언어 모드**를 기준으로 새로운 연결·수락·탐색 API를 사용해요.
+
+[WWDC25](https://developer.apple.com/videos/play/wwdc2025/250/)에서 설명한 원리를 바탕으로 온도 장비 예제를 새로 작성했어요. 낮은 OS도 지원해야 한다면 [NWConnection 문서](./connections-and-data.md)와 비교해요.
+
+## 먼저 알아둘 용어
+
+| 용어                   | 쉬운 뜻                                                                                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Swift Concurrency      | `async/await`, Task, 액터 등 비동기 실행과 격리를 표현하는 Swift 기능이에요.                                                                |
+| 구조적 동시성          | 자식 작업이 부모의 범위 안에서 완료되도록 하고 취소를 전달하는 구조예요. 임의로 만든 모든 `Task`가 자동으로 자식 작업이 되는 것은 아니에요. |
+| 프로토콜 스택          | 메시지 형식·보안·전송 규칙을 위아래로 조합한 구성이에요.                                                                                    |
+| Result Builder         | 코드 블록의 표현식을 조합하는 Swift 기능이에요. 여기서는 통신 규칙을 선언하는 데 사용해요.                                                  |
+| TLV(Type-Length-Value) | 메시지 종류·길이·내용을 함께 보내 경계를 구분하는 방식이에요.                                                                               |
+| Coder                  | Swift의 인코딩·디코딩 가능한 값을 메시지로 다루는 Network의 구체적인 타입이에요.                                                            |
+| AsyncSequence          | 시간이 지나면서 생기는 값을 `for await`로 하나씩 읽는 비동기 시퀀스예요.                                                                    |
+
+프로토콜 구성, 송수신, 메시지 직렬화, Listener·Browser, 취소와 시간 제한을 차례로 다뤄요.
+
+## 콜백의 수동 연결을 줄여요
+
+| 작업        | 기존 API                                | 새 API                                     |
+| ----------- | --------------------------------------- | ------------------------------------------ |
+| 연결        | `NWConnection`과 `start(queue:)`        | `NetworkConnection`과 비동기 송수신        |
+| 송수신 결과 | 완료 콜백의 데이터·오류                 | `try await send` / `receive`의 반환값·오류 |
+| 연결 수락   | `NWListener.newConnectionHandler`       | `NetworkListener.run`의 비동기 핸들러      |
+| 서비스 탐색 | `NWBrowser.browseResultsChangedHandler` | `NetworkBrowser.run`의 결과 집합           |
+| 수명        | 객체 보관·취소·큐를 직접 연결           | 작업 범위와 취소에 맞춘 수명 관리          |
+
+기존 API도 비동기 API예요. 새 API의 차이는 “동기에서 비동기로 바뀌었다”가 아니라 **Swift의 비동기 제어 흐름에 직접 연결된다**는 데 있어요. 기존 URLSession이나 정상 동작하는 콜백 구현을 일괄 교체할 필요는 없어요.
+
+## TLS 연결도 먼저 메시지 규칙이 필요해요
+
+아래는 요청 4바이트 `READ`에 대해 서버가 정확히 8바이트를 반환한다는 가상의 고정 길이 프로토콜이에요. [`withNetworkConnection`](<https://developer.apple.com/documentation/network/withnetworkconnection(to:using:_:)-887ho>)으로 연결을 사용하는 범위를 묶어요.
+
+```swift
+import Foundation
+import Network
+
+@available(iOS 26.0, macOS 26.0, *)
+func readFixedReply(from endpoint: NWEndpoint) async throws {
+    try await withNetworkConnection(to: endpoint, using: .parameters {
+        TLS()
+    }) { connection in
+        try await connection.send(Data("READ".utf8))
+        let reply = try await connection.receive(exactly: 8).content
+        print("응답 바이트 수: \(reply.count)")
+    }
+}
+```
+
+[`TLS`](https://developer.apple.com/documentation/network/tls) 아래의 기본 TCP·IP 구성은 추론돼요. 연결을 사용하는 동안 `send`·`receive`가 필요에 따라 연결을 시작하고 준비 상태를 기다려요. 다만 상대가 8바이트를 보내지 않으면 계속 기다리거나 오류로 끝날 수 있으므로, 아래의 시간 제한 정책도 필요해요.
+
+`exactly: 8`은 TCP를 메시지 프로토콜로 바꾸는 설정이 아니에요. 길이가 정해지지 않았다면 앞에서 길이를 읽고 검증하거나 별도 프레이밍을 사용해야 해요. `send`의 반환 역시 상대 앱의 업무 완료를 보장하지 않아요.
+
+## TLV와 Coder는 해결하는 범위가 달라요
+
+[`TLV`](https://developer.apple.com/documentation/network/tlv)는 바이트의 종류와 길이를 포함한 메시지를 제공해요. [`Coder`](https://developer.apple.com/documentation/network/coder)는 그 위의 값 인코딩·디코딩까지 줄여 줘요.
+
+| 구성                                  | 앱이 송수신하는 값        | 앱이 정해야 할 일                  |
+| ------------------------------------- | ------------------------- | ---------------------------------- |
+| `TLS { TCP() }`                       | 바이트 흐름               | 메시지 경계, 형식, 길이 제한       |
+| `TLV { TLS() }`                       | 종류가 붙은 데이터 메시지 | 종류별 의미, 데이터 형식·내용 검증 |
+| `Coder(타입, using: .json) { TLS() }` | Swift 값                  | 스키마 호환성, 업무 규칙·입력 검증 |
+
+TLV를 사용하는 작은 예제예요. `type: 1`을 조회 요청으로 해석한다는 약속도 서버와 같아야 해요.
+
+```swift
+import Foundation
+import Network
+
+@available(iOS 26.0, macOS 26.0, *)
+func requestWithTLV(from endpoint: NWEndpoint) async throws {
+    try await withNetworkConnection(to: endpoint, using: .parameters {
+        TLV {
+            TLS()
+        }
+    }) { connection in
+        try await connection.send(Data("READ".utf8), type: 1)
+        let message = try await connection.receive()
+        print("종류: \(message.metadata.type), 길이: \(message.content.count)")
+    }
+}
+```
+
+서버가 이미 다른 TLV 형식을 사용한다면 타입·길이 필드의 크기와 인코딩까지 대조해요. 이름이 TLV라는 이유만으로 모든 서버와 바로 호환되는 것은 아니에요. 앞 문서의 줄바꿈 프로토콜과도 호환되지 않아요.
+
+## Coder로 온도 요청과 응답을 교환해요
+
+`Codable`은 값의 직렬화를 위한 `Encodable`과 `Decodable`의 조합이에요. `Sendable`은 동시성 경계에서 전달할 값의 안전성을 나타내요. 자세한 차이는 [Codable](../swift/protocols/codable.md)에서 읽을 수 있어요.
+
+요청 식별자를 응답에 돌려줘서 다른 요청의 결과를 잘못 처리하지 않게 해요. 디코딩에 성공했더라도 응답 종류·식별자·값의 범위를 검사해요.
+
+```swift
+import Foundation
+
+enum DeviceMessage: Codable, Sendable, Equatable {
+    case read(id: UUID)
+    case reading(id: UUID, celsius: Double)
+}
+
+enum DeviceProtocolError: Error, Equatable {
+    case unexpectedReply
+    case invalidTemperature
+    case noReply
+}
+
+func validatedTemperature(_ message: DeviceMessage, for id: UUID) throws -> Double {
+    guard case .reading(let replyID, let celsius) = message, replyID == id else {
+        throw DeviceProtocolError.unexpectedReply
+    }
+    guard celsius.isFinite, (-80...100).contains(celsius) else {
+        throw DeviceProtocolError.invalidTemperature
+    }
+    return celsius
+}
+```
+
+이 범위는 예제 장비의 정책이에요. Coder가 업무상 유효한 값인지까지 검증해 주지는 않아요. 요청 식별자도 자동으로 중복 실행을 방지하는 키가 되지는 않으며 서버의 처리 규칙이 필요해요.
+
+실서비스용 연결은 TLS를 유지해요. 서버도 같은 Coder 메시지 형식과 인증서 구성을 지원해야 해요.
+
+```swift
+import Foundation
+import Network
+
+@available(iOS 26.0, macOS 26.0, *)
+func readTemperature(from endpoint: NWEndpoint) async throws -> Double {
+    let id = UUID()
+    var reply: DeviceMessage?
+    try await withNetworkConnection(to: endpoint, using: .parameters {
+        Coder(DeviceMessage.self, using: .json) {
+            TLS()
+        }
+    }) { connection in
+        try await connection.send(DeviceMessage.read(id: id))
+        reply = try await connection.receive().content
+    }
+    guard let reply else { throw DeviceProtocolError.noReply }
+    return try validatedTemperature(reply, for: id)
+}
+```
+
+`Coder`는 Network의 통신 프로토콜을 구성하는 **struct**예요. 문서에서 “프로토콜”이라고 설명하더라도 Swift의 `protocol` 선언을 뜻하는 것은 아니에요. JSON은 직렬화 형식이고, TCP 메시지 경계와 보안까지 모두 대신하는 형식은 아니에요.
+
+Coder가 추가하는 프레이밍까지 포함해 양쪽이 호환돼야 하므로 임의의 JSON HTTP 서버에 이 코드를 연결하면 안 돼요. 외부 입력의 메시지 크기·허용 값·스키마 변경 정책도 별도로 설계해야 해요.
+
+## Listener를 로컬 실험으로 확인해요
+
+아래 서버는 **자기 기기의 loopback 주소 `127.0.0.1`에만 바인딩하는 평문 테스트용**이에요. 인증서 준비 없이 메시지 교환을 확인하기 위한 것이며, 외부 기기에 공개하거나 민감한 데이터를 보내지 않아요.
+
+```swift
+import Foundation
+import Network
+
+@available(iOS 26.0, macOS 26.0, *)
+func runLoopbackDevice(
+    port: NWEndpoint.Port = 8787,
+    onReady: @escaping @Sendable (NWEndpoint.Port) -> Void = { _ in }
+) async throws {
+    let listener = try NetworkListener(using: .parameters {
+        Coder(DeviceMessage.self, using: .json) {
+            TCP()
+        }
+    }.localEndpoint(.hostPort(host: "127.0.0.1", port: port)))
+
+    listener.onStateUpdate { listener, state in
+        if case .ready = state, let port = listener.port {
+            onReady(port)
+        }
+    }
+    try await listener.run { connection in
+        do {
+            let request = try await connection.receive().content
+            guard case .read(let id) = request else {
+                throw DeviceProtocolError.unexpectedReply
+            }
+            try await connection.send(DeviceMessage.reading(id: id, celsius: 23.5))
+        } catch {
+            // 개별 연결의 오류를 처리하고 다른 연결의 수락은 유지해요.
+            print("장비 요청 실패: \(error)")
+        }
+    }
+}
+
+@available(iOS 26.0, macOS 26.0, *)
+func readLoopbackTemperature(port: NWEndpoint.Port = 8787) async throws -> Double {
+    let id = UUID()
+    var reply: DeviceMessage?
+    try await withNetworkConnection(
+        to: .hostPort(host: "127.0.0.1", port: port),
+        using: .parameters {
+            Coder(DeviceMessage.self, using: .json) { TCP() }
+        }
+    ) { connection in
+        try await connection.send(DeviceMessage.read(id: id))
+        reply = try await connection.receive().content
+    }
+    guard let reply else { throw DeviceProtocolError.noReply }
+    return try validatedTemperature(reply, for: id)
+}
+```
+
+[`NetworkListener.run`](<https://developer.apple.com/documentation/network/networklistener/run(_:)-4iov3>)은 수락한 연결을 비동기 핸들러로 전달해요. 서버를 먼저 실행해 준비된 뒤 클라이언트를 실행하고, 소유한 Task를 취소해 서버를 끝내요. 이미 포트가 사용 중이면 다른 포트를 양쪽에 동일하게 전달해요. 테스트에서는 `port: .any`와 `onReady`를 사용해 실제 선택된 포트를 받은 뒤 클라이언트를 연결할 수 있어요.
+
+Listener는 각 연결을 처리할 작업을 만들기 때문에 한 클라이언트의 수신을 기다린다고 다른 클라이언트 수락이 직렬로 막히는 형태는 아니에요. 그래도 연결 수 제한과 유휴 시간 제한은 필요해요. 이 서버는 요청 하나만 받고 끝내는 실습용이며, 장시간 서비스를 운영하는 서버 구현은 아니에요.
+
+실기기 간 서버를 만들 때는 `TLS()`로 바꾸는 것만으로 끝나지 않아요. 서버의 인증서·개인 키인 identity와 클라이언트의 신뢰 정책을 준비해야 해요. 인증서 검증을 무조건 통과시키는 콜백은 사용하지 않아요. [로컬 네트워크 TLS 공식 가이드](https://developer.apple.com/documentation/network/creating-an-identity-for-local-network-tls)를 함께 확인해요.
+
+## Browser는 연결할 대상을 찾아요
+
+[`NetworkBrowser`](https://developer.apple.com/documentation/network/networkbrowser)는 연결이 아니라 탐색을 담당해요. 아래 코드는 같은 서비스 이름을 찾을 때까지 기다린 뒤 탐색을 끝내요. 실제 앱에서는 발견한 목록을 보여주고 사용자가 대상을 선택하게 하는 편이 적절할 수 있어요.
+
+```swift
+import Network
+
+@available(iOS 26.0, macOS 26.0, *)
+func findDevice(named name: String) async throws -> NWEndpoint {
+    let endpoint: Bonjour.Endpoint = try await NetworkBrowser(
+        for: .bonjour("_swiftkr._tcp")
+    ).run { endpoints in
+        guard let match = endpoints.first(where: { $0.name == name }) else {
+            return .continue
+        }
+        return .finish(match)
+    }
+    return endpoint.nwEndpoint
+}
+```
+
+서비스 이름은 인증 수단이 아니에요. 검색 결과가 없을 수 있으므로 `first!`로 꺼내지 않아요. 탐색에도 취소·시간 제한이 필요하며, 발견한 엔드포인트는 연결할 때 사라질 수 있어요.
+
+위 loopback 서버는 Bonjour 광고를 하지 않기 때문에 이 Browser로 발견되지 않아요. Bonjour 광고, 서비스 타입 선언과 권한은 [Bonjour와 로컬 네트워크](./bonjour-and-local-network.md)에서 별도로 설명해요.
+
+## 작업 취소와 시간 제한을 함께 설계해요
+
+비동기 작업이 취소되어도 이미 상대 서버가 수행한 업무는 되돌아가지 않아요. 새 API는 연결·수락·탐색의 작업 수명을 연결해 주지만, 재시도 횟수나 업무의 멱등성까지 자동으로 정하지는 않아요. 멱등성은 같은 요청을 반복해도 의도한 효과가 중복되지 않는 성질이에요.
+
+다음은 **취소에 반응하는 작업**과 시간 제한 작업을 경쟁시키는 도우미예요.
+
+```swift
+enum NetworkDeadlineError: Error {
+    case timedOut
+}
+
+func withNetworkDeadline<Value: Sendable>(
+    _ duration: Duration,
+    operation: @escaping @Sendable () async throws -> Value
+) async throws -> Value {
+    try await withThrowingTaskGroup(of: Value.self) { group in
+        group.addTask { try await operation() }
+        group.addTask {
+            try await Task.sleep(for: duration)
+            throw NetworkDeadlineError.timedOut
+        }
+        defer { group.cancelAll() }
+        guard let result = try await group.next() else {
+            throw CancellationError()
+        }
+        return result
+    }
+}
+```
+
+호출은 다음과 같이 구성해요. 실습용 loopback 서버가 실행 중일 때 사용해요.
+
+```swift
+@available(iOS 26.0, macOS 26.0, *)
+func runTimedRead() async throws -> Double {
+    try await withNetworkDeadline(.seconds(5)) {
+        try await readLoopbackTemperature()
+    }
+}
+```
+
+시간 제한 쪽이 먼저 실패하면 나머지 자식 작업을 취소해요. **Task Group은 자식이 끝날 때까지 범위를 떠나지 않으므로**, 취소를 무시하는 임의의 작업을 강제로 5초에 종료시키는 도구는 아니에요. 여기서는 Network의 작업 취소 처리에 의존해요.
+
+SwiftUI 화면에서 사용할 때는 `.task`의 작업 안에서 직접 기다리거나, 버튼으로 만든 Task의 핸들을 소유하고 적절한 시점에 취소해요. `Task.detached`를 만든 뒤 화면을 떠나면 자동으로 끝날 것이라고 가정하지 않아요.
+
+## 테스트와 적용 기준을 정리해요
+
+다음 검사는 네트워크 없이 응답 검증을 확인해요. 테스트 타깃에 앞의 메시지 타입과 검증 함수를 노출하고 Swift Testing으로 실행해요.
+
+```swift
+import Foundation
+import Testing
+
+@Test func responseMustMatchRequest() throws {
+    let id = UUID()
+    #expect(try validatedTemperature(.reading(id: id, celsius: 23.5), for: id) == 23.5)
+    #expect(throws: DeviceProtocolError.unexpectedReply) {
+        try validatedTemperature(.reading(id: UUID(), celsius: 23.5), for: id)
+    }
+    #expect(throws: DeviceProtocolError.invalidTemperature) {
+        try validatedTemperature(.reading(id: id, celsius: 500), for: id)
+    }
+}
+```
+
+운영 코드에 적용하기 전에는 다음 순서를 확인해요.
+
+1. 배포 대상이 iOS 26 이상인지 확인해요.
+2. 서버의 프레이밍·직렬화·TLS 구성과 맞춰요.
+3. 단위 테스트와 loopback 송수신을 먼저 확인해요.
+4. 연결 대기·무응답·취소·잘못된 응답을 시험해요.
+5. 실기기의 네트워크 변화·권한 거부·인증서 오류를 확인해요.
+
+낮은 OS 지원이 중요하거나 기존 콜백 코드가 충분히 검증되어 있다면 즉시 마이그레이션하지 않아도 돼요. 새 코드에서 중첩 콜백과 수명 관리의 부담이 클 때 도입 효과를 비교해요.
+
+## 면접에서 이어질 수 있는 질문
+
+### Coder를 쓰면 서버의 JSON API에 바로 붙을 수 있나요
+
+아니에요. 값 직렬화뿐 아니라 Network의 메시지 프레이밍까지 서로 맞아야 해요. HTTP 서버에는 URLSession을 사용해요.
+
+### send와 receive에 await가 있으면 MainActor를 막지 않나요
+
+네트워크를 기다리는 동안에는 작업이 실행을 양보할 수 있어요. 하지만 같은 액터에서 실행하는 대량의 동기 파싱·변환까지 자동으로 다른 실행 영역으로 옮겨 주지는 않아요.
+
+### 새 API를 쓰면 취소와 재시도가 모두 해결되나요
+
+연결과 작업 수명의 연결은 쉬워지지만 업무 정책은 남아요. 시간 제한, 사용자 취소, 재시도와 중복 처리 방지, 응답 검증은 앱과 서버가 함께 정해야 해요.
+
+## 참고 자료
+
+- [WWDC25 — Use structured concurrency with Network framework](https://developer.apple.com/videos/play/wwdc2025/250/)
+- [Apple Developer — NetworkConnection](https://developer.apple.com/documentation/network/networkconnection)
+- [Apple Developer — withNetworkConnection(to:using:_:)](<https://developer.apple.com/documentation/network/withnetworkconnection(to:using:_:)-887ho>)
+- [Apple Developer — NetworkListener](https://developer.apple.com/documentation/network/networklistener)
+- [Apple Developer — NetworkBrowser](https://developer.apple.com/documentation/network/networkbrowser)
+- [Apple Developer — TLV](https://developer.apple.com/documentation/network/tlv)
+- [Apple Developer — Coder](https://developer.apple.com/documentation/network/coder)
+- [Apple Developer — Creating an Identity for Local Network TLS](https://developer.apple.com/documentation/network/creating-an-identity-for-local-network-tls)


### PR DESCRIPTION
## Summary

Apple의 Network 공식 문서와 WWDC25를 바탕으로 네트워크 학습 섹션과 문서 5개를 추가합니다. HTTP용 URLSession과 직접 연결용 Network의 역할을 구분하고, 기존 NW 계열 API와 iOS 26의 Swift Concurrency API를 각각 설명합니다.

## Changes

- `Network 시작하기`: 네트워크 용어, API 선택 기준, 프로토콜 구성, 지원 OS와 학습 순서를 정리합니다.
- `NWConnection과 메시지 경계`: 연결 상태, TCP 메시지 구분, UTF-8 조각 복원, 응답 크기 제한, 시간 제한, 취소를 구현합니다.
- `Swift Concurrency 네트워킹`: `NetworkConnection`·`NetworkListener`·`NetworkBrowser`, TLS·TLV·Coder, 구조적 동시성과 취소를 설명하고 루프백 요청·응답 예제를 제공합니다.
- `네트워크 경로 관찰`: `NWPathMonitor`의 콜백/AsyncSequence, SwiftUI 관찰 모델, 비용·저데이터 모드 정책과 실제 요청 성공의 차이를 정리합니다.
- `Bonjour와 로컬 네트워크`: 검색 화면, 서비스 엔드포인트, TLS identity를 받는 광고 구성, Info.plist, 로컬 네트워크 권한과 multicast entitlement를 설명합니다.
- 상단 내비게이션과 좌측 목차에 한국어 `네트워크` 섹션을 연결하고, 하위 그룹은 기본 닫힘으로 구성합니다.
- 학습 문서 형식에 맞춰 선행 용어·단계별 Swift 예제·비교·적용 기준·면접 질문·공식 참고 자료와 description을 포함합니다.

## Testing

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] 문서의 Swift 코드 블록 27개를 임시 Swift 패키지에 추출하고, 문서 내 테스트 8개와 추가 검증 테스트 10개를 실행해 총 18개 통과
- [x] Swift 6 언어 모드와 Xcode 26.4 SDK로 전체 비테스트 예제를 iOS 17 Simulator 타깃에서 타입 검사; 신규 API 예제에는 iOS 26 availability 적용
- [x] 루프백 통신으로 UTF-8 분할 응답, 불완전한 EOF, 응답 시간 제한, 중복 취소, Coder 왕복 통신, 취소 가능한 수신과 경로 관찰 종료 확인
- [x] 5개 문서의 description·상대 링크와 생성 HTML의 내부 앵커 145개 검사
- [x] 로컬 브라우저에서 5개 페이지 이동, 한국어 목차, 그룹 기본 접힘/펼침, Swift 코드와 표 렌더링 확인; 가로 넘침·브라우저 오류 없음

## Related Issues

Closes #63

## Notes

- 주요 자료: [Apple Network](https://developer.apple.com/documentation/network), [TN3151: Choosing the right networking API](https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api), [WWDC25: Use structured concurrency with Network framework](https://developer.apple.com/videos/play/wwdc2025/250/), [TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy).
- 일반 예제는 iOS 17+, 새 연결 API 예제는 iOS 26+를 기준으로 하며 기본 액터 격리는 `nonisolated`입니다. Swift 예제는 공식 샘플의 번역이 아닌 학습용 작성 코드입니다.
- 통신 실행 검증은 macOS의 `127.0.0.1` 루프백에서 수행했습니다. 실제 iOS 기기의 권한 프롬프트·권한 거부 복구, 기기 간 Bonjour 탐색 및 TLS 인증서/identity를 갖춘 연결은 실행 검증하지 않았습니다. 실기기 체크리스트를 문서에 명시했습니다.
- Bonjour의 TLS Listener 예제는 광고/연결 수락 구성 함수입니다. 수락된 연결의 소유·메시지 처리·시간 제한·종료는 호출자 책임임을 구분합니다.
- 개발 서버에서 기존 Rspack persistent cache의 `Directory not empty` 경고가 나타났으나 렌더링은 정상이며, 프로덕션 빌드는 통과했습니다. 관련 없는 캐시 설정은 수정하지 않았습니다.
- 테스트 패키지와 빌드 산출물은 커밋에 포함하지 않습니다. 화면은 로컬 브라우저로 확인했으며 PR용 스크린샷은 별도 첨부가 필요합니다.
