### PR TITLE
[docs] Rx 생태계 문서를 모듈별 세부 섹션으로 확장한다

### DIFF
--- a/docs/guide/rxswift/_meta.json
+++ b/docs/guide/rxswift/_meta.json
@@ -6,6 +6,29 @@
   },
   {
     "type": "custom-link",
+    "label": "핵심 모듈",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "RxSwift 핵심 구조",
+        "link": "/guide/rxswift/rxswift-core"
+      },
+      {
+        "type": "custom-link",
+        "label": "RxCocoa UI 바인딩",
+        "link": "/guide/rxswift/rxcocoa"
+      },
+      {
+        "type": "custom-link",
+        "label": "RxRelay 상태와 이벤트",
+        "link": "/guide/rxswift/rxrelay"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
     "label": "모든 연산자",
     "collapsible": true,
     "collapsed": true,

--- a/docs/guide/rxswift/_meta.json
+++ b/docs/guide/rxswift/_meta.json
@@ -6,10 +6,20 @@
   },
   {
     "type": "custom-link",
-    "label": "핵심 모듈",
+    "label": "공식 API 범위와 학습 순서",
+    "link": "/guide/rxswift/official-api-inventory"
+  },
+  {
+    "type": "custom-link",
+    "label": "RxSwift",
     "collapsible": true,
     "collapsed": true,
     "items": [
+      {
+        "type": "custom-link",
+        "label": "설치와 모듈 구성",
+        "link": "/guide/rxswift/installation-and-modules"
+      },
       {
         "type": "custom-link",
         "label": "RxSwift 핵심 구조",
@@ -17,13 +27,107 @@
       },
       {
         "type": "custom-link",
-        "label": "RxCocoa UI 바인딩",
+        "label": "Observable·Observer·Event",
+        "link": "/guide/rxswift/observable-observer-event"
+      },
+      {
+        "type": "custom-link",
+        "label": "Disposable과 자원",
+        "link": "/guide/rxswift/disposables-and-resources"
+      },
+      {
+        "type": "custom-link",
+        "label": "Scheduler와 동시성",
+        "link": "/guide/rxswift/schedulers-and-concurrency"
+      },
+      {
+        "type": "custom-link",
+        "label": "Subject와 Traits",
+        "link": "/guide/rxswift/subjects-and-traits"
+      },
+      {
+        "type": "custom-link",
+        "label": "디버깅과 사용자 정의 연산자",
+        "link": "/guide/rxswift/debugging-hooks-and-custom-operators"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "RxCocoa",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "RxCocoa 시작하기",
         "link": "/guide/rxswift/rxcocoa"
       },
       {
         "type": "custom-link",
-        "label": "RxRelay 상태와 이벤트",
+        "label": "Reactive·Binder·Control Traits",
+        "link": "/guide/rxswift/reactive-binder-control-traits"
+      },
+      {
+        "type": "custom-link",
+        "label": "Driver·Signal·SharedSequence",
+        "link": "/guide/rxswift/driver-signal-shared-sequence"
+      },
+      {
+        "type": "custom-link",
+        "label": "UIKit 컨트롤 바인딩",
+        "link": "/guide/rxswift/uikit-control-bindings"
+      },
+      {
+        "type": "custom-link",
+        "label": "리스트와 DelegateProxy",
+        "link": "/guide/rxswift/list-bindings-and-delegate-proxy"
+      },
+      {
+        "type": "custom-link",
+        "label": "Foundation 바인딩",
+        "link": "/guide/rxswift/foundation-bindings"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "RxRelay",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "RxRelay 시작하기",
         "link": "/guide/rxswift/rxrelay"
+      },
+      {
+        "type": "custom-link",
+        "label": "Relay 종류와 replay",
+        "link": "/guide/rxswift/relay-types-and-replay"
+      },
+      {
+        "type": "custom-link",
+        "label": "상태 Store와 동시성",
+        "link": "/guide/rxswift/relay-state-store-and-concurrency"
+      }
+    ]
+  },
+  {
+    "type": "custom-link",
+    "label": "Rx 테스트",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "RxTest 가상 시간",
+        "link": "/guide/rxswift/rxtest"
+      },
+      {
+        "type": "custom-link",
+        "label": "RxBlocking 동기 검사",
+        "link": "/guide/rxswift/rxblocking"
       }
     ]
   },

--- a/docs/guide/rxswift/debugging-hooks-and-custom-operators.md
+++ b/docs/guide/rxswift/debugging-hooks-and-custom-operators.md
@@ -1,0 +1,251 @@
+---
+title: RxSwift 디버깅, Hooks와 사용자 정의 연산자
+description: debug·do 연산자, 처리하지 않은 오류 Hooks, Resources 누수 추적, 재진입·동기화 경고와 안전한 사용자 정의 연산자 작성 기준을 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Tips.md
+reviewed: '2026-09-06'
+---
+
+# RxSwift 디버깅, Hooks와 사용자 정의 연산자
+
+> **면접 답변 한 줄 요약:** Rx 파이프라인은 `debug`와 `do`로 이벤트·구독 수명을 관찰하고, 처리하지 않은 오류는 Hooks에서 기록하며, 반복 조합은 기존 연산자를 감싼 사용자 정의 연산자로 추출하는 것이 안전해요.
+
+Rx 코드는 선언적으로 보이지만 실제 문제는 구독 횟수, 이벤트 실행 스레드, 종료·폐기 순서에서 생겨요. 값을 `print`하는 것만으로는 소스가 두 번 구독됐는지, 오류로 끝났는지, 소비자가 취소했는지 구분하기 어려워요.
+
+## `debug`로 전체 이벤트와 수명을 봐요
+
+```swift
+api.loadProfile()
+  .debug("profile", trimOutput: true)
+  .subscribe(
+    onNext: { profile in
+      print(profile.name)
+    },
+    onError: { error in
+      print(error)
+    }
+  )
+  .disposed(by: disposeBag)
+```
+
+`debug`는 보통 다음 정보를 출력해요.
+
+- subscribed
+- next 이벤트와 값
+- error 또는 completed
+- isDisposed
+
+같은 identifier가 두 번 subscribed되면 cold 요청을 중복 구독했을 가능성을 찾을 수 있어요. 값이 크거나 개인정보가 포함되면 `trimOutput`과 로그 정책을 사용하고 운영 로그에 원문을 남기지 마세요.
+
+## `do`는 이벤트를 바꾸지 않고 관찰해요
+
+```swift
+let profile = api.loadProfile()
+  .do(
+    onNext: { profile in
+      metrics.markLoaded(profile.id)
+    },
+    onError: { error in
+      metrics.markFailed(error)
+    },
+    onSubscribe: {
+      metrics.markStarted()
+    },
+    onDispose: {
+      metrics.markFinished()
+    }
+  )
+```
+
+`do`는 원래 이벤트를 그대로 통과시키며 로깅·측정 같은 부수 효과를 삽입해요. `map` 안에서 로그와 상태 변경을 함께 하는 것보다 의도가 드러나지만, `do`에 비즈니스 상태 전이를 숨기면 테스트와 재사용이 어려워져요.
+
+| 목적                         | 도구              |
+| ---------------------------- | ----------------- |
+| 이벤트·구독 전체를 콘솔 확인 | `debug`           |
+| 특정 이벤트에서 측정·로깅    | `do`              |
+| 오류를 복구                  | `catch`, `retry`  |
+| 오류를 값으로 검사           | `materialize`     |
+| 자원 할당 추세 확인          | `Resources.total` |
+
+## 처리하지 않은 오류는 Hooks로 들어가요
+
+`subscribe`에서 `onError`를 제공하지 않은 상태로 오류가 도착하면 `Hooks.defaultErrorHandler`가 호출돼요.
+
+```swift
+Hooks.recordCallStackOnError = true
+
+Hooks.defaultErrorHandler = { subscriptionCallStack, error in
+  logger.record(
+    error: error,
+    subscriptionCallStack: subscriptionCallStack
+  )
+}
+```
+
+`recordCallStackOnError`를 켜면 구독 시점의 호출 스택을 캡처해 처리되지 않은 오류가 어디에서 시작됐는지 찾을 수 있어요. 비용이 있으므로 빌드 환경과 진단 목적에 맞게 사용하세요.
+
+Hooks는 프로세스 전체에 영향을 주는 전역 설정이에요. 앱 시작 시 한 번 구성하고, 테스트마다 바꾼다면 원래 값을 복구해 다른 테스트에 영향을 주지 않게 하세요. Hooks를 설정했다고 각 파이프라인의 오류 복구 정책을 생략하면 안 돼요.
+
+## Rx 동기화 경고를 원인부터 해결해요
+
+디버그 빌드에서 Subject가 이벤트 처리를 끝내기 전에 같은 Subject로 다시 이벤트를 보내거나, 서로 다른 스레드가 동시에 이벤트를 보내면 재진입·동기화 anomaly 경고가 나타날 수 있어요.
+
+```swift
+let subject = PublishSubject<Int>()
+
+subject
+  .subscribe(onNext: { value in
+    if value < 3 {
+      subject.onNext(value + 1)
+    }
+  })
+  .disposed(by: disposeBag)
+
+subject.onNext(0)
+```
+
+이런 순환은 이벤트가 겹치고 호출 스택이 깊어질 수 있어요. 상태 전이를 `scan`으로 바꾸거나, 의도적인 비동기 경계라면 serial Scheduler에 enqueue하세요. 경고만 숨기는 Scheduler 전환보다 순환 의존성을 제거할 수 있는지 먼저 확인해야 해요.
+
+## Resources.total로 누수 추세를 확인해요
+
+`TRACE_RESOURCES`를 활성화한 RxSwift 빌드에서는 `Resources.total`이 Observable, Observer, Disposable 같은 내부 자원 수를 제공해요.
+
+```swift
+#if TRACE_RESOURCES
+let baseline = Resources.total
+print("Rx 기준값:", baseline)
+#endif
+```
+
+화면 진입·종료를 반복하고 비동기 정리가 끝난 뒤 수치가 계속 증가하는지 봐요. 한 번의 앞뒤 값만 비교하면 캐시와 전역 스트림을 누수로 오인할 수 있으므로 반복 추세, Memory Graph, deinit 로그를 함께 확인하세요.
+
+## RxError는 연산자 계약 위반을 표현해요
+
+`RxError`에는 요소가 없거나 둘 이상인 경우, 인자 범위 오류, 시간 초과, 이미 폐기된 자원 같은 Rx 계층의 공통 오류가 포함돼요. 예를 들어 값 둘인 Observable을 `asSingle()`로 바꾸면 “첫 값을 선택”하지 않고 요소 개수 계약 위반으로 실패해요.
+
+도메인 오류를 전부 RxError로 바꾸지 마세요. RxError는 스트림 연산 자체의 조건을 설명하고, 인증 실패·재고 부족 같은 비즈니스 오류는 도메인 오류나 상태로 유지하는 편이 좋아요.
+
+## 중첩 subscribe를 연산자로 바꿔요
+
+다음 구조는 내부 구독의 오류와 Disposable을 따로 관리해야 해서 복잡해져요.
+
+```swift
+query
+  .subscribe(onNext: { query in
+    api.search(query: query)
+      .subscribe(onNext: { result in
+        print(result)
+      })
+      .disposed(by: disposeBag)
+  })
+  .disposed(by: disposeBag)
+```
+
+연산자로 평탄화하면 최신 요청 취소, 오류, 완료가 하나의 체인에 남아요.
+
+```swift
+query
+  .flatMapLatest { query in
+    api.search(query: query)
+  }
+  .subscribe(onNext: { result in
+    print(result)
+  })
+  .disposed(by: disposeBag)
+```
+
+공식 Tips 문서도 subscribe를 중첩하지 말고 내장 연산자를 조합하라고 권장해요.
+
+## 반복 조합은 사용자 정의 연산자로 추출해요
+
+도메인 여러 곳에서 같은 조합을 반복한다면 `ObservableType` 확장으로 이름을 붙일 수 있어요.
+
+```swift
+extension ObservableType where Element == String? {
+  func nonEmptyText() -> Observable<String> {
+    compactMap { text in
+      guard let text else {
+        return nil
+      }
+
+      let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      return trimmed.isEmpty ? nil : trimmed
+    }
+    .distinctUntilChanged()
+  }
+}
+```
+
+좋은 사용자 정의 연산자는 다음 성질을 가져요.
+
+- 입력과 출력 계약이 이름과 타입에서 보여요.
+- 기존 연산자를 조합해 오류·완료·폐기 의미를 보존해요.
+- 내부에서 몰래 subscribe하지 않아요.
+- Scheduler를 불필요하게 고정하지 않아요.
+- hot으로 바꾸거나 replay하는 등 공유 의미를 숨기지 않아요.
+
+직접 `Observable.create`로 연산자를 만들기 전에 `map`, `flatMap`, `materialize`, `share` 조합으로 표현할 수 있는지 확인하세요.
+
+## 사용자 정의 연산자를 테스트해요
+
+```swift
+func testNonEmptyText() {
+  let scheduler = TestScheduler(initialClock: 0)
+  let source = scheduler.createColdObservable([
+    .next(10, "  "),
+    .next(20, " Rx "),
+    .next(30, "Rx"),
+    .completed(40),
+  ])
+
+  let result = scheduler.start {
+    source.nonEmptyText()
+  }
+
+  XCTAssertEqual(
+    result.events,
+    [
+      .next(220, "Rx"),
+      .completed(240),
+    ]
+  )
+}
+```
+
+값뿐 아니라 완료·오류 시간과 source subscriptions도 검증하면 폐기 계약이 깨진 구현을 찾을 수 있어요.
+
+## 자주 하는 실수
+
+- 운영 로그에 전체 사용자 데이터가 포함된 `debug()` 출력을 남겨요.
+- `do` 안에서 숨은 상태 전이와 추가 subscribe를 만들어요.
+- 전역 Hooks가 오류를 기록하므로 로컬 오류 처리를 생략해요.
+- 동기화 경고를 무조건 무시하거나 Scheduler 하나로 덮어요.
+- 사용자 정의 연산자 내부에서 subscribe해 취소와 오류를 분리해요.
+- Resources.total의 일시적 증가 하나만 보고 누수라고 단정해요.
+
+## 적용 체크리스트
+
+- 중복 구독 여부를 `debug`의 subscribed 로그로 확인했나요?
+- 측정용 `do`가 스트림 의미를 바꾸지 않나요?
+- 모든 실패 가능한 구독에 의도적인 오류 처리 경로가 있나요?
+- 전역 Hooks 설정을 앱 시작 한곳에서 관리하나요?
+- 재진입·동기화 경고의 순환 또는 동시 입력 원인을 찾았나요?
+- 사용자 정의 연산자가 기존 연산자로 조합되고 독립 테스트되나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `debug`와 `do`의 차이는 무엇인가요?
+
+`debug`는 구독과 모든 이벤트를 정해진 형식으로 출력하는 진단 연산자이고, `do`는 선택한 생명 주기 지점에 사용자 부수 효과를 넣어요. 둘 다 원래 이벤트를 변환하지 않아요.
+
+### 처리하지 않은 Rx 오류는 어떻게 되나요?
+
+subscribe에 onError가 없으면 `Hooks.defaultErrorHandler`가 호출돼요. 전역 기록의 마지막 안전망일 뿐이므로 복구나 사용자 상태 변환은 각 파이프라인 경계에서 처리해야 해요.
+
+## 참고 자료
+
+- [RxSwift Tips](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Tips.md)
+- [RxSwift Warnings](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Warnings.md)
+- [Hooks 공식 API](https://docs.rxswift.org/enums/hooks)
+- [Resources 공식 API](https://docs.rxswift.org/enums/resources)
+- [debug 연산자 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxSwift/Observables/Debug.swift)
+- [Unit Tests 공식 문서](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/UnitTests.md)

--- a/docs/guide/rxswift/disposables-and-resources.md
+++ b/docs/guide/rxswift/disposables-and-resources.md
@@ -1,0 +1,204 @@
+---
+title: Disposable과 Rx 자원 수명 관리
+description: Disposable, DisposeBag, CompositeDisposable, SerialDisposable 등 RxSwift의 폐기 타입을 소유권 상황별로 비교하고 자원 누수와 취소 경계를 설명합니다.
+source: https://docs.rxswift.org/rxswift/disposables
+reviewed: '2026-09-06'
+---
+
+# Disposable과 Rx 자원 수명 관리
+
+> **면접 답변 한 줄 요약:** Disposable은 구독 연결과 기반 작업을 취소하는 소유권 토큰이며, DisposeBag은 객체 수명, SerialDisposable은 교체 가능한 작업, CompositeDisposable은 동적으로 추가·제거하는 작업 묶음에 맞춰 사용해요.
+
+RxSwift에서 메모리 누수와 불필요한 작업은 서로 다른 문제예요. 객체가 해제되더라도 네트워크·타이머가 계속 돌 수 있고, 작업은 끝났어도 강한 캡처 때문에 화면이 남을 수 있어요. Disposable과 참조 관계를 함께 점검해야 해요.
+
+## Disposable은 취소 가능한 연결이에요
+
+```swift
+public protocol Disposable {
+  func dispose()
+}
+```
+
+`dispose()`는 여러 번 호출해도 한 번 정리한 자원을 다시 정리하지 않는 방식으로 구현돼야 해요. 구독이 `.completed`나 `.error`로 끝나면 Rx 체인도 자원을 정리하지만, 끝나지 않는 UI 이벤트와 타이머는 소비자가 명시적으로 폐기해야 해요.
+
+```swift
+let disposable = Observable<Int>
+  .interval(
+    .seconds(1),
+    scheduler: MainScheduler.instance
+  )
+  .subscribe(onNext: { value in
+    print(value)
+  })
+
+disposable.dispose()
+```
+
+`dispose()`는 Observer에게 `.completed`를 보내는 API가 아니에요. 더는 이벤트를 받지 않고 연결 자원을 정리하겠다는 소비자 동작이에요.
+
+## DisposeBag은 객체 수명에 구독을 묶어요
+
+```swift
+final class SearchViewController: UIViewController {
+  private let disposeBag = DisposeBag()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    searchBar.rx.text.orEmpty
+      .bind(to: viewModel.query)
+      .disposed(by: disposeBag)
+  }
+}
+```
+
+View Controller가 해제되면 bag도 해제되고 내부 Disposable이 모두 폐기돼요. 다음 두 조건이 모두 성립해야 화면도 정상 해제돼요.
+
+1. 화면 수명에 속한 구독이 화면의 DisposeBag에 들어 있어요.
+2. 구독 클로저가 화면을 강하게 캡처해 `화면 → bag → 구독 → 화면` 순환을 만들지 않아요.
+
+```swift
+viewModel.title
+  .subscribe(with: self) { owner, title in
+    owner.titleLabel.text = title
+  }
+  .disposed(by: disposeBag)
+```
+
+`subscribe(with:)`나 `withUnretained`는 소유자를 비보유로 전달할 때 유용해요. 비동기 이벤트가 owner 해제 뒤 조용히 무시돼도 되는지 도메인 의미를 함께 확인하세요.
+
+## DisposeBag을 교체하면 이전 묶음을 한 번에 취소해요
+
+재사용 셀이나 다시 바인딩되는 화면은 bag을 교체할 수 있어요.
+
+```swift
+final class ProductCell: UITableViewCell {
+  var disposeBag = DisposeBag()
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
+}
+```
+
+기존 bag의 참조가 사라지면서 이전 모델에 연결된 구독이 폐기돼요. 화면이 다시 나타날 때마다 bag을 바꾸는 패턴을 쓴다면, 고정 구독까지 중복 생성하지 않는지 확인하세요.
+
+## 상황별 Disposable 타입을 구분해요
+
+| 타입                         | 핵심 동작                                                    | 대표 상황                        |
+| ---------------------------- | ------------------------------------------------------------ | -------------------------------- |
+| `BooleanDisposable`          | 폐기 여부를 `isDisposed`로 확인하는 단순 토큰이에요.         | 사용자 정의 작업의 취소 플래그   |
+| `SingleAssignmentDisposable` | 기반 Disposable을 한 번만 나중에 지정할 수 있어요.           | 구독 생성 중 재진입 가능한 구현  |
+| `SerialDisposable`           | 새 Disposable을 대입하면 이전 것을 즉시 폐기해요.            | 최신 요청 하나만 유지            |
+| `CompositeDisposable`        | 여러 Disposable을 동적으로 추가·제거하고 함께 폐기해요.      | 작업 집합의 부분 취소            |
+| `RefCountDisposable`         | 기본 자원과 모든 종속 토큰이 폐기된 뒤 실제 자원을 정리해요. | 여러 소비자가 공유하는 기반 자원 |
+| `ScheduledDisposable`        | 지정한 Scheduler에서 기반 Disposable을 폐기해요.             | 해제 스레드 제약이 있는 자원     |
+| `DisposeBag`                 | 자신이 deinit될 때 보관한 모든 Disposable을 폐기해요.        | 객체 수명에 맞춘 일반 구독 관리  |
+| `Disposables.create`         | 하나 이상의 정리 클로저·Disposable을 하나의 토큰으로 묶어요. | 사용자 정의 Observable 정리      |
+
+앱 코드에서는 대부분 DisposeBag으로 충분하고, 나머지는 인프라나 사용자 정의 연산자에서 더 자주 사용해요.
+
+## SerialDisposable로 최신 작업을 교체해요
+
+```swift
+let currentRequest = SerialDisposable()
+
+currentRequest.disposable = api
+  .search(query: "Swift")
+  .subscribe(onNext: { print($0) })
+
+currentRequest.disposable = api
+  .search(query: "RxSwift")
+  .subscribe(onNext: { print($0) })
+```
+
+두 번째 Disposable을 대입하는 순간 첫 번째 구독이 폐기돼요. 검색 입력처럼 최신 작업만 필요할 때 쓸 수 있지만, 보통 `flatMapLatest`가 값 흐름과 취소 관계를 더 선언적으로 보여 줘요.
+
+SerialDisposable 자체를 이미 폐기한 뒤 새 Disposable을 대입하면 새 값도 즉시 폐기돼요. 소유 객체가 끝난 뒤 작업이 다시 살아나지 않는다는 장점이 있어요.
+
+## CompositeDisposable은 동적 작업 집합을 관리해요
+
+```swift
+let subscriptions = CompositeDisposable()
+
+subscriptions.insert(
+  notifications.subscribe(onNext: { print($0) })
+)
+subscriptions.insert(
+  locationUpdates.subscribe(onNext: { print($0) })
+)
+
+subscriptions.dispose()
+```
+
+각 `insert`가 돌려주는 키를 보관하면 특정 Disposable만 `remove(for:)`로 제거하고 폐기할 수 있어요. 고정된 구독 묶음이라면 DisposeBag이 더 단순하고, 실행 중 구독이 자주 추가·제거되는 관리자라면 CompositeDisposable이 어울려요.
+
+## 사용자 정의 Observable은 실제 자원을 정리해요
+
+```swift
+let observable = Observable<Void>.create { observer in
+  let token = NotificationCenter.default.addObserver(
+    forName: UIApplication.didBecomeActiveNotification,
+    object: nil,
+    queue: nil
+  ) { _ in
+    observer.onNext(())
+  }
+
+  return Disposables.create {
+    NotificationCenter.default.removeObserver(token)
+  }
+}
+```
+
+빈 `Disposables.create()`만 반환하면 구독 객체는 정리돼도 NotificationCenter observer 같은 외부 자원은 남을 수 있어요. Timer, URLSessionTask, 파일 핸들, delegate 등록마다 대응하는 취소·해제 동작을 연결하세요.
+
+## Resources.total로 개발 중 누수를 추적해요
+
+공식 `Resources.total`은 Observable, Observer, Disposable 등 내부 Rx 자원 할당 수를 세어 개발 중 누수 신호를 찾는 데 사용할 수 있어요. `TRACE_RESOURCES` 빌드 플래그가 필요한 구성인지 프로젝트의 RxSwift 통합 방식을 확인하세요.
+
+일반적인 검사는 다음과 같아요.
+
+1. 테스트할 화면 진입 전 `Resources.total`을 기록해요.
+2. 화면에 들어가 이벤트를 발생시켜요.
+3. 화면을 닫고 비동기 정리가 끝난 뒤 다시 기록해요.
+4. 진입·종료를 반복할 때 기준값이 계속 증가하는지 관찰해요.
+
+수치가 즉시 같아야 한다고 단정하지 마세요. 전역 공유 시퀀스, 캐시, 비동기 정리처럼 의도적으로 오래 사는 자원도 있으므로 반복 실행의 추세와 객체 메모리 그래프를 함께 봐야 해요.
+
+## 자주 하는 실수
+
+- `subscribe`가 반환한 Disposable을 사용하지 않아요.
+- 전역 DisposeBag에 화면 구독을 넣어 화면보다 오래 유지해요.
+- `[weak self]`만 붙이면 기반 네트워크 작업도 자동 취소된다고 생각해요.
+- DisposeBag 안의 구독 클로저가 bag 소유자를 강하게 잡아요.
+- `dispose()`가 정상 완료 콜백을 호출한다고 기대해요.
+- 사용자 정의 Observable이 등록한 외부 observer와 timer를 정리하지 않아요.
+
+## 적용 체크리스트
+
+- 구독의 소유자와 기대 수명을 한 문장으로 설명할 수 있나요?
+- 끝나지 않는 스트림이 반드시 Disposable에 연결되나요?
+- 객체 수명, 최신 작업, 동적 작업 집합 중 맞는 컨테이너를 골랐나요?
+- 폐기할 때 실제 기반 작업도 취소되나요?
+- 클로저 캡처 그래프에 순환이 없나요?
+- 반복 진입 테스트에서 Rx 자원과 객체 수가 계속 증가하지 않나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### DisposeBag과 CompositeDisposable은 무엇이 다른가요?
+
+DisposeBag은 자신의 deinit 시점에 내부 구독을 모두 폐기하는 객체 수명 컨테이너예요. CompositeDisposable은 실행 중 개별 Disposable을 키로 추가·제거하고 명시적으로 전체 폐기할 수 있는 동적 집합이에요.
+
+### 약한 캡처와 dispose는 같은 문제를 해결하나요?
+
+아니요. 약한 캡처는 객체 참조 순환을 막고, dispose는 이벤트 연결과 기반 작업을 중단해요. 안전한 수명 관리를 위해 둘 다 필요한 경우가 많아요.
+
+## 참고 자료
+
+- [RxSwift Disposables 공식 API](https://docs.rxswift.org/rxswift/disposables)
+- [DisposeBag 공식 API](https://docs.rxswift.org/classes/disposebag)
+- [Disposable 공식 API](https://docs.rxswift.org/protocols/disposable)
+- [RxSwift Warnings](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Warnings.md)
+- [Resources 공식 API](https://docs.rxswift.org/enums/resources)

--- a/docs/guide/rxswift/driver-signal-shared-sequence.md
+++ b/docs/guide/rxswift/driver-signal-shared-sequence.md
@@ -1,0 +1,236 @@
+---
+title: Driver, Signal과 SharedSequence
+description: RxCocoa SharedSequence의 Scheduler·공유 전략과 Driver·Signal의 replay 차이, 변환 오류 정책, drive·emit 사용 기준을 UI 상태와 사건 예제로 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md#rxcocoa-traits
+reviewed: '2026-09-06'
+---
+
+# Driver, Signal과 SharedSequence
+
+> **면접 답변 한 줄 요약:** Driver는 오류 없이 메인에서 최신 상태 1개를 공유하고, Signal은 같은 메인·오류 없음 계약을 가지면서 과거 사건을 replay하지 않는 SharedSequence예요.
+
+Driver와 Signal은 “Observable의 다른 실행 엔진”이 아니에요. `SharedSequence<Strategy, Element>`가 Strategy에 정의된 Scheduler와 공유 방식을 적용한 RxCocoa Trait이에요.
+
+## SharedSequence가 보장하는 것
+
+`SharingStrategyProtocol`은 두 가지를 정해요.
+
+1. 이벤트를 관찰할 Scheduler
+2. 하나의 업스트림을 Subscriber들이 공유하는 방식
+
+```text
+Observable
+  └─ asSharedSequence(error policy)
+       ├─ Strategy.scheduler
+       └─ Strategy.share(source)
+```
+
+SharedSequence는 오류를 타입에서 제거해요. 일반 Observable을 변환할 때는 오류를 어떤 값이나 다른 SharedSequence로 바꿀지 반드시 결정해야 해요.
+
+## Driver의 세 계약
+
+공식 Driver 구현은 다음 성질을 명시해요.
+
+- 오류를 보내지 않아요.
+- `MainScheduler.instance`에서 이벤트를 관찰해요.
+- `share(replay: 1, scope: .whileConnected)` 전략으로 부수 효과를 공유해요.
+
+```swift
+let title: Driver<String> = titleService.load()
+  .asDriver(onErrorJustReturn: "제목을 불러오지 못했어요")
+
+title
+  .drive(titleLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+Subscriber가 한 명 이상 연결된 동안 최신 값을 하나 기억하고 새 Subscriber에게 즉시 보내요. 모든 Subscriber가 사라지면 연결과 해당 replay 상태를 정리해요.
+
+## Signal의 세 계약
+
+Signal은 다음 성질을 가져요.
+
+- 오류를 보내지 않아요.
+- `MainScheduler.instance`에서 이벤트를 관찰해요.
+- `share(scope: .whileConnected)`로 공유하며 새 Subscriber에게 과거 값을 replay하지 않아요.
+
+```swift
+let message: Signal<String> = messageRelay.asSignal()
+
+message
+  .emit(onNext: { [weak self] text in
+    self?.showToast(text)
+  })
+  .disposed(by: disposeBag)
+```
+
+토스트, 화면 이동, 햅틱처럼 “지금 한 번 실행”해야 하는 명령형 사건에 적합해요.
+
+## Driver와 Signal을 비교해요
+
+| 항목             | Driver           | Signal           |
+| ---------------- | ---------------- | ---------------- |
+| 오류             | 없음             | 없음             |
+| 관찰 Scheduler   | 메인             | 메인             |
+| 업스트림 공유    | 연결된 동안 공유 | 연결된 동안 공유 |
+| 새 구독자 replay | 최신 값 1개      | 없음             |
+| 전용 구독 API    | `drive`          | `emit`           |
+| 대표 의미        | 현재 UI 상태     | 일회성 UI 사건   |
+
+“화면에 쓰면 모두 Driver”로 정하지 말고 replay가 맞는지 판단하세요. 화면이 다시 바인딩될 때 현재 로딩·목록 상태는 필요하지만, 과거의 alert 표시 사건은 다시 실행하면 안 돼요.
+
+## 오류 변환 정책을 선택해요
+
+일반 Observable을 Driver로 바꾸는 대표 방식은 세 가지예요.
+
+```swift
+let fallback = source.asDriver(
+  onErrorJustReturn: State.failed
+)
+
+let replacement = source.asDriver(
+  onErrorDriveWith: cachedState
+)
+
+let recovered = source.asDriver { error in
+  logger.record(error)
+  return .just(.failed)
+}
+```
+
+| 변환                    | 적합한 상황                               |
+| ----------------------- | ----------------------------------------- |
+| `onErrorJustReturn`     | 항상 같은 대체 값 하나면 충분해요.        |
+| `onErrorDriveWith`      | 캐시 Driver 등 준비된 대체 흐름이 있어요. |
+| `onErrorRecover` 클로저 | 오류 기록과 종류별 대체 정책이 필요해요.  |
+
+Signal도 같은 형태의 `asSignal` 오류 변환을 제공해요. 오류 없음은 “실패가 사라졌다”가 아니라 **실패를 변환 경계에서 처리했다**는 계약이어야 해요.
+
+## 상태 enum으로 실패 의미를 보존해요
+
+```swift
+enum ProfileState {
+  case idle
+  case loading
+  case loaded(Profile)
+  case failed(String)
+}
+
+let state: Driver<ProfileState> = reload
+  .flatMapLatest {
+    profileService.load()
+      .map(ProfileState.loaded)
+      .asDriver { error in
+        logger.record(error)
+        return .just(.failed("프로필을 불러오지 못했어요"))
+      }
+      .startWith(.loading)
+  }
+```
+
+오류를 빈 배열 하나로 바꾸면 “결과 없음”과 “통신 실패”가 합쳐질 수 있어요. UI가 구분해야 하는 실패는 상태의 case로 보존하세요.
+
+## ControlProperty와 Relay는 손실 없이 변환할 수 있어요
+
+ControlProperty는 이미 오류 없음과 메인 Scheduler 조건을 만족하므로 Driver로 바로 바꿀 수 있어요.
+
+```swift
+let query: Driver<String> = searchBar.rx.text.orEmpty
+  .asDriver()
+```
+
+BehaviorRelay와 PublishRelay도 RxCocoa가 전용 변환을 제공해요.
+
+```swift
+let stateDriver = stateRelay.asDriver()
+let eventSignal = eventRelay.asSignal()
+```
+
+이 변환은 외부에서 `accept`하는 쓰기 권한을 제거한 읽기 전용 UI 출력을 만드는 데 유용해요.
+
+## `drive`와 `emit`으로 의도를 드러내요
+
+```swift
+viewModel.state
+  .drive(with: self) { owner, state in
+    owner.render(state)
+  }
+  .disposed(by: disposeBag)
+
+viewModel.route
+  .emit(with: self) { owner, route in
+    owner.navigate(route)
+  }
+  .disposed(by: disposeBag)
+```
+
+전용 API는 오류 처리 클로저를 받지 않아요. Trait을 만들 때 오류가 제거됐기 때문이에요. 또한 공식 Driver 문서는 `drive*`, `subscribe*`, `bind*` 호출 자체를 메인 스레드에서 만들라고 안내해요. 초기 replay가 구독을 만든 스레드에서 즉시 일어날 수 있기 때문이에요.
+
+## 여러 UI가 하나의 Driver를 공유해요
+
+```swift
+let results: Driver<[Repository]> = query
+  .flatMapLatest { query in
+    api.search(query: query)
+      .asDriver(onErrorJustReturn: [])
+  }
+
+results
+  .drive(tableView.rx.items(cellIdentifier: "Cell"))
+  .disposed(by: disposeBag)
+
+results
+  .map { "\($0.count)개" }
+  .drive(countLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+하나의 Driver 값을 여러 UI가 구독해도 연결 중 업스트림 계산을 공유해요. 단, 모든 Subscriber가 사라졌다가 다시 연결되면 `.whileConnected` 정책에 따라 cold 요청이 새로 시작될 수 있어요. 영구 캐시가 필요한 경우 별도 저장소를 사용하세요.
+
+## SharedSequence와 async/await를 연결해요
+
+Driver와 Signal은 오류가 없으므로 `values`를 `for await`로 읽을 수 있어요.
+
+```swift
+for await state in stateDriver.values {
+  await auditStore.append(state)
+}
+```
+
+UI 바인딩만을 위해 Driver를 async로 바꿀 필요는 없어요. 기존 async 소비자와 만나는 adapter 경계에서 사용하고 Task 취소가 Rx 구독을 끝내는지 확인하세요.
+
+## 자주 하는 실수
+
+- 모든 UI 출력을 Driver로 만들어 과거 사건을 replay해요.
+- `asDriver(onErrorJustReturn: [])`로 실패와 빈 결과를 합쳐요.
+- Driver를 영구 메모리·디스크 캐시로 생각해요.
+- 백그라운드에서 `drive`를 호출하고 초기 replay 위치를 놓쳐요.
+- Driver로 바꾼 뒤 다시 Observable과 Driver를 반복 변환해 계약을 흐려요.
+- 하나의 View Model 출력에서 별도 Driver를 여러 번 만들어 업스트림 공유 범위를 나눠요.
+
+## 적용 체크리스트
+
+- 출력이 상태인지 사건인지 정했나요?
+- 새 Subscriber가 최신 값을 받아야 하나요?
+- 오류가 대체 값·상태·대체 흐름 중 올바른 의미로 변환됐나요?
+- `drive`와 `emit` 구독을 메인에서 만들었나요?
+- Driver 연결이 모두 끊긴 뒤 재구독 동작을 이해했나요?
+- 영구 캐시는 별도 저장소가 담당하나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Driver가 네트워크 요청 중복을 막는 이유는 무엇인가요?
+
+DriverSharingStrategy가 `share(replay: 1, scope: .whileConnected)`를 사용해 연결된 Subscriber들이 하나의 업스트림 구독을 공유하기 때문이에요.
+
+### Signal도 현재 값을 보관하나요?
+
+아니요. Signal은 연결된 동안 업스트림을 공유하지만 새 Subscriber에게 과거 값을 replay하지 않아요. 현재 상태가 필요하면 Driver가 더 맞아요.
+
+## 참고 자료
+
+- [RxCocoa Traits 공식 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md#rxcocoa-traits)
+- [Driver 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/Driver/Driver.swift)
+- [Signal 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/Signal/Signal.swift)
+- [SharedSequence 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/SharedSequence/SharedSequence.swift)
+- [Driver 구독 API](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/Driver/Driver%2BSubscription.swift)

--- a/docs/guide/rxswift/foundation-bindings.md
+++ b/docs/guide/rxswift/foundation-bindings.md
@@ -1,0 +1,246 @@
+---
+title: RxCocoa Foundation 바인딩
+description: NotificationCenter, URLSession, NSObject KVO·메서드 interception·deallocated 등 RxCocoa Foundation 확장의 구독 수명, 오류와 swizzling 주의점을 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxCocoa/Foundation
+reviewed: '2026-09-06'
+---
+
+# RxCocoa Foundation 바인딩
+
+> **면접 답변 한 줄 요약:** RxCocoa는 NotificationCenter observer, URLSession task, KVO와 Objective-C 메시지를 Observable로 감싸며, dispose에서 등록을 해제하고 KVO 소유 관계·swizzling·구독별 네트워크 실행을 호출자가 이해해야 해요.
+
+RxCocoa는 UIKit뿐 아니라 Foundation 객체도 `.rx`로 연결해요. 이 API들은 기존 시스템 메커니즘을 감싼 것이므로 KVO와 NotificationCenter의 수명, URLSession의 HTTP 오류 기준이 사라지는 것은 아니에요.
+
+## NotificationCenter를 Observable로 바꿔요
+
+```swift
+NotificationCenter.default.rx
+  .notification(UIApplication.didEnterBackgroundNotification)
+  .subscribe(onNext: { notification in
+    print(notification.name)
+  })
+  .disposed(by: disposeBag)
+```
+
+`notification(_:object:)`는 이름과 선택적 발신 객체로 알림을 필터링해요. 구독할 때 NotificationCenter observer를 등록하고 dispose할 때 제거해요.
+
+```swift
+NotificationCenter.default.rx
+  .notification(
+    .NSManagedObjectContextDidSave,
+    object: context
+  )
+  .subscribe(onNext: { notification in
+    merger.merge(notification)
+  })
+  .disposed(by: disposeBag)
+```
+
+전달 Scheduler는 알림을 게시한 실행 문맥을 따라갈 수 있어요. UI를 갱신한다면 Driver로 변환하거나 MainScheduler로 이동하세요.
+
+## URLSession 요청은 구독마다 시작해요
+
+```swift
+let request = URLRequest(
+  url: URL(string: "https://example.com/profile")!
+)
+
+let data = URLSession.shared.rx.data(request: request)
+
+data
+  .decode(type: Profile.self, decoder: JSONDecoder())
+  .subscribe(onNext: { profile in
+    print(profile.name)
+  })
+  .disposed(by: disposeBag)
+```
+
+공식 구현은 Observable을 호출할 때가 아니라 **구독할 때** data task를 만들고 시작해요. Subscriber가 둘이면 요청도 둘이에요. dispose하면 `URLSessionTask.cancel()`을 호출해요.
+
+```swift
+let sharedProfile = URLSession.shared.rx
+  .data(request: request)
+  .decode(type: Profile.self, decoder: JSONDecoder())
+  .share(replay: 1, scope: .whileConnected)
+```
+
+하나의 화면에서 같은 응답을 여러 UI가 쓸 때만 적절한 범위로 공유하세요. 서로 다른 호출자가 독립 재시도·취소를 원하면 요청도 분리해야 해요.
+
+## response, data, json의 차이
+
+| API                  | 출력                      | HTTP 상태 처리                                           |
+| -------------------- | ------------------------- | -------------------------------------------------------- |
+| `response(request:)` | `(HTTPURLResponse, Data)` | HTTP 응답인지 확인하지만 상태 코드 실패는 직접 판단해요. |
+| `data(request:)`     | `Data`                    | `200..<300`이 아니면 `RxCocoaURLError`로 실패해요.       |
+| `json(request:)`     | `Any`                     | data 검사 뒤 JSONSerialization으로 역직렬화해요.         |
+| `json(url:)`         | `Any`                     | GET URL 편의 API예요.                                    |
+
+Codable 모델에는 `json`의 `Any`보다 `data`와 `decode` 조합이 타입 안전해요.
+
+```swift
+URLSession.shared.rx
+  .response(request: request)
+  .map { response, data in
+    guard response.statusCode == 304 else {
+      return data
+    }
+    return cache.data
+  }
+```
+
+`response`를 사용할 때는 허용할 상태 코드를 호출자가 직접 검증해야 해요.
+
+## URL 요청 로그에 민감 정보를 남기지 않아요
+
+RxCocoa는 `URLSession.rx.shouldLogRequest`로 요청을 curl 형태로 출력할지 정해요. 공식 기본 구현은 DEBUG에서 true예요.
+
+```swift
+URLSession.rx.shouldLogRequest = { request in
+  request.url?.host == "staging.example.com"
+}
+```
+
+Authorization, Cookie, 개인 데이터가 포함된 body가 로그에 노출될 수 있으므로 운영·공유 로그 정책을 반드시 확인하세요.
+
+## 타입 안전한 KeyPath KVO를 사용해요
+
+```swift
+player.rx
+  .observe(\.status)
+  .distinctUntilChanged()
+  .subscribe(onNext: { status in
+    print(status)
+  })
+  .disposed(by: disposeBag)
+```
+
+Swift KeyPath 오버로드는 기본 `.new`, `.initial` 옵션으로 현재 값과 이후 변화를 내보내고 대상이 해제되면 완료해요. 해당 속성이 KVO 호환인지 확인해야 해요.
+
+## 문자열 KeyPath와 소유 관계를 이해해요
+
+```swift
+view.rx
+  .observe(
+    CGRect.self,
+    "layer.bounds",
+    retainSelf: true
+  )
+  .subscribe(onNext: { bounds in
+    print(bounds as Any)
+  })
+  .disposed(by: disposeBag)
+```
+
+공식 구현은 문자열 경로의 `observe`에 대해 다음 기준을 설명해요.
+
+- 자식 객체를 관찰하는 경로는 대상을 유지하는 것이 필요한 경우가 많아요.
+- 부모 방향의 경로는 `retainSelf: false`가 필요할 수 있어요.
+- 경로 안에 weak 속성이 있거나 소유 관계를 모르면 단순 observe는 안전하지 않을 수 있어요.
+- 문자열 오타는 컴파일러가 검증하지 못해요.
+
+가능하면 타입 안전한 Swift KeyPath API를 우선 사용하세요.
+
+## `observeWeakly`는 swizzling 비용이 있어요
+
+```swift
+controller.rx
+  .observeWeakly(
+    String.self,
+    "child.title"
+  )
+  .subscribe(onNext: { title in
+    print(title as Any)
+  })
+  .disposed(by: disposeBag)
+```
+
+`observeWeakly`는 관찰 대상을 유지하지 않고 weak 속성과 임의 소유 그래프를 다룰 수 있지만, 객체의 dealloc을 감지하기 위해 Objective-C runtime swizzling이 필요해요. 여러 라이브러리가 같은 dealloc을 swizzle하거나 swizzling이 비활성화된 빌드에서는 제약을 확인해야 해요.
+
+## 객체 해제를 이벤트로 받아요
+
+```swift
+viewController.rx.deallocated
+  .subscribe(onNext: {
+    print("화면 해제")
+  })
+  .disposed(by: disposeBag)
+```
+
+`deallocated`는 객체가 해제된 뒤 Void 하나를 보내고 완료해요. `take(until: object.rx.deallocated)`처럼 구독 수명을 객체와 연결할 수 있어요.
+
+```swift
+updates
+  .take(until: viewController.rx.deallocated)
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+```
+
+DisposeBag으로 같은 수명을 이미 관리하고 있다면 중복일 수 있어요. 객체 밖에서 해당 객체의 수명에 맞춰 스트림을 끝내야 할 때 유용해요.
+
+## Objective-C 메서드 전후를 관찰해요
+
+```swift
+let selector = #selector(UIViewController.viewDidAppear(_:))
+
+viewController.rx.sentMessage(selector)
+  .subscribe(onNext: { _ in
+    print("호출 전")
+  })
+  .disposed(by: disposeBag)
+
+viewController.rx.methodInvoked(selector)
+  .subscribe(onNext: { _ in
+    print("호출 후")
+  })
+  .disposed(by: disposeBag)
+```
+
+이 기능도 runtime interception과 swizzling에 의존하고 인자가 `[Any]`로 전달돼요. 컴파일 타임 타입 안전성이 필요한 공개 기능에서는 명시적인 delegate·method override·adapter가 더 나은지 검토하세요.
+
+## URLSession async API와 선택해요
+
+| 상황                                      | 선택                                  |
+| ----------------------------------------- | ------------------------------------- |
+| 기존 Rx 파이프라인 안에서 요청을 조합해요 | `URLSession.rx.data/response`         |
+| 새 코드가 단일 요청 중심이에요            | `URLSession.data(for:)`와 async/await |
+| Rx 소비자와 async 서비스가 만나요         | Repository adapter 한 곳에서 변환     |
+| 세밀한 인증·delegate·streaming이 필요해요 | URLSession delegate 또는 별도 client  |
+
+RxCocoa URLSession 확장은 간단한 요청 adapter예요. 캐시 정책, 인증 갱신, multipart, retry 정책을 모두 제공하는 네트워크 프레임워크는 아니에요.
+
+## 자주 하는 실수
+
+- URLSession Observable을 두 번 구독해 요청을 중복 실행해요.
+- `response(request:)`가 모든 비정상 HTTP 코드를 오류로 만든다고 생각해요.
+- debug curl 로그에 토큰과 사용자 데이터를 남겨요.
+- Notification을 게시한 백그라운드 실행 문맥에서 UI를 갱신해요.
+- 문자열 KVO의 weak 경로와 retainSelf 관계를 확인하지 않아요.
+- 여러 runtime swizzling 라이브러리의 충돌 가능성을 무시해요.
+
+## 적용 체크리스트
+
+- Notification 전달 실행 문맥을 확인했나요?
+- URL 요청이 구독마다 실행된다는 사실을 반영했나요?
+- response와 data의 HTTP 상태 처리 차이를 이해했나요?
+- 네트워크 로그에서 비밀값을 제거했나요?
+- KVO 속성이 Objective-C 관찰 가능한가요?
+- retainSelf와 weak 경로의 소유 관계를 검토했나요?
+- runtime interception보다 타입 안전한 대안이 없는지 확인했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `URLSession.rx.response`와 `data`는 무엇이 다른가요?
+
+response는 HTTPURLResponse와 Data를 함께 보내고 상태 코드를 호출자가 판단해요. data는 `200..<300`만 성공으로 보고 그 밖의 상태를 RxCocoaURLError로 종료해요.
+
+### `observe`와 `observeWeakly`는 어떻게 선택하나요?
+
+강한 속성 경로와 명확한 소유 관계에서는 단순 observe가 더 빠르고 단순해요. weak 속성이나 알 수 없는 소유 그래프에서는 observeWeakly가 필요할 수 있지만 dealloc swizzling 비용과 충돌 가능성을 감수해야 해요.
+
+## 참고 자료
+
+- [RxCocoa Foundation 공식 소스](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxCocoa/Foundation)
+- [NotificationCenter Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Foundation/NotificationCenter%2BRx.swift)
+- [URLSession Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Foundation/URLSession%2BRx.swift)
+- [NSObject KVO와 deallocated 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Foundation/NSObject%2BRx.swift)
+- [Getting Started — KVO](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/GettingStarted.md#kvo)

--- a/docs/guide/rxswift/index.md
+++ b/docs/guide/rxswift/index.md
@@ -1,6 +1,8 @@
 ---
 title: Swift로 시작하는 RxSwift
-description: Observable과 Observer, Disposable, Subject, Trait의 관계부터 RxSwift 6.10.2의 모든 공개 연산자를 고르는 방법까지 단계적으로 설명합니다.
+description: RxSwift 6.10.2의 RxSwift·RxCocoa·RxRelay·RxTest·RxBlocking 공개 API와 모든 연산자를 모듈별 학습 경로로 안내합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2
+reviewed: '2026-09-06'
 ---
 
 # Swift로 시작하는 RxSwift
@@ -149,17 +151,24 @@ Subject는 delegate나 콜백을 Rx 경계에 연결할 때 유용하지만, 여
 
 ## RxSwift 생태계 모듈을 구분해요
 
-| 모듈                        | 역할                                                                                  |
-| --------------------------- | ------------------------------------------------------------------------------------- |
-| [`RxSwift`](./rxswift-core) | Observable, 연산자, Subject, Scheduler, Disposable과 코어 Trait을 제공해요.           |
-| [`RxCocoa`](./rxcocoa)      | Apple UI 프레임워크용 바인딩, `Driver`, `Signal`, `ControlProperty` 등을 제공해요.    |
-| [`RxRelay`](./rxrelay)      | 오류나 완료 없이 값만 받는 `PublishRelay`, `BehaviorRelay`, `ReplayRelay`를 제공해요. |
-| `RxTest`                    | 가상 시간 Scheduler와 기록 가능한 Observer로 시간 기반 테스트를 지원해요.             |
-| `RxBlocking`                | 테스트에서 Observable 결과를 동기적으로 기다리는 API를 제공해요.                      |
+| 모듈                         | 역할                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------- |
+| [`RxSwift`](./rxswift-core)  | Observable, 연산자, Subject, Scheduler, Disposable과 코어 Trait을 제공해요.           |
+| [`RxCocoa`](./rxcocoa)       | Apple UI 프레임워크용 바인딩, `Driver`, `Signal`, `ControlProperty` 등을 제공해요.    |
+| [`RxRelay`](./rxrelay)       | 오류나 완료 없이 값만 받는 `PublishRelay`, `BehaviorRelay`, `ReplayRelay`를 제공해요. |
+| [`RxTest`](./rxtest)         | 가상 시간 Scheduler와 기록 가능한 Observer로 시간 기반 테스트를 지원해요.             |
+| [`RxBlocking`](./rxblocking) | 테스트에서 Observable 결과를 동기적으로 기다리는 API를 제공해요.                      |
 
-모듈을 자세히 공부할 때는 [RxSwift 핵심 구조](./rxswift-core)에서 이벤트 계약과 구독 생명 주기를 익힌 뒤, [RxCocoa UI 바인딩](./rxcocoa)에서 UIKit 입력·출력을 연결하고, [RxRelay 상태와 이벤트](./rxrelay)에서 상태와 단발 사건의 소유권을 나눠 보세요.
+전체 공개 범위와 문서의 대응 관계는 [공식 API 범위와 학습 순서](./official-api-inventory)에서 먼저 확인할 수 있어요. 사이드바도 다음 네 묶음으로 나눴어요.
 
-이 섹션의 “모든 연산자”는 **RxSwift 코어 모듈**의 공개 연산자를 뜻해요. RxCocoa의 컨트롤별 바인더는 UI API이므로 범위에 넣지 않았고, `Driver`와 `Signal`의 상세한 공유·스케줄러 계약은 RxCocoa 문서에서 설명해요.
+- **RxSwift:** 설치, Observable·Observer·Event, Disposable, Scheduler, Subject·Trait, 디버깅과 사용자 정의 연산자
+- **RxCocoa:** Reactive·Binder, Control Traits, Driver·Signal, UIKit, 리스트·DelegateProxy, Foundation
+- **RxRelay:** 세 Relay의 재생 규칙, 상태 Store와 동시성
+- **Rx 테스트:** RxTest의 가상 시간과 RxBlocking의 동기 검사
+
+각 묶음은 기본으로 닫혀 있어 필요한 모듈만 펼쳐 볼 수 있어요. [RxSwift 핵심 구조](./rxswift-core)에서 이벤트 계약과 구독 생명 주기를 익힌 뒤, [RxCocoa UI 바인딩](./rxcocoa)에서 UIKit 입력·출력을 연결하고, [RxRelay 상태와 이벤트](./rxrelay)에서 상태와 단발 사건의 소유권을 나눠 보세요.
+
+이 섹션의 “모든 연산자”는 **RxSwift 코어 모듈**에서 확인한 서로 다른 공개 연산자 이름 89개를 뜻해요. RxCocoa의 컨트롤별 바인더는 [UIKit 컨트롤 바인딩](./uikit-control-bindings)과 [Foundation 바인딩](./foundation-bindings)에서 API 계열별로 설명하고, `Driver`와 `Signal`의 상세한 공유·스케줄러 계약은 [Driver·Signal·SharedSequence](./driver-signal-shared-sequence)에서 설명해요.
 
 ## Swift Package Manager로 설치해요
 

--- a/docs/guide/rxswift/index.md
+++ b/docs/guide/rxswift/index.md
@@ -149,15 +149,17 @@ Subject는 delegate나 콜백을 Rx 경계에 연결할 때 유용하지만, 여
 
 ## RxSwift 생태계 모듈을 구분해요
 
-| 모듈         | 역할                                                                                  |
-| ------------ | ------------------------------------------------------------------------------------- |
-| `RxSwift`    | Observable, 연산자, Subject, Scheduler, Disposable과 코어 Trait을 제공해요.           |
-| `RxCocoa`    | Apple UI 프레임워크용 바인딩, `Driver`, `Signal`, `ControlProperty` 등을 제공해요.    |
-| `RxRelay`    | 오류나 완료 없이 값만 받는 `PublishRelay`, `BehaviorRelay`, `ReplayRelay`를 제공해요. |
-| `RxTest`     | 가상 시간 Scheduler와 기록 가능한 Observer로 시간 기반 테스트를 지원해요.             |
-| `RxBlocking` | 테스트에서 Observable 결과를 동기적으로 기다리는 API를 제공해요.                      |
+| 모듈                        | 역할                                                                                  |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| [`RxSwift`](./rxswift-core) | Observable, 연산자, Subject, Scheduler, Disposable과 코어 Trait을 제공해요.           |
+| [`RxCocoa`](./rxcocoa)      | Apple UI 프레임워크용 바인딩, `Driver`, `Signal`, `ControlProperty` 등을 제공해요.    |
+| [`RxRelay`](./rxrelay)      | 오류나 완료 없이 값만 받는 `PublishRelay`, `BehaviorRelay`, `ReplayRelay`를 제공해요. |
+| `RxTest`                    | 가상 시간 Scheduler와 기록 가능한 Observer로 시간 기반 테스트를 지원해요.             |
+| `RxBlocking`                | 테스트에서 Observable 결과를 동기적으로 기다리는 API를 제공해요.                      |
 
-이 섹션의 “모든 연산자”는 **RxSwift 코어 모듈**의 공개 연산자를 뜻해요. RxCocoa의 컨트롤별 바인더는 UI API이므로 범위에 넣지 않았고, `Driver`와 `Signal`은 [Trait 문서](./operators-traits-deprecated)에서 역할과 경계를 설명해요.
+모듈을 자세히 공부할 때는 [RxSwift 핵심 구조](./rxswift-core)에서 이벤트 계약과 구독 생명 주기를 익힌 뒤, [RxCocoa UI 바인딩](./rxcocoa)에서 UIKit 입력·출력을 연결하고, [RxRelay 상태와 이벤트](./rxrelay)에서 상태와 단발 사건의 소유권을 나눠 보세요.
+
+이 섹션의 “모든 연산자”는 **RxSwift 코어 모듈**의 공개 연산자를 뜻해요. RxCocoa의 컨트롤별 바인더는 UI API이므로 범위에 넣지 않았고, `Driver`와 `Signal`의 상세한 공유·스케줄러 계약은 RxCocoa 문서에서 설명해요.
 
 ## Swift Package Manager로 설치해요
 
@@ -186,14 +188,14 @@ targets: [
 
 ## Trait으로 값의 규칙을 타입에 담아요
 
-| Trait             | 값과 종료 규칙                                    | 대표 용도                   |
-| ----------------- | ------------------------------------------------- | --------------------------- |
-| `Single<Element>` | 값 하나 또는 오류 하나                            | 네트워크 응답 하나          |
-| `Maybe<Element>`  | 값 하나, 값 없는 정상 완료, 또는 오류             | 있을 수도 없는 캐시 조회    |
-| `Completable`     | 값 없이 정상 완료 또는 오류                       | 저장·삭제 작업의 성공 여부  |
-| `Infallible`      | 오류 없이 값 0개 이상                             | 실패하지 않는 도메인 이벤트 |
-| `Driver`          | 오류 없음, 메인 Scheduler 관찰, 최신 값 1개 공유  | UI 상태 구동, RxCocoa       |
-| `Signal`          | 오류 없음, 메인 Scheduler 관찰, 과거 값 재생 없음 | UI 단발 이벤트, RxCocoa     |
+| Trait                                                             | 값과 종료 규칙                                    | 대표 용도                   |
+| ----------------------------------------------------------------- | ------------------------------------------------- | --------------------------- |
+| `Single<Element>`                                                 | 값 하나 또는 오류 하나                            | 네트워크 응답 하나          |
+| `Maybe<Element>`                                                  | 값 하나, 값 없는 정상 완료, 또는 오류             | 있을 수도 없는 캐시 조회    |
+| `Completable`                                                     | 값 없이 정상 완료 또는 오류                       | 저장·삭제 작업의 성공 여부  |
+| `Infallible`                                                      | 오류 없이 값 0개 이상                             | 실패하지 않는 도메인 이벤트 |
+| [`Driver`](./rxcocoa#driver는-ui-상태를-구동해요)                 | 오류 없음, 메인 Scheduler 관찰, 최신 값 1개 공유  | UI 상태 구동, RxCocoa       |
+| [`Signal`](./rxcocoa#signal은-replay하지-않는-ui-사건을-전달해요) | 오류 없음, 메인 Scheduler 관찰, 과거 값 재생 없음 | UI 단발 이벤트, RxCocoa     |
 
 Trait은 런타임에 완전히 다른 스트림 엔진이 아니라 Observable의 제약과 의미를 타입으로 표현하는 래퍼예요. 값 하나가 보장되는 API를 `Observable`로 노출하기보다 `Single`로 노출하면 호출자가 결과 개수를 추측할 필요가 없어요.
 
@@ -236,7 +238,7 @@ Trait은 런타임에 완전히 다른 스트림 엔진이 아니라 Observable�
 3. 생성, 변환, 결합, 오류 처리, Scheduler 전환을 작은 단계로 연결해요.
 4. cold·hot 여부와 Subscriber마다 작업을 반복할지 공유할지 정해요.
 5. `Disposable`, `DisposeBag`, Task의 소유 수명을 정해요.
-6. UI 갱신은 메인 Scheduler와 RxCocoa Trait 제약을 확인해요.
+6. UI 갱신은 [RxCocoa](./rxcocoa)의 메인 Scheduler와 Trait 제약을 확인해요.
 7. RxTest의 가상 시간으로 시간 기반 연산자와 종료 경로를 테스트해요.
 
 ## 면접에서 이어질 수 있는 질문

--- a/docs/guide/rxswift/installation-and-modules.md
+++ b/docs/guide/rxswift/installation-and-modules.md
@@ -1,0 +1,159 @@
+---
+title: RxSwift 설치와 모듈 선택
+description: RxSwift 6.10.2의 RxSwift, RxCocoa, RxRelay, RxTest, RxBlocking 의존 관계와 Swift Package Manager·XCFramework·Carthage 설치 기준을 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2
+reviewed: '2026-09-06'
+---
+
+# RxSwift 설치와 모듈 선택
+
+> **면접 답변 한 줄 요약:** RxSwift 패키지는 코어·UI·Relay·테스트 제품을 분리해 제공하므로 타깃마다 필요한 제품만 연결하고, 6.10부터 공식 지원이 폐기된 CocoaPods 대신 Swift Package Manager나 Carthage를 우선 선택해요.
+
+RxSwift 저장소 하나를 추가해도 앱이 모든 모듈을 자동으로 import하는 것은 아니에요. 제품별 의존 관계와 타깃 역할을 먼저 정해야 빌드 시간과 계층 의존성을 불필요하게 늘리지 않을 수 있어요.
+
+## 다섯 제품의 의존 관계
+
+```text
+RxCocoa ───────▶ RxRelay
+   │                │
+   └────────────┬───┘
+                ▼
+             RxSwift ◀──── RxTest
+                ▲
+                └──────── RxBlocking
+```
+
+| 제품         | 포함할 타깃                       | 역할                                                 |
+| ------------ | --------------------------------- | ---------------------------------------------------- |
+| `RxSwift`    | 도메인·데이터·화면 공통           | Observable, 연산자, Scheduler, Subject, Trait        |
+| `RxRelay`    | 상태와 사건을 Relay로 소유하는 곳 | PublishRelay, BehaviorRelay, ReplayRelay             |
+| `RxCocoa`    | UIKit·AppKit 화면 타깃            | UI 바인딩, Driver, Signal, DelegateProxy             |
+| `RxTest`     | 단위 테스트 타깃                  | 가상 시간, hot·cold 테스트 Observable, 기록 Observer |
+| `RxBlocking` | 제한적인 통합 테스트 타깃         | 현재 스레드를 막고 Observable 결과를 동기적으로 조회 |
+
+`RxCocoa`는 `RxSwift`와 `RxRelay`에 의존해요. 반대로 도메인 계층이 RxCocoa를 import하면 UI 전용 타입이 아래 계층으로 새기 쉬우므로 코어 로직은 `RxSwift`만 의존하게 두는 편이 좋아요.
+
+## Swift Package Manager로 추가해요
+
+Xcode의 **File → Add Package Dependencies**에서 다음 URL을 입력해요.
+
+```text
+https://github.com/ReactiveX/RxSwift.git
+```
+
+버전 규칙은 앱의 배포 정책에 맞추되, 문서 예제는 `6.10.2`를 기준으로 해요. `Package.swift`에서는 제품을 타깃별로 나눠요.
+
+```swift
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+  name: "Feature",
+  platforms: [.iOS(.v16)],
+  products: [
+    .library(name: "Feature", targets: ["Feature"]),
+  ],
+  dependencies: [
+    .package(
+      url: "https://github.com/ReactiveX/RxSwift.git",
+      exact: "6.10.2"
+    ),
+  ],
+  targets: [
+    .target(
+      name: "Feature",
+      dependencies: [
+        .product(name: "RxSwift", package: "RxSwift"),
+        .product(name: "RxCocoa", package: "RxSwift"),
+        .product(name: "RxRelay", package: "RxSwift"),
+      ]
+    ),
+    .testTarget(
+      name: "FeatureTests",
+      dependencies: [
+        "Feature",
+        .product(name: "RxTest", package: "RxSwift"),
+        .product(name: "RxBlocking", package: "RxSwift"),
+      ]
+    ),
+  ]
+)
+```
+
+앱 타깃에 `RxTest`와 `RxBlocking`을 넣지 않고 테스트 타깃에만 연결하세요. 코어 패키지라면 `RxCocoa`를 빼고 `RxSwift`·`RxRelay`만 선택할 수 있어요.
+
+## XCFramework로 직접 연결할 수 있어요
+
+RxSwift 6 릴리스는 바이너리 XCFramework를 제공해요. 릴리스 자산에서 필요한 프레임워크를 받아 Xcode의 **Frameworks, Libraries, and Embedded Content**에 추가할 수 있어요.
+
+직접 바이너리를 관리할 때는 다음을 확인하세요.
+
+- 동일 버전의 `RxSwift`, `RxRelay`, `RxCocoa`를 사용해요.
+- 시뮬레이터와 기기 slice가 모두 포함됐는지 확인해요.
+- 앱과 내부 프레임워크가 서로 다른 방식으로 RxSwift를 중복 연결하지 않게 해요.
+- 새 버전의 서명 주체와 체크섬을 공식 릴리스 정보에서 확인해요.
+
+소스 기반 의존성 해석과 자동 업데이트가 필요하면 Swift Package Manager가 더 단순하고, 네트워크 없이 검증된 바이너리를 배포해야 하는 조직이라면 XCFramework가 맞을 수 있어요.
+
+## Carthage는 여전히 공식 선택지예요
+
+`Cartfile`에는 버전을 명시해요.
+
+```text
+github "ReactiveX/RxSwift" == 6.10.2
+```
+
+Carthage는 기본적으로 동적 프레임워크를 빌드하며, 공식 README는 정적 라이브러리로 바꾸는 별도 절차도 안내해요. 빌드 산출물 캐시와 링킹 방식을 직접 관리할 필요가 없다면 SPM이 보통 더 간단해요.
+
+## CocoaPods는 6.10부터 공식 지원이 폐기됐어요
+
+RxSwift 6.10.2 릴리스 노트는 CocoaPods 지원이 공식적으로 deprecated됐고 SPM 또는 Carthage로 이동하라고 안내해요. 기존 Pod 설치가 즉시 사라진다는 뜻은 아니지만, 새 프로젝트의 기본 선택으로 삼거나 장기 유지보수를 기대하기는 어려워요.
+
+마이그레이션할 때는 한 번에 한 의존성 관리자만 RxSwift를 공급하게 하세요. Pod와 SPM 양쪽에서 RxSwift가 링크되면 동일 심볼 중복이나 타입 정체성 문제를 만들 수 있어요.
+
+## import 경계를 정해요
+
+| 파일 역할                  | 권장 import                       |
+| -------------------------- | --------------------------------- |
+| Repository·Use Case        | `RxSwift`                         |
+| 상태 Store                 | `RxSwift`, `RxRelay`              |
+| UIKit View Controller      | `RxSwift`, `RxCocoa`              |
+| Relay를 직접 소유하는 화면 | `RxSwift`, `RxCocoa`, `RxRelay`   |
+| 가상 시간 단위 테스트      | `RxSwift`, `RxTest`, `XCTest`     |
+| 동기 결과 통합 테스트      | `RxSwift`, `RxBlocking`, `XCTest` |
+
+공개 인터페이스에 Driver나 Signal을 쓰면 그 모듈의 소비자도 RxCocoa에 의존해야 해요. 화면과 무관한 모듈은 `Observable`, `Single`, `Infallible`처럼 RxSwift 타입으로 경계를 유지할지 검토하세요.
+
+## 자주 하는 실수
+
+- 모든 타깃에 다섯 제품을 전부 연결해 의존 범위를 키워요.
+- 앱과 사내 프레임워크가 서로 다른 RxSwift 버전을 포함해 충돌해요.
+- SPM으로 옮긴 뒤 남은 Pod·수동 프레임워크를 제거하지 않아요.
+- 테스트 전용 RxBlocking을 제품 코드에서 사용해 동기 대기와 교착 위험을 만들어요.
+- `import RxCocoa`만으로 모든 코어 타입의 소유 모듈을 구분하지 못해요.
+
+## 적용 체크리스트
+
+- 각 타깃이 실제 사용하는 Rx 제품만 연결했나요?
+- UI와 무관한 계층에서 RxCocoa를 제거할 수 있나요?
+- 테스트 제품이 앱 산출물에 포함되지 않나요?
+- 저장소 안에서 RxSwift 버전과 설치 방식이 하나로 통일됐나요?
+- CocoaPods를 사용 중이라면 SPM 또는 Carthage 전환 계획이 있나요?
+- 새 버전 적용 전 릴리스 노트와 지원 Xcode·Swift 버전을 확인했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### RxSwift와 RxCocoa를 왜 분리하나요?
+
+RxSwift는 플랫폼 중립적인 스트림 코어이고 RxCocoa는 UIKit·AppKit 등 Apple UI 연동 계층이에요. 분리하면 도메인 로직이 UI 프레임워크에 의존하지 않게 만들 수 있어요.
+
+### RxTest와 RxBlocking을 앱 타깃에 넣지 않는 이유는 무엇인가요?
+
+둘은 테스트 편의를 위한 제품이고, 특히 RxBlocking은 현재 스레드를 막으므로 제품의 비동기 흐름에 사용하기 부적절해요. 테스트 타깃에만 연결하는 것이 목적과 산출물 범위를 분명하게 해요.
+
+## 참고 자료
+
+- [RxSwift 6.10.2 공식 저장소와 설치 안내](https://github.com/ReactiveX/RxSwift/tree/6.10.2)
+- [RxSwift 6.10.2 릴리스 노트](https://github.com/ReactiveX/RxSwift/releases/tag/6.10.2)
+- [Swift Package Manager Package.swift](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Package.swift)

--- a/docs/guide/rxswift/list-bindings-and-delegate-proxy.md
+++ b/docs/guide/rxswift/list-bindings-and-delegate-proxy.md
@@ -1,0 +1,226 @@
+---
+title: 리스트 바인딩과 DelegateProxy
+description: UITableView·UICollectionView의 rx.items, 모델 선택·prefetch 이벤트, data source 수명과 DelegateProxy의 전달·메서드 interception 제약을 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Common/DelegateProxy.swift
+reviewed: '2026-09-06'
+---
+
+# 리스트 바인딩과 DelegateProxy
+
+> **면접 답변 한 줄 요약:** RxCocoa는 data source와 delegate 자리에 프록시를 설치해 목록 값과 UIKit 콜백을 Observable로 연결하며, 프록시는 메인 스레드에서 사용하고 반환값이 없는 알림형 메서드만 동적으로 관찰할 수 있어요.
+
+UITableView와 UICollectionView는 data source와 delegate가 각각 한 자리예요. RxCocoa는 이 자리를 무시하지 않고 proxy 객체를 설치한 뒤 Rx 구독과 실제 delegate에 호출을 나눠 전달해요.
+
+## `rx.items`가 data source를 설치해요
+
+```swift
+let products: Driver<[Product]> = viewModel.products
+
+products
+  .drive(
+    collectionView.rx.items(
+      cellIdentifier: "ProductCell",
+      cellType: ProductCell.self
+    )
+  ) { _, product, cell in
+    cell.render(product)
+  }
+  .disposed(by: disposeBag)
+```
+
+구독이 시작되면 RxCocoa가 reactive array data source를 설치하고, 새 배열이 올 때 셀 개수와 구성을 갱신해요. 반환된 Disposable이 폐기될 때 data source 바인딩도 정리돼요.
+
+## 제공되는 items 형태를 구분해요
+
+| 형태                              | 특징                                                    |
+| --------------------------------- | ------------------------------------------------------- |
+| `items(cellIdentifier:)`          | 등록한 identifier로 셀을 dequeue해요.                   |
+| `items(cellIdentifier:cellType:)` | 구체적인 셀 타입을 추론해 configuration을 제공해요.     |
+| `items(dataSource:)`              | `RxTableViewDataSourceType` 등 별도 data source를 써요. |
+| 사용자 정의 data source           | 섹션·모델 조회·업데이트 정책을 직접 구현해요.           |
+
+기본 array data source는 단순 목록에 적합해요. 섹션 모델, diff 애니메이션, 헤더·푸터가 필요하면 RxDataSources 같은 별도 라이브러리나 UIKit Diffable Data Source를 비교하세요. RxDataSources는 RxCocoa 본체에 포함된 제품이 아니에요.
+
+## 모델 선택은 data source의 모델 조회를 사용해요
+
+```swift
+collectionView.rx.modelSelected(Product.self)
+  .bind(to: viewModel.select)
+  .disposed(by: disposeBag)
+```
+
+`modelSelected`는 선택된 IndexPath를 reactive data source의 `model(at:)`으로 변환해요. `rx.items` 계열 또는 `SectionedViewDataSourceType`을 구현한 data source가 설치돼 있어야 해요.
+
+```swift
+collectionView.rx.itemSelected
+  .withLatestFrom(products) { indexPath, products in
+    products[indexPath.item]
+  }
+  .bind(to: viewModel.select)
+  .disposed(by: disposeBag)
+```
+
+직접 IndexPath를 배열에 적용하는 방식은 업데이트 시점이 어긋나면 범위를 벗어날 수 있어요. 가능한 경우 data source의 모델 조회 계약을 사용하세요.
+
+## 셀 표시와 종료 사건을 관찰해요
+
+```swift
+collectionView.rx.willDisplayCell
+  .subscribe(onNext: { cell, indexPath in
+    analytics.recordVisible(indexPath)
+  })
+  .disposed(by: disposeBag)
+
+collectionView.rx.didEndDisplayingCell
+  .subscribe(onNext: { cell, indexPath in
+    imageLoader.cancel(indexPath)
+  })
+  .disposed(by: disposeBag)
+```
+
+didEndDisplaying의 IndexPath는 데이터 갱신 뒤 현재 모델 위치와 일치하지 않을 수 있어요. 장기 작업을 취소하려면 셀이나 요청이 모델 ID를 직접 소유하게 하는 방법도 고려하세요.
+
+## prefetch data source도 프록시를 사용해요
+
+```swift
+collectionView.rx.prefetchItems
+  .subscribe(onNext: { indexPaths in
+    imageLoader.prefetch(indexPaths)
+  })
+  .disposed(by: disposeBag)
+
+collectionView.rx.cancelPrefetchingForItems
+  .subscribe(onNext: { indexPaths in
+    imageLoader.cancelPrefetch(indexPaths)
+  })
+  .disposed(by: disposeBag)
+```
+
+직접 `UICollectionViewDataSourcePrefetching`도 구현한다면 `rx.setPrefetchDataSource`로 forwarding 대상을 설치하세요. 직접 프로퍼티를 덮어쓰면 Rx 프록시가 분리될 수 있어요.
+
+## DelegateProxy의 구조
+
+```text
+UICollectionView
+      │ delegate
+      ▼
+RxCollectionViewDelegateProxy
+      ├─ PublishSubject로 Rx Observer에게 전달
+      └─ forward delegate로 UIKit delegate 호출 전달
+```
+
+DelegateProxy는 부모 객체에 associated object로 연결되고, 현재 delegate를 proxy로 교체해요. `setForwardToDelegate`를 통해 일반 delegate도 호출을 받을 수 있어요.
+
+공식 구현은 DelegateProxy가 thread-safe하지 않으며 **메인 스레드 한 곳에서 사용해야 한다**고 명시해요.
+
+## `sentMessage`와 `methodInvoked` 시점이 달라요
+
+| API                       | Observer에게 보내는 시점   |
+| ------------------------- | -------------------------- |
+| `sentMessage(selector)`   | 대상 메서드를 호출하기 전  |
+| `methodInvoked(selector)` | 대상 메서드 호출이 끝난 뒤 |
+
+```swift
+let selector = #selector(UIViewController.viewDidAppear(_:))
+
+viewController.rx.methodInvoked(selector)
+  .subscribe(onNext: { arguments in
+    print("viewDidAppear 완료:", arguments)
+  })
+  .disposed(by: disposeBag)
+```
+
+인자 배열은 `[Any]`이므로 타입 캐스팅과 selector 인덱스를 직접 관리해야 해요. RxCocoa가 이미 타입 안전한 `itemSelected` 같은 API를 제공하면 그것을 우선 사용하세요.
+
+## 반환값 없는 delegate 메서드만 동적 관찰해요
+
+DelegateProxy의 `sentMessage`와 `methodInvoked`는 반환값이 `Void`인 알림형 메서드를 관찰하는 용도예요. 반환값이 있는 메서드는 다음 이유로 자동 관찰하기 어려워요.
+
+- 프록시가 어떤 기본 반환값을 사용해야 할지 알 수 없어요.
+- 해당 메서드는 사건 알림이 아니라 동작 정책을 결정하는 경우가 많아요.
+- 여러 Observer가 서로 다른 반환값을 요구할 수 있어요.
+
+`shouldSelect`, 내비게이션 정책처럼 반환값이 필요한 메서드는 실제 delegate에서 구현하고, 필요하다면 내부 Subject로 결과 사건만 별도 노출하세요.
+
+## 일반 delegate를 함께 설치해요
+
+```swift
+tableView.rx.setDelegate(self)
+  .disposed(by: disposeBag)
+```
+
+RxCocoa의 `setDelegate`는 forwarding delegate를 설치하고 폐기 시 연결을 되돌리는 Disposable을 반환해요. 일반적으로 delegate를 retain하지 않으므로 View Controller 같은 별도 소유자가 살아 있어야 해요.
+
+다음 코드는 피하세요.
+
+```swift
+tableView.rx.itemSelected
+  .subscribe()
+  .disposed(by: disposeBag)
+
+tableView.delegate = anotherDelegate
+```
+
+마지막 직접 대입이 proxy를 덮어 Rx 이벤트가 멈추거나 예측하기 어려운 동작을 만들 수 있어요.
+
+## 재사용 셀의 구독을 모델 수명과 맞춰요
+
+```swift
+final class ProductCell: UICollectionViewCell {
+  var disposeBag = DisposeBag()
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
+}
+```
+
+셀의 버튼·이미지 로딩처럼 현재 모델에 속한 구독은 셀 bag에 보관하고 재사용 때 폐기해요. View Model의 전체 목록 Driver는 화면의 bag이 소유해야 해요.
+
+## diff 갱신 도구와 역할을 구분해요
+
+| 도구                       | Rx 연결      | diff 계산·애니메이션 | 데이터 소유 방식             |
+| -------------------------- | ------------ | -------------------- | ---------------------------- |
+| RxCocoa 기본 `rx.items`    | 직접         | 기본 reload 성격     | 단순 배열                    |
+| RxDataSources              | 직접         | animated data source | 섹션 모델과 identity         |
+| UIKit Diffable Data Source | adapter 필요 | snapshot diff        | Hashable identifier snapshot |
+| DifferenceKit              | adapter 필요 | staged changeset     | Differentiable 모델          |
+
+목록 바인딩과 diff 계산은 별개 책임이에요. 데이터 크기와 애니메이션 요구사항에 맞는 data source를 고르세요.
+
+## 자주 하는 실수
+
+- `rx.items`를 쓰면서 별도 dataSource를 직접 대입해요.
+- Rx delegate 구독 뒤 일반 delegate를 프로퍼티에 직접 덮어써요.
+- 반환값이 있는 delegate 메서드를 `methodInvoked`만으로 처리하려 해요.
+- DelegateProxy를 백그라운드에서 설치해요.
+- 모델 변경과 IndexPath 사용 시점을 분리하지 않아요.
+- 셀 재사용 뒤 이전 모델 구독을 남겨요.
+
+## 적용 체크리스트
+
+- 기본 items와 custom data source 중 요구사항에 맞는 방식을 골랐나요?
+- 모델 선택이 현재 data source의 모델 조회를 사용하나요?
+- delegate·dataSource proxy를 직접 대입으로 덮지 않나요?
+- 반환값이 필요한 delegate 정책의 실제 소유자가 있나요?
+- proxy 설치와 구독이 메인에서 이뤄지나요?
+- 셀·화면·prefetch 작업의 Disposable 수명을 분리했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### DelegateProxy가 필요한 이유는 무엇인가요?
+
+UIKit delegate 프로퍼티는 하나뿐이므로 Rx Observer와 일반 delegate가 호출을 함께 받으려면 중간에서 사건을 관찰하고 forwarding하는 객체가 필요해요.
+
+### `methodInvoked`로 모든 delegate 메서드를 관찰할 수 있나요?
+
+아니요. 동적 관찰은 기본적으로 반환값이 없는 알림형 메서드에 적합해요. 반환값이 필요한 정책 메서드는 실제 delegate 구현에서 처리해야 해요.
+
+## 참고 자료
+
+- [DelegateProxy 공식 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Common/DelegateProxy.swift)
+- [UITableView Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/UITableView%2BRx.swift)
+- [UICollectionView Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/UICollectionView%2BRx.swift)
+- [SectionedViewDataSourceType](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Common/SectionedViewDataSourceType.swift)
+- [CollectionView Prefetching Proxy](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/Proxies/RxCollectionViewDataSourcePrefetchingProxy.swift)

--- a/docs/guide/rxswift/observable-observer-event.md
+++ b/docs/guide/rxswift/observable-observer-event.md
@@ -1,0 +1,207 @@
+---
+title: Observable, Observer와 Event 계약
+description: ObservableType과 ObserverType의 역할, Event의 next·error·completed 문법, 구독별 실행, AnyObserver, materialize와 사용자 정의 Observable 경계를 설명합니다.
+source: https://docs.rxswift.org/protocols/observabletype
+reviewed: '2026-09-06'
+---
+
+# Observable, Observer와 Event 계약
+
+> **면접 답변 한 줄 요약:** Observable은 구독마다 Observer에게 직렬화된 `next* (error | completed)?` 이벤트를 전달하고, Observer는 종료 뒤 이벤트가 더 오지 않는다는 계약을 전제로 값을 소비해요.
+
+RxSwift 코드는 결국 “누가 이벤트를 만들고, 누가 구독하며, 언제 끝나는가”로 읽을 수 있어요. 이 계약을 이해하면 연산자 조합이 복잡해져도 오류와 취소 경로를 추적하기 쉬워져요.
+
+## 핵심 타입의 역할
+
+| 타입                              | 역할                                                               |
+| --------------------------------- | ------------------------------------------------------------------ |
+| `Observable<Element>`             | 실제 Observable 시퀀스를 나타내는 클래스예요.                      |
+| `ObservableType`                  | 연산자가 확장되는 핵심 프로토콜이며 `subscribe`를 요구해요.        |
+| `ObservableConvertibleType`       | 자신을 Observable로 바꾸는 `asObservable()` 계약을 제공해요.       |
+| `ObserverType`                    | `on(_:)`으로 Event를 받는 소비자 계약이에요.                       |
+| `Event<Element>`                  | `.next(Element)`, `.error(Error)`, `.completed`를 담는 enum이에요. |
+| `AnyObserver<Element>`            | 구체적인 Observer 타입을 숨기는 타입 소거 래퍼예요.                |
+| `GroupedObservable<Key, Element>` | `groupBy` 결과에서 그룹 키와 그룹별 Observable을 함께 제공해요.    |
+
+대부분의 앱 코드는 `Observable`을 직접 subclass하지 않고 `Observable.create`, Subject, 기존 API와 연산자를 조합해요.
+
+## Event 문법을 코드로 읽어요
+
+```swift
+import RxSwift
+
+let observer = AnyObserver<Int> { event in
+  switch event {
+  case let .next(value):
+    print("값:", value)
+  case let .error(error):
+    print("실패:", error)
+  case .completed:
+    print("정상 완료")
+  }
+}
+
+Observable.of(1, 2, 3)
+  .subscribe(observer)
+  .dispose()
+```
+
+Event의 문법은 다음과 같아요.
+
+```text
+next* (error | completed)?
+```
+
+- 값은 없거나 여러 개일 수 있어요.
+- 오류와 정상 완료는 서로 배타적인 종료 이벤트예요.
+- 종료 뒤에는 값이나 다른 종료 이벤트를 보내지 않아요.
+- 끝나지 않는 Observable도 유효해요.
+
+`Event.element`는 next일 때만 값을 돌려주고, `isStopEvent`는 error 또는 completed인지 알려 줘요. 일반 앱 코드에서는 `subscribe(onNext:onError:onCompleted:)`가 더 읽기 쉽지만, 이벤트 자체를 다루는 로깅·테스트·연산자 구현에서는 Event가 유용해요.
+
+## subscribe는 정의를 실행과 연결해요
+
+```swift
+let source = Observable.deferred {
+  print("새 구독")
+  return Observable.of(10, 20)
+}
+
+source.subscribe(onNext: { print("A:", $0) }).dispose()
+source.subscribe(onNext: { print("B:", $0) }).dispose()
+```
+
+`deferred`의 factory는 구독마다 호출되므로 `새 구독`도 두 번 출력돼요. Observable 변수 하나를 공유했다고 실행까지 자동 공유되는 것은 아니에요.
+
+| 구분    | Observable 정의            | 구독 실행                                 |
+| ------- | -------------------------- | ----------------------------------------- |
+| 시점    | 연산자를 조합할 때         | `subscribe`, `bind`, `drive`를 호출할 때  |
+| 하는 일 | 어떤 값 흐름을 만들지 표현 | Observer를 연결하고 실제 부수 효과를 시작 |
+| 반환값  | 새 Observable 또는 Trait   | `Disposable`                              |
+
+## 한 구독의 이벤트는 순서가 있어요
+
+Observable 계약을 지키는 소스는 한 Observer에게 이벤트를 동시에 겹쳐 보내지 않고 순서 있게 전달해야 해요. 여러 Scheduler에서 값이 만들어지더라도 같은 구독의 Observer가 `.next` 두 개를 동시에 처리하게 만들면 안 돼요.
+
+하지만 이 규칙이 앱의 모든 공유 상태를 안전하게 만드는 것은 아니에요.
+
+- 서로 다른 Observable의 Observer는 동시에 실행될 수 있어요.
+- 여러 구독이 같은 변수에 접근하면 별도 동기화가 필요해요.
+- Observer 안에서 같은 Subject에 다시 값을 보내면 재진입이 일어날 수 있어요.
+- 오래 걸리는 `onNext`는 이벤트를 전달하는 현재 Scheduler를 막을 수 있어요.
+
+## create에서는 종료와 취소를 모두 구현해요
+
+```swift
+import Foundation
+import RxSwift
+
+func makeClock() -> Observable<Date> {
+  Observable.create { observer in
+    let timer = DispatchSource.makeTimerSource()
+    timer.schedule(
+      deadline: .now(),
+      repeating: .seconds(1)
+    )
+    timer.setEventHandler {
+      observer.onNext(Date())
+    }
+    timer.resume()
+
+    return Disposables.create {
+      timer.cancel()
+    }
+  }
+}
+```
+
+사용자 정의 소스에서는 다음을 지켜야 해요.
+
+1. 종료 이벤트를 최대 한 번 보내요.
+2. 종료 또는 dispose 뒤 추가 값을 만들지 않게 기반 작업을 중단해요.
+3. 여러 실행 문맥에서 이벤트가 올 수 있다면 Observer 전달을 직렬화해요.
+4. Observer를 작업이 필요 이상으로 오래 보관하지 않아요.
+
+기존 Rx API를 조합할 수 있다면 직접 `create`하는 것보다 검증된 연산자를 사용하는 편이 안전해요.
+
+## AnyObserver로 쓰기 인터페이스를 좁혀요
+
+Subject를 외부에 그대로 반환하면 호출자가 종료 이벤트까지 보낼 수 있어요. 값 입력이 필요한 협력자에게만 `AnyObserver`를 노출해 구체적인 Subject를 숨길 수 있어요.
+
+```swift
+let inputSubject = PublishSubject<String>()
+
+let input = AnyObserver<String> { event in
+  guard case let .next(value) = event else {
+    return
+  }
+  inputSubject.onNext(value.trimmingCharacters(in: .whitespaces))
+}
+
+input.onNext("  RxSwift  ")
+```
+
+오류와 완료가 필요 없는 입력이라면 종료 API 자체가 없는 RxRelay가 더 명확할 수 있어요. AnyObserver는 타입을 지울 뿐 도메인 계약을 자동으로 제한하지는 않아요.
+
+## materialize로 종료를 값처럼 다뤄요
+
+`materialize()`는 `Observable<Element>`를 `Observable<Event<Element>>`로 바꿔요. 원래 오류도 바깥 Observable을 종료시키는 대신 `.error` 값으로 관찰할 수 있어요.
+
+```swift
+api.loadProfile()
+  .materialize()
+  .subscribe(onNext: { event in
+    analytics.record(event)
+  })
+  .disposed(by: disposeBag)
+```
+
+`dematerialize()`는 Event 값을 다시 실제 next·error·completed 이벤트로 복원해요. 모든 오류를 materialize해서 비즈니스 상태로 쓰기보다, 이벤트 자체를 검사해야 하는 로깅·재시도 제어·테스트 경계에서 제한적으로 사용하세요.
+
+## Observable과 Trait의 경계를 정해요
+
+| 실제 계약               | 더 구체적인 타입      |
+| ----------------------- | --------------------- |
+| 값 0개 이상, 오류 가능  | `Observable<Element>` |
+| 값 정확히 1개 또는 오류 | `Single<Element>`     |
+| 값 0개나 1개 또는 오류  | `Maybe<Element>`      |
+| 값 없이 완료 또는 오류  | `Completable`         |
+| 값 0개 이상, 오류 없음  | `Infallible<Element>` |
+
+Observable로 모든 것을 표현할 수 있지만, 공개 API에서 가능한 이벤트 수를 Trait으로 좁히면 호출자가 `take(1)` 같은 추측을 하지 않아도 돼요.
+
+## 자주 하는 실수
+
+- Observable 변수를 재사용하면 네트워크 요청도 자동 공유된다고 생각해요.
+- `.error` 뒤에 같은 구독으로 값이 다시 올 것으로 기대해요.
+- `create`에서 기반 Task·Timer·URLSessionTask를 취소하지 않아요.
+- 여러 스레드가 직접 Observer에 이벤트를 보내며 직렬화 계약을 깨요.
+- Observer 클로저에서 무거운 동기 작업을 실행해 현재 Scheduler를 막아요.
+- Subject나 AnyObserver를 전역 입력으로 공개해 이벤트 생산자를 추적하기 어렵게 만들어요.
+
+## 적용 체크리스트
+
+- 값 개수와 종료 조건을 타입과 문서로 표현했나요?
+- 구독마다 새로 실행되는 부수 효과를 파악했나요?
+- 사용자 정의 소스가 종료 뒤 이벤트를 보내지 않나요?
+- dispose가 실제 기반 작업을 취소하나요?
+- 서로 다른 스트림이 공유 상태를 수정할 때 동기화 경계가 있나요?
+- Observable보다 구체적인 Trait을 사용할 수 있나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### ObservableType과 ObservableConvertibleType은 무엇이 다른가요?
+
+ObservableType은 직접 구독 가능한 시퀀스의 핵심 계약이고 대부분의 연산자가 확장돼요. ObservableConvertibleType은 자신을 일반 Observable로 변환할 수 있다는 더 넓은 계약이에요.
+
+### 종료 이벤트와 dispose는 어떻게 다른가요?
+
+error와 completed는 생산자가 Observer에게 보내는 이벤트이고, dispose는 소비자가 구독 연결을 끊는 동작이에요. dispose가 정상 완료 이벤트를 만들어 주지는 않아요.
+
+## 참고 자료
+
+- [ObservableType 공식 API](https://docs.rxswift.org/protocols/observabletype)
+- [ObserverType 공식 API](https://docs.rxswift.org/protocols/observertype)
+- [Event 공식 API](https://docs.rxswift.org/enums/event)
+- [Getting Started의 Observable 계약](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/GettingStarted.md)
+- [Observable.create 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxSwift/Observables/Create.swift)

--- a/docs/guide/rxswift/official-api-inventory.md
+++ b/docs/guide/rxswift/official-api-inventory.md
@@ -1,0 +1,128 @@
+---
+title: RxSwift 공식 API 범위와 학습 순서
+description: RxSwift 6.10.2의 RxSwift·RxCocoa·RxRelay·RxTest·RxBlocking 공개 API를 문서별로 연결하고 포함 범위와 권장 학습 순서를 안내합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2
+reviewed: '2026-09-06'
+---
+
+# RxSwift 공식 API 범위와 학습 순서
+
+> **면접 답변 한 줄 요약:** RxSwift 생태계는 코어 스트림을 담당하는 RxSwift, Apple UI 연결을 담당하는 RxCocoa, 종료 없는 값 통로인 RxRelay, 가상 시간과 동기 검사를 제공하는 RxTest·RxBlocking으로 나뉘어요.
+
+RxSwift 문서가 몇 개인지만 세면 실제 범위를 판단하기 어려워요. 한 문서에 개념을 모두 넣으면 찾기 힘들고, API 이름만 나열하면 왜 쓰는지 알기 어려워요. 이 페이지는 **RxSwift 6.10.2 공식 저장소의 공개 제품과 API 계열**을 기준으로 각 내용을 어느 문서에서 설명하는지 연결해요.
+
+## 먼저 알아둘 용어
+
+| 용어           | 뜻                                                                                                         |
+| -------------- | ---------------------------------------------------------------------------------------------------------- |
+| 제품(product)  | Swift Package Manager에서 target이 의존성으로 선택하는 배포 단위예요. RxSwift에는 다섯 제품이 있어요.      |
+| 모듈(module)   | `import RxSwift`처럼 코드에서 가져오는 컴파일 단위예요.                                                    |
+| 공개 API       | 앱 코드가 직접 사용하도록 노출된 타입·메서드·프로토콜이에요.                                               |
+| 구현 세부 사항 | `Producer`, `Sink`, lock과 내부 자료 구조처럼 공개 API를 동작시키지만 일반 앱에서 직접 쓰지 않는 코드예요. |
+| API 인벤토리   | 어떤 기능 계열을 어느 문서에서 설명하는지 추적하는 목록이에요.                                             |
+| 플랫폼 바인딩  | UIKit·AppKit·Foundation 객체의 이벤트와 속성을 Rx source·sink로 바꾸는 확장이에요.                         |
+
+## 다섯 제품의 경계를 확인해요
+
+```text
+RxCocoa ───────┐
+   │           │
+   ▼           ▼
+RxRelay ───▶ RxSwift ◀── RxTest
+                 ▲
+                 └────── RxBlocking
+```
+
+| 제품         | 공식 공개 범위                                                             | 이 섹션에서 시작할 문서              |
+| ------------ | -------------------------------------------------------------------------- | ------------------------------------ |
+| `RxSwift`    | Observable, Observer, Event, 연산자, Disposable, Scheduler, Subject, Trait | [RxSwift 핵심 구조](./rxswift-core)  |
+| `RxCocoa`    | Reactive, Binder, UI Trait, UIKit·AppKit·Foundation 바인딩, DelegateProxy  | [RxCocoa 시작하기](./rxcocoa)        |
+| `RxRelay`    | PublishRelay, BehaviorRelay, ReplayRelay와 `bind(to:)`                     | [RxRelay 시작하기](./rxrelay)        |
+| `RxTest`     | TestScheduler, hot·cold Observable, 기록 가능한 Observer와 Subscription    | [RxTest 가상 시간](./rxtest)         |
+| `RxBlocking` | Observable을 테스트에서 동기적으로 검사하는 BlockingObservable             | [RxBlocking 동기 검사](./rxblocking) |
+
+설치 방법과 제품 의존 관계는 [설치와 모듈 구성](./installation-and-modules)에서 먼저 확인할 수 있어요.
+
+## RxSwift 코어 범위를 문서별로 찾아봐요
+
+| 공식 API 계열                             | 다루는 내용                                                               | 상세 문서                                                                                 |
+| ----------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `ObservableType`, `ObserverType`, `Event` | 생성, 구독, 이벤트 문법, 타입 지우기, 이벤트를 값으로 바꾸기              | [Observable·Observer·Event](./observable-observer-event)                                  |
+| `Disposable`과 구현 타입                  | DisposeBag, 교체·복합·참조 카운트·예약 폐기, 취소와 자원 수명             | [Disposable과 자원](./disposables-and-resources)                                          |
+| `SchedulerType`과 구현 타입               | 구독 위치, 관찰 위치, 직렬·병렬·메인·가상 시간, async 브리지              | [Scheduler와 동시성](./schedulers-and-concurrency)                                        |
+| 네 가지 Subject와 코어 Trait              | Publish·Behavior·Replay·AsyncSubject, Single·Maybe·Completable·Infallible | [Subject와 Traits](./subjects-and-traits)                                                 |
+| 연산자                                    | 생성·변환·필터·결합·시간·오류·공유·Trait·폐기 API                         | [모든 연산자](./operators-create-convert)                                                 |
+| `debug`, `do`, `Hooks`, `Resources`       | 파이프라인 관찰, 전역 오류 처리, 자원 추적, 사용자 정의 연산자            | [디버깅과 사용자 정의 연산자](./debugging-hooks-and-custom-operators)                     |
+| Swift Concurrency 브리지                  | Observable의 `values`, AsyncSequence의 `asObservable`, 취소 전파          | [Scheduler와 동시성](./schedulers-and-concurrency#rxswift와-swift-concurrency를-연결해요) |
+
+“모든 연산자” 문서는 RxSwift 6.10.2 공개 심볼에서 추출한 **서로 다른 연산자 이름 89개**를 목적별 일곱 문서에 나눠 설명해요. 오버로드마다 같은 이름을 반복해 별도 페이지로 만들지는 않고, 의미가 달라지는 오버로드를 해당 항목에서 비교해요.
+
+## RxCocoa 범위를 문서별로 찾아봐요
+
+| 공식 API 계열                              | 다루는 내용                                                        | 상세 문서                                                          |
+| ------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `Reactive`, `ReactiveCompatible`, `Binder` | `.rx` 네임스페이스, source와 sink, 안전한 UI 출력                  | [Reactive·Binder·Control Traits](./reactive-binder-control-traits) |
+| `ControlProperty`, `ControlEvent`          | UI 입력의 읽기·쓰기 계약과 컨트롤 사건                             | [Reactive·Binder·Control Traits](./reactive-binder-control-traits) |
+| `SharedSequence`, `Driver`, `Signal`       | 메인 Scheduler, 오류 없는 UI 출력, replay와 공유 범위              | [Driver·Signal·SharedSequence](./driver-signal-shared-sequence)    |
+| UIKit 확장                                 | 버튼·텍스트·스크롤·내비게이션·웹 뷰·애플리케이션 이벤트            | [UIKit 컨트롤 바인딩](./uikit-control-bindings)                    |
+| 리스트와 delegate·data source              | `items`, 선택·표시·prefetch 사건, 프록시 등록과 전달               | [리스트와 DelegateProxy](./list-bindings-and-delegate-proxy)       |
+| Foundation 확장                            | NotificationCenter, URLSession, KVO, deallocation, 메서드 가로채기 | [Foundation 바인딩](./foundation-bindings)                         |
+
+RxCocoa 저장소에는 iOS와 함께 macOS용 AppKit 확장도 있어요. 이 사이트는 iOS 학습 문서이므로 UIKit을 전체 학습 경로로 설명하고, AppKit은 동일한 `Reactive`·`Binder`·delegate proxy 원리가 적용되는 플랫폼 범위로 안내해요. 컨트롤별 속성 오버로드를 한 줄씩 복제하기보다 공통 계약과 대표 API를 다루고, 정확한 최신 심볼은 공식 API 레퍼런스로 연결해요.
+
+## RxRelay와 테스트 범위를 문서별로 찾아봐요
+
+| 범위                 | 핵심 질문                                                         | 상세 문서                                                  |
+| -------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| 세 Relay의 재생 규칙 | 새 Subscriber가 과거 값이나 현재 값을 받아야 하나요?              | [Relay 종류와 replay](./relay-types-and-replay)            |
+| 상태 Store와 동시성  | 변경 경로를 캡슐화하고 read-modify-write 경쟁을 어떻게 막을까요?  | [상태 Store와 동시성](./relay-state-store-and-concurrency) |
+| RxTest               | 시간 기반 흐름을 실제로 기다리지 않고 어떻게 검증할까요?          | [RxTest 가상 시간](./rxtest)                               |
+| RxBlocking           | 짧게 끝나는 시퀀스의 값·오류를 동기 테스트에서 어떻게 확인할까요? | [RxBlocking 동기 검사](./rxblocking)                       |
+
+## 포함하지 않은 범위도 명확히 해요
+
+이 섹션의 “빠짐없이”는 **일반 iOS 앱 개발자가 선택하고 조합하는 공개 제품, 핵심 개념, 공개 API 계열과 RxSwift 연산자 이름**을 빠뜨리지 않는다는 뜻이에요. 다음 항목은 의도적으로 줄 단위 해설 범위에서 제외해요.
+
+- `Producer`, `Sink`, lock, tail-recursive sink stack, 플랫폼별 원자 연산처럼 라이브러리 내부 구현을 위한 비공개 또는 저수준 구조
+- 같은 의미를 갖는 모든 generic 제약·플랫폼·타입 오버로드의 선언 복제
+- 공식 샘플 앱 전체 코드와 공식 문서의 문장별 번역
+- 일반 iOS 앱에서 사용하지 않는 macOS 컨트롤별 바인더의 개별 사용 예제
+
+내부 구현은 동작 원리를 설명할 때 필요한 부분만 인용 없이 해설하고 공식 소스에 연결해요. 공개 API가 추가되거나 의미가 달라지면 기준 버전을 올리고 인벤토리와 검증 목록을 함께 갱신해야 해요.
+
+## 권장 학습 순서를 정리해요
+
+1. [설치와 모듈 구성](./installation-and-modules)에서 필요한 제품만 target에 연결해요.
+2. [Observable·Observer·Event](./observable-observer-event)에서 스트림의 이벤트 계약을 익혀요.
+3. [Disposable과 자원](./disposables-and-resources), [Scheduler와 동시성](./schedulers-and-concurrency)으로 수명과 실행 위치를 설계해요.
+4. [Subject와 Traits](./subjects-and-traits)에서 값의 개수와 종료 가능성을 타입으로 표현해요.
+5. 목적에 맞는 [연산자](./operators-create-convert)를 골라 파이프라인을 만들어요.
+6. UIKit 화면에서는 [RxCocoa](./rxcocoa), 상태 입력에서는 [RxRelay](./rxrelay)를 필요한 경계에만 추가해요.
+7. [RxTest](./rxtest)와 [RxBlocking](./rxblocking)으로 값·시간·구독·폐기를 검증해요.
+
+## 적용 체크리스트
+
+- 현재 프로젝트가 사용하는 RxSwift 버전과 문서 기준 버전이 같은가요?
+- target마다 RxSwift, RxCocoa, RxRelay 중 실제 필요한 제품만 가져오나요?
+- Event 종료 규칙, Disposable 수명, Scheduler 위치를 함께 설계했나요?
+- UI 상태와 단발 사건에 Driver·Signal·Relay를 의미에 맞게 골랐나요?
+- 시간 기반 로직은 RxTest로 구독·폐기 시점까지 검증하나요?
+- 새 공식 공개 API가 생겼을 때 이 인벤토리와 관련 문서를 함께 갱신하나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### RxSwift와 RxCocoa는 왜 별도 모듈인가요?
+
+RxSwift는 플랫폼에 덜 의존하는 Observable 코어이고, RxCocoa는 UIKit·AppKit·Foundation 객체를 위한 바인딩과 UI Trait을 제공해요. 도메인 계층이 RxCocoa에 의존하지 않게 분리하면 UI 프레임워크 결합을 화면 경계에 제한할 수 있어요.
+
+### 공개 API를 빠짐없이 설명한다는 것은 모든 소스 파일을 번역한다는 뜻인가요?
+
+아니에요. 앱 개발자가 사용하는 공개 개념과 API 계열, 연산자 이름을 추적한다는 뜻이에요. 내부 구현과 반복 오버로드는 원리를 이해하는 데 필요한 만큼 설명하고 정확한 선언은 공식 소스로 연결해요.
+
+## 참고 자료
+
+- [RxSwift 6.10.2 공식 저장소](https://github.com/ReactiveX/RxSwift/tree/6.10.2)
+- [RxSwift 공식 API 레퍼런스](https://docs.rxswift.org/)
+- [RxSwift 공식 문서 목록](https://github.com/ReactiveX/RxSwift/tree/6.10.2/Documentation)
+- [RxSwift 구성 요소 관계](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/GettingStarted.md)
+- [RxSwift 모듈 의존 관계](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/GettingStarted.md#what-are-the-components-of-rxswift)

--- a/docs/guide/rxswift/operators-traits-deprecated.md
+++ b/docs/guide/rxswift/operators-traits-deprecated.md
@@ -110,6 +110,8 @@ RxCocoa는 UI 바인딩에 맞춘 `Driver`와 `Signal`을 제공해요.
 
 화면 상태처럼 최근 값이 필요한 흐름은 `Driver`, 탭이나 일회성 알림처럼 과거 값을 다시 보내면 안 되는 흐름은 `Signal`이 잘 맞아요. 두 타입은 RxCocoa의 공유 시퀀스이므로 이 문서의 RxSwift 핵심 Observable 연산자 목록과는 범위가 달라요.
 
+`Binder`, `ControlProperty`, `ControlEvent`와 함께 UI 입력부터 출력까지 연결하는 방법, Driver와 Signal의 정확한 공유 정책은 [RxCocoa로 UIKit 입력과 출력을 바인딩하기](./rxcocoa)에서 자세히 설명해요.
+
 ## 폐기된 이름을 최신 API로 바꿔요
 
 RxSwift 6은 여러 연산자 이름과 인자 레이블을 Swift API Design Guidelines에 맞게 정리했어요. 폐기 API는 당장 컴파일될 수 있어도 경고가 발생하고 이후 버전에서 제거될 수 있으므로 새 코드에서는 최신 이름을 사용하세요.

--- a/docs/guide/rxswift/reactive-binder-control-traits.md
+++ b/docs/guide/rxswift/reactive-binder-control-traits.md
@@ -1,0 +1,222 @@
+---
+title: Reactive, Binder와 Control Traits
+description: RxCocoa의 .rx Reactive 프록시, ReactiveCompatible, Binder, ControlProperty, ControlEvent와 UIControl target-action 연결 원리를 공식 구현 기준으로 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxCocoa
+reviewed: '2026-09-06'
+---
+
+# Reactive, Binder와 Control Traits
+
+> **면접 답변 한 줄 요약:** RxCocoa의 `.rx`는 원본 객체를 감싼 Reactive 프록시이고, ControlProperty·ControlEvent가 UI 입력을 내보내며 Binder가 오류 없는 값을 메인 Scheduler에서 UI에 적용해요.
+
+`button.rx.tap`과 `label.rx.text`는 겉으로 비슷하지만 같은 종류의 API가 아니에요. 하나는 UI에서 나오는 source이고 다른 하나는 UI로 들어가는 sink예요. 방향과 replay 규칙을 구분해야 순환 바인딩과 오류 종료를 피할 수 있어요.
+
+## ReactiveCompatible과 Reactive를 구분해요
+
+`ReactiveCompatible`을 채택한 타입은 `.rx` 네임스페이스를 얻어요. `Reactive<Base>`는 원본 객체를 `base`에 보관하는 가벼운 프록시예요.
+
+```swift
+let reactiveSearchBar: Reactive<UISearchBar> = searchBar.rx
+let originalSearchBar: UISearchBar = reactiveSearchBar.base
+```
+
+NSObject 계열은 RxCocoa가 호환성을 제공하므로 UIKit 객체에 직접 채택 코드를 쓸 필요가 없어요. 사용자 정의 참조 타입도 ReactiveCompatible을 채택해 `.rx` 확장에 보조 API를 모을 수 있어요.
+
+```swift
+final class Player: ReactiveCompatible {
+  var volume: Float = 0
+}
+
+extension Reactive where Base: Player {
+  var volume: Binder<Float> {
+    Binder(base) { player, volume in
+      player.volume = min(max(volume, 0), 1)
+    }
+  }
+}
+```
+
+Reactive 확장은 비즈니스 로직 저장소가 아니라 원본 타입과 Rx 세계를 연결하는 adapter로 유지하세요.
+
+## UI source와 sink를 구분해요
+
+| 방향    | 대표 API                               | 타입                       |
+| ------- | -------------------------------------- | -------------------------- |
+| UI → Rx | `button.rx.tap`                        | `ControlEvent<Void>`       |
+| UI → Rx | `textField.rx.text`                    | `ControlProperty<String?>` |
+| Rx → UI | `label.rx.text`                        | `Binder<String?>`          |
+| Rx → UI | `button.rx.isEnabled`                  | `Binder<Bool>`             |
+| UI ↔ Rx | ControlProperty를 source와 sink로 사용 | `ControlProperty<Element>` |
+
+UI 값을 읽는 것과 UI에 값을 쓰는 것을 같은 Relay로 무조건 양방향 연결하면 피드백 루프가 생길 수 있어요. 사용자 입력과 렌더링 상태를 별도 흐름으로 두고 `distinctUntilChanged()` 같은 동등성 경계를 명시하세요.
+
+## Binder는 오류를 받지 않는 UI Observer예요
+
+```swift
+viewModel.title
+  .bind(to: titleLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+공식 Binder의 성질은 다음과 같아요.
+
+- 기본적으로 `MainScheduler`에서 바인딩해요.
+- 대상 객체를 강하게 보관하지 않아요.
+- next 값만 처리하고 error 이벤트를 허용하지 않아요.
+- 디버그에서 오류가 들어오면 실패하고 릴리스에서는 오류를 기록해요.
+
+따라서 오류 가능한 Observable은 Binder 전에 사용자 상태로 변환해야 해요.
+
+```swift
+profileTitle
+  .catch { error in
+    logger.record(error)
+    return .just("프로필을 불러오지 못했어요")
+  }
+  .bind(to: titleLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+## 동적 멤버 Binder를 이해해요
+
+Reactive는 참조 타입의 쓰기 가능한 속성을 동적 멤버 Binder로 만들 수 있어요.
+
+```swift
+viewModel.isHidden
+  .bind(to: emptyView.rx.isHidden)
+  .disposed(by: disposeBag)
+```
+
+단순 속성 대입에는 편리하지만, 값 변환이나 애니메이션처럼 별도 의미가 있으면 이름 있는 Binder를 만들어 의도를 드러내세요.
+
+```swift
+extension Reactive where Base: UIView {
+  var animatedVisibility: Binder<Bool> {
+    Binder(base) { view, isVisible in
+      UIView.animate(withDuration: 0.2) {
+        view.alpha = isVisible ? 1 : 0
+      }
+    }
+  }
+}
+```
+
+## ControlProperty는 현재 값과 사용자 변경을 제공해요
+
+```swift
+let text: ControlProperty<String?> = textField.rx.text
+
+text.orEmpty
+  .subscribe(onNext: { value in
+    print(value)
+  })
+  .disposed(by: disposeBag)
+```
+
+ControlProperty의 공식 계약은 다음과 같아요.
+
+1. 구독하면 현재 값을 먼저 보내요.
+2. 이후 사용자 조작으로 생긴 값을 보내요.
+3. 컨트롤이 해제되면 완료해요.
+4. 오류를 보내지 않아요.
+5. 메인 Scheduler에서 구독·관찰해요.
+6. 최신 값을 하나 공유하는 성격을 가져요.
+
+현재 값을 건너뛰고 이후 변경만 필요하면 `changed`를 사용해요.
+
+```swift
+textField.rx.text.orEmpty.changed
+  .subscribe(onNext: { text in
+    analytics.recordEdited(text)
+  })
+  .disposed(by: disposeBag)
+```
+
+`textField.text = "새 값"`처럼 코드로 속성을 바꿨다고 사용자 control event가 항상 발생하는 것은 아니에요. 상태 입력은 View Model이나 Relay의 명시적인 메서드로 전달하세요.
+
+## ControlEvent는 초기값 없는 UI 사건이에요
+
+```swift
+let tap: ControlEvent<Void> = submitButton.rx.tap
+
+tap
+  .subscribe(onNext: {
+    print("제출")
+  })
+  .disposed(by: disposeBag)
+```
+
+ControlEvent는 오류와 초기 replay가 없고, 컨트롤 해제 시 완료하며, 메인 Scheduler에서 구독·관찰해요. 탭·선택·편집 시작처럼 현재 상태가 아닌 순간 사건에 적합해요.
+
+## UIControl은 target-action을 Rx로 연결해요
+
+```swift
+slider.rx.controlEvent(.valueChanged)
+  .withLatestFrom(slider.rx.value)
+  .subscribe(onNext: { value in
+    print("볼륨:", value)
+  })
+  .disposed(by: disposeBag)
+```
+
+RxCocoa의 ControlTarget이 UIKit target-action 등록을 관리하고, 구독이 폐기되면 연결을 정리해요. 컨트롤별 확장은 이를 이용해 `tap`, `value`, `isOn` 같은 타입 안전한 API를 제공해요.
+
+## 양방향 바인딩은 순환을 점검해요
+
+```swift
+textField.rx.text.orEmpty
+  .distinctUntilChanged()
+  .bind(to: queryRelay)
+  .disposed(by: disposeBag)
+
+queryRelay
+  .distinctUntilChanged()
+  .bind(to: textField.rx.text)
+  .disposed(by: disposeBag)
+```
+
+ControlProperty의 setter가 동일한 사용자 event를 다시 발생시키지 않는 경우가 많지만, 모든 사용자 정의 컨트롤이 같은 것은 아니에요. 두 방향의 변환이 비대칭이거나 값 정규화가 반복되면 루프가 생길 수 있으므로 한쪽을 상태의 단일 소유자로 정하는 편이 안전해요.
+
+## 타입 선택 기준
+
+| 질문                                       | 선택              |
+| ------------------------------------------ | ----------------- |
+| 컨트롤의 현재 값과 이후 변경이 필요한가요? | `ControlProperty` |
+| 지금 발생한 UI 사건만 필요한가요?          | `ControlEvent`    |
+| Observable 값을 UI 속성에 적용하나요?      | `Binder`          |
+| 여러 UI가 소비할 View Model 상태인가요?    | `Driver`          |
+| replay하면 안 되는 View Model 사건인가요?  | `Signal`          |
+
+## 자주 하는 실수
+
+- source와 sink 방향을 구분하지 않고 양방향 연결해요.
+- 오류 가능한 Observable을 Binder에 직접 연결해요.
+- ControlProperty가 코드로 바꾼 모든 속성 변경을 event로 보낸다고 생각해요.
+- Binder 안에 네트워크 요청과 상태 전이를 넣어요.
+- UI 구독을 백그라운드에서 만들고 초기 replay 위치를 놓쳐요.
+
+## 적용 체크리스트
+
+- UI 값이 상태인지 사건인지 구분했나요?
+- Binder 이전에 오류를 처리했나요?
+- 사용자 정의 Reactive API가 adapter 역할만 하나요?
+- 양방향 바인딩의 단일 상태 소유자와 중복 제거 기준이 있나요?
+- 컨트롤과 구독의 수명이 DisposeBag에 연결됐나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### `.rx`가 원본 객체를 바꾸나요?
+
+아니요. `Reactive<Base>`가 원본 객체를 base로 감싸고 확장 API를 제공해요. 원본 타입의 별도 복사본이나 subclass를 만드는 것은 아니에요.
+
+### Binder가 대상을 강하게 잡지 않는 이유는 무엇인가요?
+
+구독이 Binder 대상 UI를 불필요하게 연장하지 않게 해 참조 순환 가능성을 줄이기 위해서예요. 구독 자체의 수명 관리는 여전히 DisposeBag으로 해야 해요.
+
+## 참고 자료
+
+- [Reactive 공식 API](https://docs.rxswift.org/structs/reactive)
+- [Binder 공식 API](https://docs.rxswift.org/structs/binder)
+- [ControlProperty 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/ControlProperty.swift)
+- [ControlEvent 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/ControlEvent.swift)
+- [UIControl Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/UIControl%2BRx.swift)

--- a/docs/guide/rxswift/relay-state-store-and-concurrency.md
+++ b/docs/guide/rxswift/relay-state-store-and-concurrency.md
@@ -1,0 +1,273 @@
+---
+title: Relay 상태 Store와 동시성
+description: BehaviorRelay와 PublishRelay로 읽기 전용 Driver·Signal을 노출하는 Store를 만들고 단방향 상태 변경, read-modify-write 경쟁, 영속성과 테스트 기준을 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/BehaviorRelay.swift
+reviewed: '2026-09-06'
+---
+
+# Relay 상태 Store와 동시성
+
+> **면접 답변 한 줄 요약:** Relay Store는 상태 Relay와 사건 Relay를 private으로 소유하고 Driver·Signal만 공개하며, 모든 read-modify-write를 MainActor·actor·serial Scheduler 중 하나에서 직렬화해야 해요.
+
+Relay는 상태를 보관할 수 있지만 상태 관리 아키텍처 자체는 아니에요. 누가 값을 바꿀 수 있는지, 변경 순서가 어떻게 직렬화되는지, 실패와 영속성을 어디서 처리할지는 Store가 설계해야 해요.
+
+## 상태와 사건을 분리해요
+
+```swift
+import Foundation
+import RxSwift
+import RxRelay
+import RxCocoa
+
+struct CartItem: Equatable {
+  let id: UUID
+  let name: String
+}
+
+struct CartState: Equatable {
+  var items: [CartItem] = []
+  var isSaving = false
+}
+
+enum CartMessage {
+  case added
+  case alreadyExists
+  case saveFailed
+}
+
+@MainActor
+final class CartStore {
+  private let stateRelay = BehaviorRelay(value: CartState())
+  private let messageRelay = PublishRelay<CartMessage>()
+
+  var state: Driver<CartState> {
+    stateRelay
+      .asDriver()
+      .distinctUntilChanged()
+  }
+
+  var message: Signal<CartMessage> {
+    messageRelay.asSignal()
+  }
+
+  /// 장바구니에 상품을 추가합니다.
+  ///
+  /// - Parameter item: 새로 담을 상품입니다.
+  func add(
+    item: CartItem
+  ) {
+    var next = stateRelay.value
+
+    guard !next.items.contains(where: { $0.id == item.id }) else {
+      messageRelay.accept(.alreadyExists)
+      return
+    }
+
+    next.items.append(item)
+    stateRelay.accept(next)
+    messageRelay.accept(.added)
+  }
+}
+```
+
+핵심 경계는 다음과 같아요.
+
+- BehaviorRelay는 현재 화면 상태를 보관해요.
+- PublishRelay는 다시 실행하면 안 되는 메시지를 전달해요.
+- Relay는 private이라 Store만 accept할 수 있어요.
+- 외부는 Driver와 Signal로 읽기만 해요.
+- `@MainActor`가 상태 변경 순서를 메인 actor에 격리해요.
+
+## public Relay보다 의도 있는 메서드를 제공해요
+
+```swift
+// 피해야 할 공개 쓰기 권한
+let cartState = BehaviorRelay(value: CartState())
+```
+
+Relay를 공개하면 화면, 네트워크 callback, 테스트 helper가 각자 전체 상태를 accept할 수 있어요. `add`, `remove`, `save`처럼 의도를 드러내는 입력만 제공하면 상태 불변식을 한곳에서 검증할 수 있어요.
+
+## read-modify-write는 하나의 원자 연산이 아니에요
+
+```swift
+var next = stateRelay.value
+next.items.append(item)
+stateRelay.accept(next)
+```
+
+두 작업이 동시에 같은 기존 값을 읽고 서로 다른 값을 append한 뒤 accept하면 마지막 쓰기가 앞선 변경을 덮을 수 있어요. BehaviorRelay 내부의 개별 `value`와 `accept` 동기화가 세 줄 전체를 원자적으로 만들지는 않아요.
+
+```text
+작업 A: read [] ─ append A ───────── accept [A]
+작업 B: ─ read [] ─ append B ─ accept [B]
+결과: 실행 순서에 따라 A 또는 B 갱신을 잃을 수 있어요.
+```
+
+다음 중 하나로 상태 변경을 직렬화하세요.
+
+- UIKit 화면 상태는 Store 전체를 `@MainActor`로 격리해요.
+- 백그라운드 상태는 Swift actor 안에서 계산하고 완성된 값을 Relay에 전달해요.
+- Rx만 사용하는 계층은 전용 `SerialDispatchQueueScheduler`에서 action을 reduce해요.
+- 여러 입력을 하나의 action Observable로 모아 `scan`으로 상태를 만들어요.
+
+Relay는 actor나 lock의 대체물이 아니고 Sendable 안전성을 자동으로 제공하지 않아요.
+
+## action과 scan으로 단방향 흐름을 만들어요
+
+```swift
+enum CounterAction {
+  case increment
+  case decrement
+  case reset
+}
+
+let actionRelay = PublishRelay<CounterAction>()
+
+let state = actionRelay
+  .scan(0) { state, action in
+    switch action {
+    case .increment:
+      return state + 1
+    case .decrement:
+      return state - 1
+    case .reset:
+      return 0
+    }
+  }
+  .startWith(0)
+  .distinctUntilChanged()
+  .share(replay: 1, scope: .whileConnected)
+```
+
+입력을 action 하나로 모으면 상태 변경 순서와 규칙을 테스트하기 쉬워요. 상태가 반드시 Subscriber와 무관하게 유지돼야 한다면 Store가 BehaviorRelay를 소유하고 scan 결과를 bind할 수 있어요. 반대로 화면이 연결된 동안만 계산하면 된다면 공유 Observable만으로도 충분할 수 있어요.
+
+## 같은 상태 방출을 제어해요
+
+BehaviorRelay는 같은 값을 accept해도 방출해요. State가 Equatable이라면 출력에서 중복을 제거할 수 있어요.
+
+```swift
+var state: Driver<CartState> {
+  stateRelay
+    .asDriver()
+    .distinctUntilChanged()
+}
+```
+
+큰 상태 전체 비교가 비싸거나 화면이 일부 필드만 필요하면 필드를 먼저 map한 뒤 중복을 제거하세요.
+
+```swift
+let itemCount = store.state
+  .map(\.items.count)
+  .distinctUntilChanged()
+```
+
+## 비동기 요청 상태를 값으로 모델링해요
+
+Relay 자체는 오류로 종료되지 않으므로 요청의 실패를 무시하지 말고 상태나 사건으로 바꿔요.
+
+```swift
+enum ProductListState: Equatable {
+  case idle
+  case loading
+  case loaded([Product])
+  case failed(String)
+}
+
+requestRelay
+  .flatMapLatest { request in
+    api.load(request)
+      .map(ProductListState.loaded)
+      .catch { error in
+        logger.record(error)
+        return .just(.failed("상품을 불러오지 못했어요"))
+      }
+      .startWith(.loading)
+  }
+  .bind(to: stateRelay)
+  .disposed(by: disposeBag)
+```
+
+요청 Observable은 오류와 취소 계약을 유지하고, Store 경계에서 화면이 이해하는 상태로 변환해요.
+
+## Relay는 영속성 계층이 아니에요
+
+앱 재실행 뒤에도 장바구니가 남아야 한다면 UserDefaults, 파일, SwiftData, Realm 같은 저장소가 필요해요.
+
+```text
+영구 저장소 ── load ──▶ Store ── Driver ──▶ 화면
+     ▲                    │
+     └──── save ◀──── 상태 변경
+```
+
+초기값을 저장소에서 읽고 Relay에 넣으며, 상태 변경 뒤 저장 작업의 성공·실패를 별도로 처리하세요. ReplayRelay 버퍼를 디스크 캐시처럼 사용하면 앱 종료 시 모두 사라져요.
+
+## Relay를 전역 이벤트 버스로 만들지 않아요
+
+전역 PublishRelay에 모든 화면 사건을 넣으면 생산자와 소비자의 의존 관계, 순서, 중복, 수명을 추적하기 어려워요.
+
+- 기능별 Store가 Relay를 소유해요.
+- 사건 타입을 작은 enum으로 제한해요.
+- 외부에는 Signal이나 Observable만 노출해요.
+- 화면 간 통신은 Router, 도메인 Store, 명시적 의존성을 우선해요.
+
+## Store를 테스트해요
+
+```swift
+@MainActor
+func testAddItem() {
+  let store = CartStore()
+  let item = CartItem(
+    id: UUID(),
+    name: "RxSwift 책"
+  )
+  var states: [CartState] = []
+
+  let disposable = store.state
+    .drive(onNext: { states.append($0) })
+
+  store.add(item: item)
+
+  XCTAssertEqual(states.last?.items, [item])
+  disposable.dispose()
+}
+```
+
+시간 기반 파이프라인이 있다면 RxTest의 TestScheduler로 action 시간과 출력 이벤트를 검증하세요. Store의 Relay를 public으로 열어 테스트 값을 주입하기보다 공개 입력을 통해 상태를 바꾸는 편이 실제 계약을 검증해요.
+
+## 자주 하는 실수
+
+- Relay를 public으로 열어 모든 계층이 accept해요.
+- 상태와 일회성 사건을 BehaviorRelay 하나에 섞어요.
+- 여러 queue에서 `value`를 읽고 수정해 갱신을 잃어요.
+- 같은 상태 accept가 자동으로 제거된다고 생각해요.
+- 네트워크 오류를 Relay가 알아서 무시할 것으로 기대해요.
+- ReplayRelay를 앱 영구 저장소로 사용해요.
+- 전역 PublishRelay를 기능 간 메시지 버스로 사용해요.
+
+## 적용 체크리스트
+
+- 상태와 사건이 다른 Relay로 분리됐나요?
+- Relay 쓰기 권한이 Store 내부에만 있나요?
+- 모든 상태 변경이 하나의 actor 또는 serial 경계에 있나요?
+- 오류와 로딩을 사용자 상태로 모델링했나요?
+- 동일 상태 렌더링을 줄일 기준이 있나요?
+- 영속성 요구사항을 별도 저장소가 담당하나요?
+- 테스트가 공개 입력과 읽기 전용 출력을 사용하나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### BehaviorRelay가 thread-safe하면 Store도 thread-safe한가요?
+
+아니요. 개별 API의 내부 동기화와 상태 전이 전체의 원자성은 달라요. value 읽기, 수정, accept를 하나의 MainActor·actor·serial Scheduler에서 실행해야 갱신 손실을 막을 수 있어요.
+
+### 상태와 사건을 Relay 타입으로 어떻게 구분하나요?
+
+새 Subscriber가 현재 값을 알아야 하는 상태는 BehaviorRelay, 구독 뒤 새로 발생한 값만 처리해야 하는 사건은 PublishRelay를 기본으로 선택해요. 외부 출력은 각각 Driver와 Signal로 좁힐 수 있어요.
+
+## 참고 자료
+
+- [BehaviorRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/BehaviorRelay.swift)
+- [PublishRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/PublishRelay.swift)
+- [RxCocoa Driver 변환](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/Driver/BehaviorRelay%2BDriver.swift)
+- [RxCocoa Signal 변환](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/Signal/PublishRelay%2BSignal.swift)
+- [Observable bind to Relay](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/Observable%2BBind.swift)

--- a/docs/guide/rxswift/relay-types-and-replay.md
+++ b/docs/guide/rxswift/relay-types-and-replay.md
@@ -1,0 +1,234 @@
+---
+title: PublishRelay, BehaviorRelay와 ReplayRelay
+description: 세 RxRelay 타입의 accept·value·buffer·late subscriber 동작, asObservable·asInfallible 변환과 Observable bind 오류 규칙을 공식 구현 기준으로 비교합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxRelay
+reviewed: '2026-09-06'
+---
+
+# PublishRelay, BehaviorRelay와 ReplayRelay
+
+> **면접 답변 한 줄 요약:** PublishRelay는 새 사건만, BehaviorRelay는 초기값과 최신 값 하나를, ReplayRelay는 지정한 과거 버퍼를 전달하며 세 타입 모두 `accept`로 next만 받고 종료하지 않아요.
+
+RxRelay의 세 타입은 각각 PublishSubject, BehaviorSubject, ReplaySubject를 감싸요. 차이는 오류·완료 API를 제거하고 값 입력을 `accept`로 제한한다는 점이에요.
+
+## 공통 계약
+
+```swift
+let relay = PublishRelay<Int>()
+
+relay.accept(1)
+relay.accept(2)
+```
+
+- `.error`를 보낼 수 없어요.
+- `.completed`를 보낼 수 없어요.
+- 값은 `accept(_:)`로 넣어요.
+- ObservableType이므로 직접 구독할 수 있어요.
+- `asObservable()`과 `asInfallible()`로 읽기 타입을 바꿀 수 있어요.
+- 스스로 종료하지 않으므로 Subscriber의 dispose 수명은 별도로 관리해요.
+
+## PublishRelay는 구독 뒤 값만 전달해요
+
+```swift
+let relay = PublishRelay<String>()
+
+relay.accept("구독 전")
+
+relay
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+
+relay.accept("구독 후")
+// 구독 후
+```
+
+새 Subscriber에게 초기값이나 최근 값을 주지 않아요. 버튼 탭을 Store에 전달하거나, 토스트·화면 이동 같은 일회성 사건을 내부에서 발행할 때 적합해요.
+
+```swift
+private let routeRelay = PublishRelay<Route>()
+
+var route: Signal<Route> {
+  routeRelay.asSignal()
+}
+```
+
+Relay를 private으로 두고 Signal만 공개하면 외부는 과거 replay 없이 사건을 소비할 수 있고 `accept` 권한은 소유자에게 남아요.
+
+## BehaviorRelay는 항상 최신 값이 있어요
+
+```swift
+let relay = BehaviorRelay(value: 0)
+
+print(relay.value) // 0
+
+relay.accept(1)
+print(relay.value) // 1
+```
+
+초기값이 필수이고 새 Subscriber는 최신 값을 즉시 받아요. `value`는 현재 값을 동기적으로 읽어요.
+
+```swift
+relay
+  .subscribe(onNext: { print("A:", $0) })
+  .disposed(by: disposeBag)
+
+relay.accept(2)
+
+relay
+  .subscribe(onNext: { print("B:", $0) })
+  .disposed(by: disposeBag)
+
+// A: 1
+// A: 2
+// B: 2
+```
+
+화면 상태, 선택된 필터, 장바구니처럼 새 소비자가 현재 값을 알아야 하는 데이터에 적합해요. 값이 없을 수 있다는 이유로 무조건 Optional 초기값을 쓰기보다 `.idle` 같은 명시적 초기 상태를 모델링하세요.
+
+## ReplayRelay는 최근 N개를 보관해요
+
+```swift
+let relay = ReplayRelay<String>.create(bufferSize: 2)
+
+relay.accept("A")
+relay.accept("B")
+relay.accept("C")
+
+relay
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+
+// B
+// C
+```
+
+`create(bufferSize:)`는 최근 N개만 보관해요. `createUnbound()`는 들어온 모든 값을 저장하므로 공식 구현도 메모리 사용에 주의하라고 명시해요.
+
+ReplayRelay에는 BehaviorRelay의 `value`와 같은 동기 조회 API가 없어요. 버퍼는 late subscriber에게 이벤트를 replay하기 위한 것이지, 임의 조회와 삭제를 제공하는 컬렉션 저장소가 아니에요.
+
+## late subscriber 동작을 한눈에 봐요
+
+```text
+시간       A ── B ── C ── [구독] ── D
+
+PublishRelay                    D
+BehaviorRelay               C, D
+ReplayRelay(buffer: 2)    B, C, D
+```
+
+상태에는 최신 값, 사건에는 구독 후 값이라는 기준이 가장 중요해요. ReplayRelay는 “혹시 놓칠까 봐” 선택하기보다 과거 N개를 새 소비자가 받아야 하는 명시적 요구가 있을 때만 사용하세요.
+
+## Observable과 Infallible로 읽기 권한을 좁혀요
+
+```swift
+private let stateRelay = BehaviorRelay(value: State.initial)
+
+var state: Observable<State> {
+  stateRelay.asObservable()
+}
+
+var safeState: Infallible<State> {
+  stateRelay.asInfallible()
+}
+```
+
+`asObservable()`은 일반 RxSwift 소비자와 연산자를 위한 경계이고, `asInfallible()`은 오류가 없다는 계약까지 타입에 표현해요. UIKit 화면에는 `asDriver()`와 `asSignal()`이 메인 Scheduler 계약을 추가해요.
+
+## 같은 값을 accept해도 다시 방출해요
+
+```swift
+let relay = BehaviorRelay(value: false)
+
+relay
+  .distinctUntilChanged()
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+
+relay.accept(false)
+relay.accept(true)
+relay.accept(true)
+```
+
+Relay는 동등성을 검사하지 않아요. 모든 accept를 이벤트로 전달해요. 같은 상태 렌더링을 줄여야 한다면 `Equatable` 기준을 정하고 읽기 경계에서 `distinctUntilChanged()`를 사용하세요.
+
+## Observable을 Relay에 bind할 때 오류를 처리해요
+
+```swift
+searchBar.rx.text.orEmpty
+  .bind(to: queryRelay)
+  .disposed(by: disposeBag)
+```
+
+ControlProperty처럼 오류 없는 입력은 바로 bind할 수 있어요. 오류 가능한 Observable은 먼저 복구하거나 오류 상태로 분기해야 해요.
+
+```swift
+api.loadProducts()
+  .catch { error in
+    errorRelay.accept(error)
+    return .empty()
+  }
+  .bind(to: productsRelay)
+  .disposed(by: disposeBag)
+```
+
+공식 `Observable+Bind` 구현은 Relay에 오류가 들어오면 디버그에서 fatal error를 발생시키고 릴리스에서는 로그를 남겨요. Relay가 오류를 무시하고 계속 구독해 주는 것이 아니에요.
+
+## Relay와 Subject를 비교해요
+
+| 타입            | 값 입력  | 오류·완료 | 최신 값 조회  | replay           |
+| --------------- | -------- | --------- | ------------- | ---------------- |
+| PublishSubject  | `onNext` | 가능      | 불가          | 없음             |
+| BehaviorSubject | `onNext` | 가능      | `try value()` | 최신 1개         |
+| ReplaySubject   | `onNext` | 가능      | 불가          | 버퍼 또는 무제한 |
+| PublishRelay    | `accept` | 불가      | 불가          | 없음             |
+| BehaviorRelay   | `accept` | 불가      | `value`       | 최신 1개         |
+| ReplayRelay     | `accept` | 불가      | 불가          | 버퍼 또는 무제한 |
+
+실패와 완료가 도메인 의미라면 Subject나 Single·Maybe·Completable을 사용하세요. 종료 없는 상태·사건 입력에 Relay가 맞아요.
+
+## Relay와 share를 비교해요
+
+| 질문                  | Relay                       | `share(replay:scope:)`                 |
+| --------------------- | --------------------------- | -------------------------------------- |
+| 외부에서 값을 넣나요? | `accept` 가능               | 불가                                   |
+| 주된 목적             | 상태·사건의 소유 지점       | 기존 cold 소스의 구독과 부수 효과 공유 |
+| 종료                  | 없음                        | 원본 소스의 오류·완료를 따라요.        |
+| replay                | Relay 종류에 따라 정해져요. | 인자와 scope로 정해요.                 |
+
+네트워크 요청 중복을 막기 위해 BehaviorRelay에 결과를 수동 복사하기보다, 먼저 `share`가 문제에 맞는지 확인하세요.
+
+## 자주 하는 실수
+
+- 모든 값을 BehaviorRelay로 만들어 사건까지 replay해요.
+- ReplayRelay를 영구 저장소나 조회 가능한 배열로 생각해요.
+- `createUnbound()`에 무한 이벤트를 쌓아요.
+- Relay를 public으로 노출해 아무 코드나 accept하게 해요.
+- 같은 값을 자동으로 제거한다고 생각해요.
+- 오류 Observable을 바로 Relay에 bind해 디버그 실패를 만들어요.
+
+## 적용 체크리스트
+
+- 값이 현재 상태인지 일회성 사건인지 구분했나요?
+- late subscriber가 받아야 하는 값의 개수를 정했나요?
+- Relay가 private이고 읽기 전용 출력만 공개되나요?
+- ReplayRelay 버퍼에 메모리 상한이 있나요?
+- 동일 상태 재방출 기준을 정했나요?
+- bind 전 오류가 의도적으로 처리되나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Relay가 절대 메모리 누수를 만들지 않나요?
+
+아니요. Relay가 오류·완료 없이 계속 살아 있다는 뜻일 뿐이에요. Relay와 Subscriber의 소유 관계, DisposeBag 수명, ReplayRelay 버퍼 크기에 따라 메모리를 오래 유지할 수 있어요.
+
+### BehaviorRelay의 초기값은 왜 필수인가요?
+
+새 Subscriber에게 언제나 현재 값 하나를 제공한다는 계약을 지키기 위해서예요. 초기 상태를 정의할 수 없다면 Optional, 명시적 상태 enum 또는 다른 Relay가 더 맞는지 검토해야 해요.
+
+## 참고 자료
+
+- [RxRelay 공식 소스](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxRelay)
+- [PublishRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/PublishRelay.swift)
+- [BehaviorRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/BehaviorRelay.swift)
+- [ReplayRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/ReplayRelay.swift)
+- [Relay bind 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/Observable%2BBind.swift)

--- a/docs/guide/rxswift/rxblocking.md
+++ b/docs/guide/rxswift/rxblocking.md
@@ -1,0 +1,192 @@
+---
+title: RxBlocking으로 동기 결과 검사하기
+description: toBlocking의 timeout과 first·last·single·toArray·materialize 동작을 비교하고 테스트 전용 동기 대기에서 발생할 수 있는 무한 대기와 메인 스레드 교착을 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxBlocking
+reviewed: '2026-09-06'
+---
+
+# RxBlocking으로 동기 결과 검사하기
+
+> **면접 답변 한 줄 요약:** RxBlocking은 테스트에서 현재 스레드를 막고 Observable 결과를 동기적으로 꺼내는 도구이며, 완료되지 않는 스트림과 메인 Scheduler 의존 소스에서는 timeout 또는 교착 위험이 있어 제품 코드에 사용하면 안 돼요.
+
+RxBlocking의 공식 `BlockingObservable` 문서도 테스트와 데모에는 유용하지만 일반 제품 앱에는 부적절하다고 설명해요. 비동기 모델을 동기 호출로 숨기기 때문에 사용 범위를 테스트 타깃으로 제한하세요.
+
+## Observable을 BlockingObservable로 바꿔요
+
+```swift
+import RxSwift
+import RxBlocking
+
+let blocking = Observable.of(1, 2, 3)
+  .toBlocking(timeout: 1)
+```
+
+`toBlocking(timeout:)` 자체가 바로 기다리는 것은 아니고 blocking 연산자를 제공하는 래퍼를 만들어요. `first`, `last`, `single`, `toArray`, `materialize`를 호출할 때 현재 스레드를 막아요.
+
+timeout이 지나면 `RxError.timeout`을 throw해요. timeout을 생략하면 종료되지 않는 소스에서 무한 대기할 수 있어요.
+
+## blocking 연산자를 비교해요
+
+| 연산자          | 기다리는 조건                               | 반환                                  |
+| --------------- | ------------------------------------------- | ------------------------------------- |
+| `first()`       | 첫 값 또는 그 전의 종료·오류                | `Element?`                            |
+| `last()`        | 전체 시퀀스 종료                            | 마지막 `Element?`                     |
+| `single()`      | 전체 결과가 정확히 하나인지 확인            | `Element`                             |
+| `single(_:)`    | 조건을 만족하는 결과가 정확히 하나인지 확인 | `Element`                             |
+| `toArray()`     | 전체 시퀀스 정상 완료                       | `[Element]`                           |
+| `materialize()` | 전체 시퀀스 정상 완료 또는 오류             | `MaterializedSequenceResult<Element>` |
+
+`first()`는 첫 값을 받으면 구독을 폐기할 수 있지만, `last()`와 `toArray()`는 마지막을 알기 위해 완료를 기다려야 해요.
+
+## 배열 결과를 검사해요
+
+```swift
+import XCTest
+import RxSwift
+import RxBlocking
+
+func testFilteredValues() throws {
+  let result = try Observable.of(1, 2, 3, 4)
+    .filter { $0.isMultiple(of: 2) }
+    .toBlocking(timeout: 1)
+    .toArray()
+
+  XCTAssertEqual(result, [2, 4])
+}
+```
+
+값과 순서만 간단히 검사할 때 읽기 쉬워요. 이벤트 시각과 구독·폐기를 검증해야 한다면 RxTest가 더 적합해요.
+
+## first, last, single의 빈 시퀀스 처리가 달라요
+
+```swift
+let first = try Observable<Int>
+  .empty()
+  .toBlocking(timeout: 1)
+  .first()
+
+XCTAssertNil(first)
+```
+
+`first()`와 `last()`는 빈 시퀀스에서 nil을 반환해요. `single()`은 정확히 한 값이 아니면 `RxError.noElements` 또는 `RxError.moreThanOneElement`를 throw해요.
+
+```swift
+XCTAssertThrowsError(
+  try Observable.of(1, 2)
+    .toBlocking(timeout: 1)
+    .single()
+)
+```
+
+값 하나의 계약을 검증하는 테스트라면 single이 의도를 더 분명히 보여 줘요.
+
+## materialize로 실패 전 값도 확인해요
+
+```swift
+enum LoadError: Error {
+  case failed
+}
+
+let result = Observable.concat(
+  .just(1),
+  .just(2),
+  .error(LoadError.failed)
+)
+.toBlocking(timeout: 1)
+.materialize()
+
+switch result {
+case let .completed(elements):
+  XCTFail("오류를 기대했지만 완료했어요: \(elements)")
+case let .failed(elements, error):
+  XCTAssertEqual(elements, [1, 2])
+  XCTAssertTrue(error is LoadError)
+}
+```
+
+`toArray()`는 오류를 throw하므로 오류 전 값 목록을 함께 잃어요. `materialize()`는 정상 완료의 전체 값 또는 실패 전 값과 오류를 함께 반환해 통합 흐름을 자세히 검사할 수 있어요.
+
+## 완료되지 않는 Observable을 주의해요
+
+```swift
+let result = try Observable<Int>
+  .never()
+  .toBlocking(timeout: 0.1)
+  .toArray()
+```
+
+`never`는 값도 종료도 보내지 않으므로 timeout까지 현재 스레드가 멈춰요. Relay, UI event, 무한 interval에 `last`나 `toArray`를 쓰면 같은 문제가 생겨요.
+
+무한 스트림의 일부만 검사하려면 `take`로 테스트 경계를 만든 뒤 완료시키거나 RxTest로 가상 시간과 dispose를 검증하세요.
+
+```swift
+let values = try updates
+  .take(3)
+  .toBlocking(timeout: 1)
+  .toArray()
+```
+
+## 메인 스레드 교착을 피해야 해요
+
+다음 조건이 동시에 성립하면 교착 또는 timeout이 발생할 수 있어요.
+
+1. 테스트가 메인 스레드에서 `toBlocking`으로 현재 스레드를 막아요.
+2. source가 `observe(on: MainScheduler.instance)` 뒤 이벤트를 보내려고 해요.
+3. 메인 스레드는 blocking 호출이 끝나기를 기다려 예약된 이벤트를 실행하지 못해요.
+
+```text
+Main Thread: toBlocking 대기 ─────────────┐
+                                          │
+MainScheduler event: 메인 실행 대기 ◀─────┘
+```
+
+해결을 위해 제품 코드를 억지로 다른 Scheduler로 바꾸기보다 RxTest로 Scheduler를 주입하거나 async 테스트로 경계를 유지하세요.
+
+## RxTest와 선택 기준
+
+| 요구사항                           | 선택                     |
+| ---------------------------------- | ------------------------ |
+| 값 배열 하나를 간단히 동기 검증    | RxBlocking               |
+| debounce·retry·timeout의 시각 검증 | RxTest                   |
+| hot·cold 구독과 dispose 시각 검증  | RxTest                   |
+| 실패 전 값과 종료 오류를 함께 검사 | RxBlocking `materialize` |
+| MainScheduler 기반 UI Trait 테스트 | Scheduler 주입과 RxTest  |
+| async API의 결과 하나를 검사       | XCTest async 테스트      |
+
+RxBlocking은 간단하지만 비동기 구조를 숨겨요. 테스트 요구가 커지면 RxTest의 기록 기반 검증으로 옮기는 편이 좋아요.
+
+## 자주 하는 실수
+
+- 제품 코드에서 비동기 값을 동기 반환하려고 RxBlocking을 사용해요.
+- timeout을 생략하고 끝나지 않는 Relay를 기다려요.
+- MainScheduler가 필요한 source를 메인 스레드에서 block해요.
+- `last`와 `toArray`가 완료 이벤트를 필요로 한다는 점을 놓쳐요.
+- 이벤트 시간과 폐기까지 검증해야 하는 테스트에 값 배열만 비교해요.
+- `single()`이 첫 값을 반환한다고 오해해요.
+
+## 적용 체크리스트
+
+- RxBlocking이 테스트 타깃에만 연결됐나요?
+- 모든 blocking 호출에 합리적인 timeout이 있나요?
+- source가 유한하게 완료되는지 확인했나요?
+- source가 현재 막고 있는 Scheduler를 필요로 하지 않나요?
+- 값 개수에 맞는 first·last·single·toArray를 골랐나요?
+- 시간과 구독 수명 검증에는 RxTest를 사용했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### RxBlocking을 제품 코드에 쓰면 안 되는 이유는 무엇인가요?
+
+현재 스레드를 막아 응답성과 동시성을 해치고, source가 같은 Scheduler를 필요로 하면 교착을 만들 수 있어요. 비동기 취소와 구조화된 수명도 호출부에서 보이지 않게 돼요.
+
+### `single()`과 `first()`의 차이는 무엇인가요?
+
+first는 첫 값을 받으면 반환하고 빈 시퀀스에서는 nil이에요. single은 전체 시퀀스에서 값이 정확히 하나인지 확인하며 0개나 2개 이상이면 오류를 throw해요.
+
+## 참고 자료
+
+- [RxBlocking 공식 소스](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxBlocking)
+- [BlockingObservable 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxBlocking/BlockingObservable.swift)
+- [Blocking 연산자 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxBlocking/BlockingObservable%2BOperators.swift)
+- [toBlocking 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxBlocking/ObservableConvertibleType%2BBlocking.swift)
+- [Unit Tests 공식 문서](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/UnitTests.md)

--- a/docs/guide/rxswift/rxcocoa.md
+++ b/docs/guide/rxswift/rxcocoa.md
@@ -13,6 +13,16 @@ RxSwift만으로도 Observable을 만들 수 있지만, `UITextField`의 문자�
 
 이 문서는 **RxSwift 6.10.2의 RxCocoa 공식 구현과 Traits 문서**를 기준으로 해요. Observable의 구독·공유·Scheduler가 아직 낯설다면 [RxSwift 핵심 구조와 생명 주기](./rxswift-core)를 먼저 읽어 보세요.
 
+## 이 모듈의 상세 문서
+
+- [Reactive·Binder·Control Traits](./reactive-binder-control-traits): `.rx` 프록시와 UI source·sink의 계약
+- [Driver·Signal·SharedSequence](./driver-signal-shared-sequence): 오류·Scheduler·공유·replay 정책의 차이
+- [UIKit 컨트롤 바인딩](./uikit-control-bindings): 텍스트, 버튼, 스크롤, 제스처, 내비게이션과 웹 뷰
+- [리스트와 DelegateProxy](./list-bindings-and-delegate-proxy): table·collection 바인딩과 delegate 호출 중계
+- [Foundation 바인딩](./foundation-bindings): NotificationCenter, URLSession, KVO와 객체 생명 주기
+
+Rx 생태계 전체 범위와 권장 순서는 [공식 API 범위와 학습 순서](./official-api-inventory)에서 확인하세요.
+
 ## 먼저 알아둘 용어
 
 | 용어            | 뜻                                                                                                          |

--- a/docs/guide/rxswift/rxcocoa.md
+++ b/docs/guide/rxswift/rxcocoa.md
@@ -1,0 +1,444 @@
+---
+title: RxCocoa로 UIKit 입력과 출력을 바인딩하기
+description: RxCocoa의 Reactive 프록시, Binder, ControlProperty, ControlEvent, Driver, Signal과 DelegateProxy를 UIKit 검색 화면 예제로 자세히 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxCocoa
+reviewed: '2026-09-06'
+---
+
+# RxCocoa로 UIKit 입력과 출력을 바인딩하기
+
+> **면접 답변 한 줄 요약:** RxCocoa는 UIKit의 속성·컨트롤 이벤트·delegate를 Observable과 Binder로 연결하고, `Driver`와 `Signal`로 메인 스레드·오류 없음·공유 정책을 UI 계약에 담는 모듈이에요.
+
+RxSwift만으로도 Observable을 만들 수 있지만, `UITextField`의 문자열을 읽고 `UILabel`의 텍스트를 갱신하려면 UIKit의 target-action, delegate, 속성 대입을 직접 연결해야 해요. RxCocoa는 이 경계를 `searchBar.rx.text`, `button.rx.tap`, `label.rx.text`처럼 일관된 형태로 제공해요.
+
+이 문서는 **RxSwift 6.10.2의 RxCocoa 공식 구현과 Traits 문서**를 기준으로 해요. Observable의 구독·공유·Scheduler가 아직 낯설다면 [RxSwift 핵심 구조와 생명 주기](./rxswift-core)를 먼저 읽어 보세요.
+
+## 먼저 알아둘 용어
+
+| 용어            | 뜻                                                                                                          |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| Reactive 프록시 | 원본 객체를 `base`로 보관하고 `.rx` 아래에 반응형 API를 제공하는 `Reactive<Base>` 래퍼예요.                 |
+| source          | UI에서 Observable 쪽으로 값을 내보내는 API예요. `button.rx.tap`, `textField.rx.text`가 대표적이에요.        |
+| sink            | Observable 값을 UI에 적용하는 소비 지점이에요. `label.rx.text` 같은 Binder가 대표적이에요.                  |
+| binding         | source의 값을 sink에 연결해 자동으로 전달하는 관계예요.                                                     |
+| UI Trait        | 메인 Scheduler, 오류 없음, 공유 같은 UI 전용 규칙을 타입에 담은 RxCocoa 래퍼예요.                           |
+| DelegateProxy   | UIKit delegate·data source 호출을 가로채 Observable로 전달하면서 원래 delegate 전달도 중계하는 프록시예요.  |
+| replay          | 새 Subscriber에게 구독 전의 최근 값을 다시 보내는 동작이에요. 상태에는 유용하지만 일회성 사건에는 주의해요. |
+
+## `.rx`는 원본 객체를 감싼 Reactive 프록시예요
+
+RxCocoa에서 `NSObject` 계열은 `ReactiveCompatible`을 채택하므로 `.rx`를 사용할 수 있어요.
+
+```swift
+let text: ControlProperty<String?> = searchBar.rx.text
+let tap: ControlEvent<Void> = searchButton.rx.tap
+let title: Binder<String?> = titleLabel.rx.text
+```
+
+이 세 값은 방향이 달라요.
+
+```text
+UITextField ── ControlProperty ──▶ Observable 파이프라인
+UIButton    ── ControlEvent ─────▶ Observable 파이프라인
+Observable ── Binder ────────────▶ UILabel
+```
+
+`.rx`는 UIKit 객체를 복제하지 않아요. `Reactive<Base>`가 원본 객체를 `base`로 참조하고, RxCocoa가 확장으로 source와 sink를 제공해요.
+
+## Binder는 UI에 값을 쓰는 안전한 출구예요
+
+`Binder<Value>`는 Observable의 값을 특정 객체에 적용하는 Observer예요. 공식 API 기준으로 다음 성질을 가져요.
+
+- 지정한 Scheduler에서 바인딩하며 기본값은 `MainScheduler`예요.
+- 바인딩 대상 객체를 강하게 붙잡지 않아요.
+- 오류 이벤트를 받을 수 있는 일반 Observer가 아니며, 오류가 들어오면 디버그 빌드에서 실패하고 릴리스 빌드에서는 로그를 남겨요.
+
+```swift
+let disposeBag = DisposeBag()
+
+viewModel.title
+  .bind(to: titleLabel.rx.text)
+  .disposed(by: disposeBag)
+
+viewModel.isLoading
+  .bind(to: activityIndicator.rx.isAnimating)
+  .disposed(by: disposeBag)
+```
+
+따라서 Binder에 연결하기 전 업스트림 오류를 반드시 처리해야 해요.
+
+```swift
+viewModel.title
+  .catch { error in
+    logger.record(error)
+    return .just("불러오지 못했어요")
+  }
+  .bind(to: titleLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+오류를 빈 값으로 무조건 숨기기보다 사용자에게 보여 줄 실패 상태, 재시도 경로, 기록할 오류를 먼저 정하세요.
+
+## 사용자 정의 Binder로 명령형 UI 코드를 감춰요
+
+반복되는 속성 변경은 `Reactive` 확장에 Binder로 모을 수 있어요.
+
+```swift
+import UIKit
+import RxCocoa
+
+extension Reactive where Base: UIView {
+  var isDimmed: Binder<Bool> {
+    Binder(base) { view, isDimmed in
+      view.alpha = isDimmed ? 0.45 : 1.0
+      view.isUserInteractionEnabled = !isDimmed
+    }
+  }
+}
+
+viewModel.isLoading
+  .bind(to: contentView.rx.isDimmed)
+  .disposed(by: disposeBag)
+```
+
+또한 `Reactive`의 동적 멤버 Binder는 참조 타입의 쓰기 가능한 속성을 sink로 만들 수 있어요. RxCocoa가 명시적인 Binder를 이미 제공한다면 그 API를 먼저 사용하고, 단순 속성 대입에만 동적 멤버를 고려하세요.
+
+```swift
+viewModel.isHidden
+  .bind(to: emptyView.rx.isHidden)
+  .disposed(by: disposeBag)
+```
+
+Binder는 도메인 로직을 넣는 장소가 아니에요. 값의 의미를 결정하는 변환은 View Model에서 끝내고, Binder는 색상·텍스트·표시 여부처럼 UI 적용만 담당하게 두세요.
+
+## ControlProperty는 현재 값이 있는 컨트롤 속성이에요
+
+`UITextField.rx.text`는 `ControlProperty<String?>`예요. 공식 Traits 문서가 설명하는 성질은 다음과 같아요.
+
+- 구독하면 컨트롤의 현재 값부터 받아요.
+- 사용자 조작으로 생긴 변경을 이어서 받아요.
+- 컨트롤이 해제되면 시퀀스가 완료해요.
+- 오류를 보내지 않아요.
+- 메인 Scheduler에서 구독·관찰해요.
+- 마지막 값을 하나 공유하는 성격을 가져요.
+- Observer이기도 해서 값을 컨트롤에 다시 바인딩할 수 있어요.
+
+```swift
+searchBar.rx.text.orEmpty
+  .distinctUntilChanged()
+  .subscribe(onNext: { query in
+    print("검색어:", query)
+  })
+  .disposed(by: disposeBag)
+```
+
+::::warning 코드로 바꾼 값이 항상 UI 이벤트가 되지는 않아요
+ControlProperty는 주로 **사용자가 컨트롤을 조작해 발생한 변경**을 전달해요. `textField.text = "RxSwift"`처럼 프로그래밍 방식으로 속성을 바꿨다고 동일한 control event가 자동 발생한다고 가정하지 마세요. 앱 상태를 바꾸려면 View Model 입력이나 Relay 같은 명시적 경로를 사용하세요.
+::::
+
+현재 값을 제외하고 이후 사용자 변경만 필요하면 `ControlProperty.changed`를 사용할 수 있어요.
+
+```swift
+searchBar.rx.text.orEmpty.changed
+  .subscribe(onNext: { query in
+    print("이후 변경:", query)
+  })
+  .disposed(by: disposeBag)
+```
+
+## ControlEvent는 replay하지 않는 UI 사건이에요
+
+`button.rx.tap`은 `ControlEvent<Void>`예요.
+
+- 구독 직후 과거 사건이나 초기값을 보내지 않아요.
+- 컨트롤이 해제되면 완료해요.
+- 오류를 보내지 않아요.
+- 메인 Scheduler에서 구독·관찰해요.
+
+```swift
+retryButton.rx.tap
+  .subscribe(onNext: {
+    print("재시도")
+  })
+  .disposed(by: disposeBag)
+```
+
+버튼 탭, 선택, 편집 시작처럼 “지금 발생한 사건”에는 ControlEvent가 자연스러워요. 화면이 다시 바인딩될 때 과거 탭이 재생되면 안 되므로 최신 값을 보존하는 상태 스트림과 구분하세요.
+
+## Driver는 UI 상태를 구동해요
+
+`Driver<Element>`는 `SharedSequence<DriverSharingStrategy, Element>`의 별칭이에요. 공식 구현이 보장하는 핵심은 세 가지예요.
+
+1. 오류를 전달하지 않아요.
+2. 이벤트를 `MainScheduler`에서 관찰해요.
+3. 하나의 업스트림 구독을 공유하고, 연결된 동안 최신 값 1개를 replay해요.
+
+개념적으로 다음 공유 정책과 같아요.
+
+```swift
+source
+  .observe(on: MainScheduler.instance)
+  .catchAndReturn(fallback)
+  .share(replay: 1, scope: .whileConnected)
+```
+
+실제 코드에서는 `asDriver`로 오류 대체 정책을 명시해요.
+
+```swift
+let title: Driver<String> = titleService.loadTitle()
+  .asDriver(onErrorJustReturn: "제목을 불러오지 못했어요")
+
+title
+  .drive(titleLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+`drive`, `drive(onNext:)` 같은 Driver 전용 구독은 메인 스레드에서 호출해야 해요. Driver가 이벤트 관찰 위치를 보장한다고 해서 백그라운드에서 UI 바인딩 구독 자체를 만드는 습관까지 권장되는 것은 아니에요.
+
+## Signal은 replay하지 않는 UI 사건을 전달해요
+
+`Signal<Element>`도 오류 없이 메인 Scheduler에서 관찰하고 업스트림을 공유해요. Driver와 달리 새 Subscriber에게 과거 값을 replay하지 않아요.
+
+```swift
+let message: Signal<String> = viewModel.message
+
+message
+  .emit(onNext: { [weak self] text in
+    self?.showToast(text)
+  })
+  .disposed(by: disposeBag)
+```
+
+화면 표시 상태, 버튼 활성화처럼 새 구독자가 현재 값을 알아야 하면 Driver가 어울려요. 토스트, 화면 이동, 햅틱처럼 과거 사건을 다시 실행하면 안 되면 Signal이 더 잘 맞아요.
+
+## UI 타입을 한 표에서 비교해요
+
+| 타입              | 방향        | 오류 | 메인 관찰 | 초기·최근 값 replay          | 대표 용도                |
+| ----------------- | ----------- | ---- | --------- | ---------------------------- | ------------------------ |
+| `Binder<T>`       | 스트림 → UI | 거부 | 기본 보장 | 해당 없음                    | UI 속성 적용             |
+| `ControlProperty` | UI ↔ 스트림 | 없음 | 보장      | 현재 값 1개                  | 텍스트, 선택 상태        |
+| `ControlEvent`    | UI → 스트림 | 없음 | 보장      | 없음                         | 탭, 편집 시작            |
+| `Driver<T>`       | 스트림 → UI | 없음 | 보장      | 연결 중 최신 값 1개          | 화면 상태                |
+| `Signal<T>`       | 스트림 → UI | 없음 | 보장      | 없음                         | 일회성 화면 사건         |
+| `Observable<T>`   | 일반 스트림 | 가능 | 미보장    | 소스와 연산자에 따라 달라요. | 도메인·데이터 파이프라인 |
+
+`ControlProperty`와 `ControlEvent`는 컨트롤에서 만들어지는 Trait이고, Driver와 Signal은 View Model 출력처럼 일반 Observable을 UI 계약으로 변환할 때 주로 사용해요. Binder는 반대편에서 UI에 값을 적용하는 sink예요.
+
+## 검색 화면을 입력부터 출력까지 연결해요
+
+GitHub 저장소를 검색하는 화면을 예로 들어 볼게요. `searchAPI.search(query:)`는 `Observable<[Repository]>`를 반환한다고 가정해요.
+
+```swift
+import UIKit
+import RxSwift
+import RxCocoa
+
+struct Repository {
+  let name: String
+}
+
+enum SearchViewState {
+  case idle
+  case loading
+  case loaded([Repository])
+  case failed(String)
+}
+
+let disposeBag = DisposeBag()
+
+let query = searchBar.rx.text.orEmpty
+  .asDriver()
+  .debounce(.milliseconds(300))
+  .distinctUntilChanged()
+
+let state: Driver<SearchViewState> = query
+  .flatMapLatest { query in
+    guard !query.isEmpty else {
+      return .just(.idle)
+    }
+
+    return searchAPI.search(query: query)
+      .map(SearchViewState.loaded)
+      .asDriver { error in
+        logger.record(error)
+        return .just(.failed("검색 결과를 불러오지 못했어요"))
+      }
+      .startWith(.loading)
+  }
+
+let repositories = state
+  .map { state -> [Repository] in
+    guard case let .loaded(items) = state else {
+      return []
+    }
+    return items
+  }
+
+repositories
+  .drive(
+    tableView.rx.items(
+      cellIdentifier: "RepositoryCell",
+      cellType: UITableViewCell.self
+    )
+  ) { _, repository, cell in
+    cell.textLabel?.text = repository.name
+  }
+  .disposed(by: disposeBag)
+
+state
+  .map { state in
+    if case .loading = state {
+      return true
+    }
+    return false
+  }
+  .drive(activityIndicator.rx.isAnimating)
+  .disposed(by: disposeBag)
+
+state
+  .compactMap { state -> String? in
+    guard case let .failed(message) = state else {
+      return nil
+    }
+    return message
+  }
+  .drive(errorLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+이 흐름에서 각 도구의 역할은 분명해요.
+
+1. `ControlProperty`가 현재 검색어와 사용자 변경을 입력으로 제공해요.
+2. Driver의 `debounce`와 `flatMapLatest`가 최신 검색만 유지해요.
+3. 네트워크 오류를 UI가 표현할 `failed` 상태로 바꿔 Driver 계약을 만들어요.
+4. Driver가 동일한 상태 흐름을 테이블, 로딩 표시, 오류 문구에 공유해요.
+5. Binder와 `tableView.rx.items`가 명령형 UI 갱신을 화면 경계에 모아요.
+
+단순히 `asDriver(onErrorJustReturn: [])`로 바꾸면 “검색 결과가 없음”과 “네트워크 실패”가 모두 빈 배열이 돼요. 사용자 경험에서 둘을 구분해야 한다면 예제처럼 상태 enum으로 모델링하세요.
+
+## UITableView와 UICollectionView 바인딩을 이해해요
+
+RxCocoa의 `tableView.rx.items`와 `collectionView.rx.items`는 데이터 시퀀스를 UIKit data source 호출로 연결해요.
+
+```swift
+repositories
+  .drive(
+    collectionView.rx.items(
+      cellIdentifier: "RepositoryCell",
+      cellType: RepositoryCell.self
+    )
+  ) { _, repository, cell in
+    cell.configure(with: repository)
+  }
+  .disposed(by: disposeBag)
+```
+
+`rx.items`가 반환하는 Disposable은 data source 프록시의 수명과 연결돼요. 구독이 살아 있는 동안 RxCocoa가 data source를 유지하고, 폐기되면 바인딩 관계도 정리돼요.
+
+단순 배열 바인딩은 편리하지만 삽입·삭제 애니메이션과 복잡한 섹션 diff가 필요하면 RxDataSources, DifferenceKit, UIKit Diffable Data Source 같은 별도 전략을 비교하세요. 모든 값 방출마다 전체 셀을 직접 다시 만드는 방식이 항상 최선은 아니에요.
+
+## DelegateProxy는 delegate 호출을 Observable로 바꿔요
+
+UIKit의 delegate는 한 객체 프로퍼티에 하나만 설정할 수 있어요. RxCocoa는 `DelegateProxy`로 delegate 호출을 가로채 Observable 이벤트로 전달하고, 필요하면 원래 delegate에도 호출을 넘겨요.
+
+```swift
+tableView.rx.itemSelected
+  .subscribe(onNext: { indexPath in
+    print("선택:", indexPath)
+  })
+  .disposed(by: disposeBag)
+```
+
+직접 delegate도 설정해야 한다면 RxCocoa가 제공하는 경로를 사용해 충돌을 피하세요.
+
+```swift
+tableView.rx.setDelegate(self)
+  .disposed(by: disposeBag)
+```
+
+다음 실수를 주의하세요.
+
+- Rx 바인딩 뒤에 `tableView.delegate = anotherObject`를 직접 대입해 프록시를 덮지 않아요.
+- `rx.items`와 별도의 `dataSource`를 동시에 소유하지 않아요.
+- delegate 반환값이 필요한 고급 API는 단순 `methodInvoked` 관찰만으로 충분한지 확인해요.
+- Rx가 지원하지 않는 custom delegate라면 `DelegateProxy` 구현 비용과 단순 adapter의 비용을 비교해요.
+
+## 재사용 셀은 셀 단위 구독 수명을 가져요
+
+셀을 재사용할 때 이전 모델의 구독이 남아 있으면 새 셀 내용에 옛 이벤트가 섞일 수 있어요.
+
+```swift
+final class RepositoryCell: UITableViewCell {
+  var disposeBag = DisposeBag()
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
+}
+```
+
+셀 내부 버튼처럼 셀 수명에 종속되는 구독은 셀의 bag에 보관하고, 화면 전체 상태 구독은 View Controller의 bag에 보관하세요. 다만 매번 재사용 때 바인딩을 다시 만들기보다 셀의 고정 UI 이벤트를 한 번 외부로 노출하는 구조가 더 단순한지도 함께 검토해야 해요.
+
+## 자주 하는 실수를 점검해요
+
+### UI에 일반 Observable을 바로 구독해요
+
+스케줄러와 오류 처리가 호출부마다 흩어져요. View Model 출력 경계에서 Driver 또는 Signal로 변환하면 UI 계약이 한곳에 모여요.
+
+### Driver를 모든 스트림에 사용해요
+
+Driver는 최신 값을 replay하므로 일회성 사건을 다시 실행할 수 있어요. 상태는 Driver, 사건은 Signal이라는 출발점을 두고 실제 replay 요구사항으로 판단하세요.
+
+### `asDriver(onErrorJustReturn:)`로 오류를 숨겨요
+
+오류가 계약에서 사라진 대신 대체 값의 의미를 사용자가 구분하지 못할 수 있어요. 실패 상태, 로깅, 재시도를 함께 설계하세요.
+
+### 하나의 cold 요청을 여러 UI 출력에서 따로 구독해요
+
+요청이 중복될 수 있어요. View Model에서 공유된 Driver 하나를 만들고 여러 Binder가 그 출력을 구동하게 하세요.
+
+### Binder 안에 비즈니스 로직을 넣어요
+
+Binder는 UI 적용 경계예요. 필터링, 권한 판정, 상태 전이는 View Model이나 도메인 계층에서 처리하세요.
+
+## 적용 체크리스트
+
+- UI 입력이 현재 값을 가진 속성인지, replay하면 안 되는 사건인지 구분했나요?
+- View Model 출력이 Driver와 Signal 중 어떤 계약을 요구하는지 정했나요?
+- Binder에 도달하기 전에 오류를 사용자 상태로 변환했나요?
+- 동일한 cold 작업을 여러 UI가 소비할 때 구독이 공유되나요?
+- `rx.items`와 직접 data source 설정이 충돌하지 않나요?
+- delegate를 직접 설정한다면 RxCocoa 프록시를 보존하나요?
+- 화면과 재사용 셀의 DisposeBag 수명을 구분했나요?
+- 프로그래밍 방식의 속성 변경을 사용자 control event로 오해하지 않았나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Driver와 Signal의 가장 중요한 차이는 무엇인가요?
+
+둘 다 오류 없이 메인 Scheduler에서 관찰하고 업스트림을 공유하지만, Driver는 연결 중 최신 값 하나를 replay하고 Signal은 과거 값을 replay하지 않아요. 그래서 상태와 일회성 사건을 구분하는 기준이 돼요.
+
+### Binder가 일반 Observer보다 UI에 적합한 이유는 무엇인가요?
+
+기본적으로 메인 Scheduler에서 값을 적용하고 대상을 강하게 붙잡지 않으며 오류를 허용하지 않아서, UI sink가 지켜야 할 제약을 타입과 구현에 모아 두기 때문이에요.
+
+### ControlProperty와 ControlEvent는 무엇이 다른가요?
+
+ControlProperty는 현재 값을 먼저 보내고 이후 사용자 변경을 전달하는 양방향 속성이며, ControlEvent는 초기값이나 과거 replay 없이 지금 발생한 사건만 전달하는 읽기 전용 흐름이에요.
+
+### RxCocoa가 delegate를 Observable로 만드는 방식은 무엇인가요?
+
+DelegateProxy가 UIKit delegate 자리에 들어가 메서드 호출을 관찰 가능한 이벤트로 전달하고, 필요하면 실제 delegate로 호출을 중계해요. 직접 delegate를 덮어쓰면 프록시와 충돌할 수 있어요.
+
+## 참고 자료
+
+- [ReactiveX/RxSwift 6.10.2 — RxCocoa](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxCocoa)
+- [RxCocoa Traits 공식 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md#rxcocoa-traits)
+- [Binder 공식 API](https://docs.rxswift.org/structs/binder)
+- [ControlProperty 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/ControlProperty.swift)
+- [ControlEvent 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/ControlEvent.swift)
+- [Driver 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/Driver/Driver.swift)
+- [Signal 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Traits/Signal/Signal.swift)
+- [DelegateProxy 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/Common/DelegateProxy.swift)
+- [UITableView Rx 확장 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/UITableView%2BRx.swift)

--- a/docs/guide/rxswift/rxrelay.md
+++ b/docs/guide/rxswift/rxrelay.md
@@ -13,6 +13,13 @@ reviewed: '2026-09-06'
 
 이 문서는 **RxSwift 6.10.2의 RxRelay 공식 구현**을 기준으로 해요. UI 출력에 사용하는 `Driver`와 `Signal`은 [RxCocoa UI 바인딩](./rxcocoa)에서 설명해요.
 
+## 이 모듈의 상세 문서
+
+- [Relay 종류와 replay](./relay-types-and-replay): PublishRelay·BehaviorRelay·ReplayRelay의 구독 전후 전달 규칙
+- [상태 Store와 동시성](./relay-state-store-and-concurrency): 변경 경로 캡슐화, Driver·Signal 출력과 경쟁 상태 예방
+
+RxSwift·RxCocoa와 테스트 제품을 포함한 전체 범위는 [공식 API 범위와 학습 순서](./official-api-inventory)에서 확인하세요.
+
 ## 먼저 알아둘 용어
 
 | 용어              | 뜻                                                                                                            |

--- a/docs/guide/rxswift/rxrelay.md
+++ b/docs/guide/rxswift/rxrelay.md
@@ -1,0 +1,358 @@
+---
+title: RxRelay로 상태와 이벤트 모델링하기
+description: PublishRelay, BehaviorRelay, ReplayRelay의 저장·재생 규칙과 accept 사용법, 상태·이벤트 선택 기준, 캡슐화와 동시성 주의점을 공식 구현 기준으로 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxRelay
+reviewed: '2026-09-06'
+---
+
+# RxRelay로 상태와 이벤트 모델링하기
+
+> **면접 답변 한 줄 요약:** RxRelay는 Subject를 감싸 `.next` 값만 받도록 만든 종료 없는 스트림이며, 현재 상태에는 `BehaviorRelay`, 새 사건에는 `PublishRelay`, 제한된 과거 재생에는 `ReplayRelay`를 사용해요.
+
+화면 상태나 사용자 입력은 보통 값이 계속 바뀌지만 “오류로 종료”하거나 “정상 완료”할 대상은 아니에요. Subject로 표현하면 어느 코드든 `onError`나 `onCompleted`를 보내 스트림을 영구 종료할 수 있어요. RxRelay는 이런 입력에서 종료 이벤트를 제거해 값만 받도록 만든 별도 모듈이에요.
+
+이 문서는 **RxSwift 6.10.2의 RxRelay 공식 구현**을 기준으로 해요. UI 출력에 사용하는 `Driver`와 `Signal`은 [RxCocoa UI 바인딩](./rxcocoa)에서 설명해요.
+
+## 먼저 알아둘 용어
+
+| 용어              | 뜻                                                                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| Relay             | Subject를 감싸 값 이벤트만 받고 오류나 완료를 외부 API에서 제거한 타입이에요.                                 |
+| `accept(_:)`      | Relay에 새 값을 넣는 메서드예요. 내부 Subject의 `.onNext`로 전달돼요.                                         |
+| current value     | 가장 최근 상태값이에요. `BehaviorRelay.value`로 읽을 수 있어요.                                               |
+| replay buffer     | 새 Subscriber에게 다시 보낼 과거 값의 개수예요.                                                               |
+| 상태(state)       | 화면이 현재 어떤 모습이어야 하는지 나타내며, 새 구독자도 최신 값을 알아야 하는 데이터예요.                    |
+| 사건(event)       | 버튼 탭, 토스트 요청처럼 특정 시점에 한 번 발생하며 과거 값을 재실행하면 안 되는 신호예요.                    |
+| read-modify-write | 현재 값을 읽고 수정한 뒤 새 값으로 쓰는 연속 작업이에요. 각 단계가 안전해도 전체가 원자적이지 않을 수 있어요. |
+
+## Relay는 Subject의 종료 API를 제거해요
+
+공식 구현에서 각 Relay는 대응하는 Subject를 내부에 보관하고, `accept`를 Subject의 `.onNext`로 전달해요.
+
+```text
+PublishRelay  ── wraps ── PublishSubject
+BehaviorRelay ── wraps ── BehaviorSubject
+ReplayRelay   ── wraps ── ReplaySubject
+```
+
+```swift
+import RxSwift
+import RxRelay
+
+let relay = PublishRelay<String>()
+let disposeBag = DisposeBag()
+
+relay
+  .subscribe(onNext: { value in
+    print(value)
+  })
+  .disposed(by: disposeBag)
+
+relay.accept("로그인 완료")
+```
+
+Relay에는 `onError`와 `onCompleted`를 보내는 공개 API가 없어요. 그렇다고 구독 자원이 자동으로 사라지는 것은 아니에요. Relay가 스스로 종료하지 않으므로 Subscriber는 `Disposable`과 `DisposeBag`으로 수명을 반드시 관리해야 해요.
+
+## 세 Relay의 재생 규칙을 비교해요
+
+| 타입                     | 생성할 때 필요한 값 | 새 Subscriber가 처음 받는 값           | 현재 값 직접 읽기 | 대표 용도                        |
+| ------------------------ | ------------------- | -------------------------------------- | ----------------- | -------------------------------- |
+| `PublishRelay<Element>`  | 없음                | 구독 이후 `accept`한 값만 받아요.      | 불가              | 탭, 토스트, 화면 이동 요청       |
+| `BehaviorRelay<Element>` | 초기값              | 가장 최근 값 1개를 즉시 받아요.        | `value`           | 화면 상태, 설정, 선택 목록       |
+| `ReplayRelay<Element>`   | 버퍼 크기           | 버퍼에 남은 과거 값을 순서대로 받아요. | 불가              | 제한된 최근 기록, 연결 직후 복구 |
+
+선택 질문은 “몇 개를 저장할까?”보다 **이 값이 상태인지 사건인지**에서 시작하세요.
+
+```text
+새 구독자가 현재 값을 알아야 하나요?
+├─ 예  ─▶ BehaviorRelay
+└─ 아니요
+   ├─ 과거 N개가 명시적으로 필요한가요? ─▶ ReplayRelay
+   └─ 새 사건만 필요하나요?              ─▶ PublishRelay
+```
+
+## PublishRelay는 구독 뒤의 사건만 보내요
+
+```swift
+let toastRelay = PublishRelay<String>()
+
+toastRelay.accept("첫 번째 메시지")
+
+toastRelay
+  .subscribe(onNext: { message in
+    print(message)
+  })
+  .disposed(by: disposeBag)
+
+toastRelay.accept("두 번째 메시지")
+
+// 두 번째 메시지만 출력해요.
+```
+
+첫 번째 메시지는 Subscriber가 없을 때 발생했으므로 사라져요. 이것은 버그가 아니라 PublishRelay의 계약이에요. 화면이 아직 구독하지 않았을 때 생긴 사건도 반드시 처리해야 한다면 “사건 버퍼”를 무작정 늘리기보다 앱 상태나 명시적인 큐로 모델링해야 하는지 먼저 검토하세요.
+
+일회성 UI 사건을 화면에 노출할 때는 RxCocoa의 Signal로 읽기 전용 계약을 만들 수 있어요.
+
+```swift
+import RxCocoa
+
+private let messageRelay = PublishRelay<String>()
+
+var message: Signal<String> {
+  messageRelay.asSignal()
+}
+```
+
+외부에는 `Signal`만 보이므로 값을 주입하는 `accept` 권한은 소유 객체 안에 남아요.
+
+## BehaviorRelay는 초기값과 최신 상태를 가져요
+
+BehaviorRelay는 반드시 초기값을 받아요.
+
+```swift
+struct FilterState: Equatable {
+  var keyword = ""
+  var showsFavoritesOnly = false
+}
+
+let filterRelay = BehaviorRelay(value: FilterState())
+
+filterRelay
+  .subscribe(onNext: { state in
+    print(state.keyword, state.showsFavoritesOnly)
+  })
+  .disposed(by: disposeBag)
+```
+
+구독 직후 초기 `FilterState()`가 한 번 전달돼요. 이후 상태를 바꾸려면 새 값을 `accept`해요.
+
+```swift
+var nextState = filterRelay.value
+nextState.keyword = "RxSwift"
+filterRelay.accept(nextState)
+```
+
+`value`는 가장 최근 값을 동기적으로 읽어요. 하지만 상태가 없을 수도 있다는 이유만으로 `BehaviorRelay<State?>`를 만들고 `nil`을 무조건 초기값으로 두면 화면마다 nil 분기가 늘어날 수 있어요. `.idle`, `.loading`, `.loaded`, `.failed`를 가진 enum처럼 실제 상태 기계를 모델링할 수 있는지 먼저 생각하세요.
+
+## ReplayRelay는 정한 개수만 과거 값을 다시 보내요
+
+```swift
+let historyRelay = ReplayRelay<String>.create(bufferSize: 2)
+
+historyRelay.accept("A")
+historyRelay.accept("B")
+historyRelay.accept("C")
+
+historyRelay
+  .subscribe(onNext: { value in
+    print(value)
+  })
+  .disposed(by: disposeBag)
+
+// B
+// C
+```
+
+버퍼 크기가 2이므로 새 Subscriber는 최근 두 값만 받아요. `ReplayRelay.createUnbound()`는 모든 과거 값을 보관하므로 공식 구현도 메모리 사용에 주의하라고 명시해요. 로그 전체처럼 데이터가 계속 늘어나는 흐름에는 제한된 버퍼나 별도 영구 저장소를 사용하세요.
+
+ReplayRelay는 `BehaviorRelay.value`처럼 현재 값을 동기적으로 꺼내는 API를 제공하지 않아요. 과거 값 컬렉션을 직접 조회하고 수정해야 한다면 Relay 버퍼를 저장소로 오해한 것이 아닌지 점검하세요.
+
+## 상태 저장소는 쓰기 권한을 캡슐화해요
+
+장바구니 상태는 BehaviorRelay로, 사용자에게 한 번 보여 줄 메시지는 PublishRelay로 분리해 볼게요.
+
+```swift
+import Foundation
+import RxSwift
+import RxRelay
+import RxCocoa
+
+struct CartItem: Equatable {
+  let id: UUID
+  let name: String
+}
+
+struct CartState: Equatable {
+  var items: [CartItem]
+}
+
+@MainActor
+final class CartStore {
+  private let stateRelay = BehaviorRelay(
+    value: CartState(items: [])
+  )
+  private let messageRelay = PublishRelay<String>()
+
+  var state: Driver<CartState> {
+    stateRelay
+      .asDriver()
+      .distinctUntilChanged()
+  }
+
+  var message: Signal<String> {
+    messageRelay.asSignal()
+  }
+
+  /// 장바구니에 상품을 추가하고 사용자 메시지를 발행합니다.
+  ///
+  /// - Parameter item: 장바구니에 새로 담을 상품입니다.
+  func add(
+    item: CartItem
+  ) {
+    var nextState = stateRelay.value
+
+    guard !nextState.items.contains(where: { $0.id == item.id }) else {
+      messageRelay.accept("이미 담은 상품이에요")
+      return
+    }
+
+    nextState.items.append(item)
+    stateRelay.accept(nextState)
+    messageRelay.accept("장바구니에 담았어요")
+  }
+}
+```
+
+구조의 핵심은 다음과 같아요.
+
+- Relay는 `private`이라 Store만 `accept`할 수 있어요.
+- 화면에는 현재 값이 필요한 `state: Driver<CartState>`를 노출해요.
+- 화면에는 replay하면 안 되는 `message: Signal<String>`를 노출해요.
+- `@MainActor`가 상태 읽기와 쓰기를 한 실행 영역으로 직렬화해요.
+- `distinctUntilChanged()`는 같은 상태를 다시 accept했을 때 불필요한 UI 갱신을 줄여요.
+
+`BehaviorRelay` 자체는 같은 값을 걸러 주지 않아요. 모든 `accept`는 새 이벤트예요. 값이 `Equatable`이고 중복 제거가 의미 있을 때 읽기 경계에 `distinctUntilChanged()`를 적용하세요.
+
+## `value`를 수정하는 전체 과정은 원자적이지 않아요
+
+다음 코드는 자주 쓰이지만 여러 실행 문맥에서 동시에 호출되면 갱신을 잃을 수 있어요.
+
+```swift
+var items = itemsRelay.value
+items.append(newItem)
+itemsRelay.accept(items)
+```
+
+예를 들어 작업 A와 B가 모두 같은 기존 배열을 읽은 뒤 각각 다른 항목을 추가해 accept하면, 마지막 쓰기가 앞선 변경을 덮을 수 있어요. `value` 읽기와 `accept`가 각각 내부 잠금을 사용하더라도 **읽기 → 수정 → 쓰기 전체**가 하나의 원자 연산이 되는 것은 아니에요.
+
+다음 중 하나로 상태 소유권을 직렬화하세요.
+
+- 화면 상태 Store 전체를 `@MainActor`로 격리해요.
+- 전용 serial Scheduler나 직렬 큐 한 곳에서만 상태를 변경해요.
+- 여러 동시 작업의 결과를 Relay 밖의 actor에서 합친 뒤 완성된 상태만 accept해요.
+- 입력을 하나의 Observable로 모아 `scan`으로 다음 상태를 계산해요.
+
+RxRelay는 상태 보관 도구이지 actor나 lock의 대체물이 아니며, `Sendable` 안전성을 자동으로 제공하지 않아요.
+
+## Observable을 Relay에 bind할 때 오류를 먼저 처리해요
+
+오류가 없는 UI 입력은 Relay에 자연스럽게 연결할 수 있어요.
+
+```swift
+searchBar.rx.text.orEmpty
+  .bind(to: queryRelay)
+  .disposed(by: disposeBag)
+```
+
+반면 오류가 날 수 있는 Observable을 Relay에 바로 bind하면 문제가 생겨요. Relay는 오류를 받을 수 없으므로 공식 `bind(to:)` 구현은 업스트림 오류에서 디버그 빌드의 실패 또는 릴리스 로그로 처리해요.
+
+```swift
+api.loadRecommendations()
+  .catch { error in
+    errorRelay.accept(error)
+    return .empty()
+  }
+  .bind(to: recommendationsRelay)
+  .disposed(by: disposeBag)
+```
+
+오류를 `.empty()`로 바꾸기 전에 별도 오류 상태에 기록하거나 재시도 정책을 적용하세요. Relay가 종료되지 않는다는 이유로 업스트림 오류가 자동으로 무시되는 것은 아니에요.
+
+## Relay와 비슷한 도구를 비교해요
+
+| 도구                        | 외부에서 값 입력 | 오류·완료 | 최근 값 보존               | 주된 역할                   |
+| --------------------------- | ---------------- | --------- | -------------------------- | --------------------------- |
+| `PublishSubject`            | `onNext`         | 가능      | 없음                       | 종료 가능한 콜백 어댑터     |
+| `BehaviorSubject`           | `onNext`         | 가능      | 최신 값 1개                | 종료 가능한 상태 시퀀스     |
+| `PublishRelay`              | `accept`         | 불가      | 없음                       | 종료 없는 사건 입력         |
+| `BehaviorRelay`             | `accept`         | 불가      | 최신 값 1개와 `value`      | 종료 없는 상태 입력         |
+| `ReplayRelay`               | `accept`         | 불가      | 정한 버퍼 또는 무제한      | 종료 없는 제한적 과거 재생  |
+| `share(replay:scope:)` 결과 | 직접 입력 불가   | 소스 따름 | 연산자 설정에 따라 달라요. | cold 소스의 구독 공유       |
+| `Driver`                    | 직접 입력 불가   | 불가      | 연결 중 최신 값 1개        | 메인 Scheduler UI 상태 출력 |
+| `Signal`                    | 직접 입력 불가   | 불가      | 없음                       | 메인 Scheduler UI 사건 출력 |
+
+Relay와 `share`는 바꿔 쓸 수 있는 도구가 아니에요. Relay는 외부에서 값을 주입할 수 있는 상태·사건의 **소유 지점**이고, `share`는 기존 Observable의 **구독과 부수 효과를 공유**하는 연산자예요.
+
+## Relay가 해결하지 않는 문제를 알아둬요
+
+### 영구 저장소가 아니에요
+
+Relay의 값과 replay 버퍼는 메모리에만 있어요. 앱 재실행 뒤 복구가 필요하면 UserDefaults, 파일, 데이터베이스 같은 저장소가 필요해요.
+
+### 동시성 안전을 자동으로 보장하지 않아요
+
+여러 작업이 같은 상태를 읽고 수정하는 정책은 Store, actor, serial Scheduler가 책임져야 해요.
+
+### 중복 값을 자동으로 제거하지 않아요
+
+같은 값을 accept해도 다시 방출해요. 도메인에서 동일성 기준을 정하고 `distinctUntilChanged()`를 적용하세요.
+
+### 실패와 완료를 표현할 수 없어요
+
+네트워크 요청의 성공·실패처럼 종료가 의미 있는 작업 자체를 Relay로 바꾸면 계약이 약해져요. 요청은 `Single`이나 Observable로 유지하고, 그 결과로 화면 상태 Relay를 갱신하는 구조가 더 분명해요.
+
+### 전역 이벤트 버스가 되기 쉬워요
+
+전역 PublishRelay에 여러 기능이 임의 문자열이나 enum 사건을 보내면 의존 관계와 순서를 추적하기 어려워요. Relay는 가능한 한 작은 Store나 기능 경계가 소유하고 입력 메서드와 읽기 전용 출력을 통해 사용하세요.
+
+## 선택 기준을 정리해요
+
+| 질문                                                    | 선택                                              |
+| ------------------------------------------------------- | ------------------------------------------------- |
+| 새 Subscriber가 현재 상태를 즉시 알아야 하나요?         | `BehaviorRelay`                                   |
+| 구독 이후의 새 사건만 전달하면 되나요?                  | `PublishRelay`                                    |
+| 새 Subscriber가 제한된 과거 N개를 반드시 받아야 하나요? | `ReplayRelay.create(bufferSize:)`                 |
+| 값과 함께 오류 또는 정상 완료가 도메인 계약인가요?      | Relay 대신 Subject, Observable, PrimitiveSequence |
+| 여러 Subscriber의 중복 네트워크 요청만 막고 싶은가요?   | Relay 대신 `share(replay:scope:)`                 |
+| UI에 읽기 전용 상태·사건으로 노출하나요?                | `Driver` 또는 `Signal`로 변환                     |
+| 앱 재실행 뒤에도 값이 남아야 하나요?                    | Relay와 별도로 영구 저장소 사용                   |
+
+## 적용 체크리스트
+
+- 값이 상태인지 사건인지 먼저 구분했나요?
+- Relay를 `private`로 두고 외부 쓰기 권한을 제한했나요?
+- 외부에는 Observable, Driver, Signal 같은 읽기 전용 형태를 노출했나요?
+- BehaviorRelay에 의미 있는 초기 상태를 제공했나요?
+- `value` 읽기부터 `accept`까지 하나의 직렬 실행 영역에 있나요?
+- 같은 상태 재방출을 줄여야 한다면 동일성 기준을 정했나요?
+- ReplayRelay 버퍼 크기와 메모리 상한을 정했나요?
+- 오류 가능한 Observable을 bind하기 전에 오류를 처리했나요?
+- Relay가 종료되지 않으므로 Subscriber의 dispose 수명을 관리했나요?
+- 영구 저장, 동시성, 비즈니스 오류를 Relay가 해결한다고 오해하지 않았나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Subject와 Relay의 차이는 무엇인가요?
+
+Subject는 `.next`, `.error`, `.completed`를 받을 수 있지만 Relay는 Subject를 감싸 값만 `accept`하도록 제한해요. 상태나 UI 사건처럼 외부에서 종료시키면 안 되는 입력에 Relay가 적합해요.
+
+### BehaviorRelay와 PublishRelay는 어떻게 선택하나요?
+
+새 Subscriber가 즉시 현재 값을 알아야 하는 상태라면 BehaviorRelay, 구독 이후 새로 생긴 사건만 받아야 한다면 PublishRelay를 선택해요.
+
+### BehaviorRelay의 `value`를 읽고 accept하면 thread-safe한가요?
+
+각 API 호출의 내부 동기화와 별개로 읽기·수정·쓰기 전체는 원자적이지 않아요. 여러 실행 문맥에서 상태를 바꿀 수 있다면 MainActor, actor, serial Scheduler 같은 단일 소유 경계로 직렬화해야 해요.
+
+### ReplayRelay를 캐시로 사용해도 되나요?
+
+연결 중 최근 이벤트 재생에는 쓸 수 있지만 영구 캐시가 아니고, 큰 값이나 무제한 버퍼는 메모리를 계속 사용해요. 조회·만료·영속성이 필요한 캐시는 별도 저장소로 설계해야 해요.
+
+## 참고 자료
+
+- [ReactiveX/RxSwift 6.10.2 — RxRelay](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxRelay)
+- [PublishRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/PublishRelay.swift)
+- [BehaviorRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/BehaviorRelay.swift)
+- [ReplayRelay 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/ReplayRelay.swift)
+- [ObservableType+Relay 바인딩 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxRelay/Observable%2BBind.swift)
+- [RxCocoa Traits 공식 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md#rxcocoa-traits)

--- a/docs/guide/rxswift/rxswift-core.md
+++ b/docs/guide/rxswift/rxswift-core.md
@@ -1,0 +1,373 @@
+---
+title: RxSwift 핵심 구조와 생명 주기
+description: RxSwift의 모듈 구조, Observable 이벤트 계약, 구독과 폐기, cold·hot 시퀀스, 공유, Scheduler와 Swift Concurrency 연동을 공식 문서 기준으로 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2
+reviewed: '2026-09-06'
+---
+
+# RxSwift 핵심 구조와 생명 주기
+
+> **면접 답변 한 줄 요약:** RxSwift는 `Observable`이 값을 밀어 보내고 Observer가 구독하는 모델이며, 이벤트 종료 규칙과 `Disposable` 수명, 실행 Scheduler, 공유 범위를 함께 설계해야 안전하게 사용할 수 있어요.
+
+연산자 이름을 많이 아는 것만으로는 RxSwift 코드를 안정적으로 만들기 어려워요. 같은 네트워크 Observable을 두 번 구독하면 요청도 두 번 실행될 수 있고, `dispose()`와 `.completed`를 같다고 생각하면 취소와 정상 종료를 잘못 모델링할 수 있어요.
+
+이 문서는 **RxSwift 6.10.2** 공식 저장소와 API 문서를 기준으로 코어 모듈의 실행 원리를 설명해요. 개별 연산자의 사용법은 [모든 연산자 문서](./operators-create-convert)에서 이어서 볼 수 있어요.
+
+## 먼저 알아둘 용어
+
+| 용어                   | 뜻                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------- |
+| push                   | 생산자가 준비된 값을 소비자에게 보내는 방식이에요. Observable은 Observer에게 이벤트를 push해요.   |
+| pull                   | 소비자가 다음 값을 직접 요청해 가져오는 방식이에요. Swift의 일반 `Sequence` 순회가 대표적이에요.  |
+| 구독(subscription)     | Observable과 Observer를 연결해 이벤트 전달을 시작하는 관계예요.                                   |
+| 부수 효과(side effect) | 네트워크 요청, 파일 읽기, 로그 기록처럼 값을 계산하는 것 외에 외부 상태에 영향을 주는 작업이에요. |
+| 종료 이벤트            | `.completed` 또는 `.error`예요. 둘 중 하나가 오면 해당 구독에는 다음 이벤트가 더 오지 않아요.     |
+| disposal               | 소비자가 구독을 끊고 관련 자원을 정리하는 동작이에요. 생산자가 보내는 종료 이벤트와는 달라요.     |
+| cold Observable        | 보통 구독할 때마다 값 생산과 부수 효과를 새로 시작하는 Observable이에요.                          |
+| hot Observable         | 구독 여부와 무관하게 진행되는 값 생산을 여러 Observer가 바라보는 Observable이에요.                |
+| Scheduler              | 구독, 이벤트 전달, 시간 기반 작업을 언제 어디에서 실행할지 표현하는 RxSwift의 추상화예요.         |
+| serialization          | 한 구독의 이벤트가 동시에 겹쳐 전달되지 않도록 순서 있게 처리되는 성질이에요.                     |
+
+## RxSwift 모듈의 의존 관계를 먼저 봐요
+
+공식 저장소의 모듈 의존 관계를 단순화하면 다음과 같아요.
+
+```text
+RxCocoa ───────┐
+   │           │
+   ▼           ▼
+RxRelay ───▶ RxSwift ◀── RxTest
+                 ▲
+                 └────── RxBlocking
+```
+
+- `RxSwift`는 Observable, Subject, Scheduler, Disposable과 코어 Trait을 제공하며 다른 Rx 모듈에 의존하지 않아요.
+- `RxRelay`는 RxSwift에 의존하고, 종료되지 않는 값 통로인 Relay를 제공해요.
+- `RxCocoa`는 RxSwift와 RxRelay에 의존하고 UIKit·AppKit 등 Apple UI 프레임워크를 Rx 형태로 연결해요.
+- `RxTest`와 `RxBlocking`은 테스트를 위한 별도 제품이에요.
+
+화면과 무관한 도메인·데이터 계층은 가능하면 `RxSwift`만 알아도 되게 만들고, UIKit 바인딩이 필요한 화면 계층에서 `RxCocoa`를 가져오면 모듈 경계가 선명해져요. 상태와 이벤트를 종료 없는 입력으로 노출해야 할 때만 `RxRelay`를 선택하세요.
+
+## Sequence와 Observable은 방향이 달라요
+
+일반 `Sequence`는 소비자가 `next()`를 호출해 값을 하나씩 가져와요. 반면 Observable은 시간이 지나며 생긴 이벤트를 Observer에게 보내요.
+
+```text
+Sequence:   Consumer ── next() ──▶ Producer
+Observable: Producer ── Event ───▶ Observer
+```
+
+그래서 배열뿐 아니라 버튼 탭, 위치 변화, 소켓 메시지, 네트워크 응답처럼 **도착 시점과 개수가 고정되지 않은 값**도 하나의 인터페이스로 조합할 수 있어요.
+
+```swift
+import RxSwift
+
+let temperatures = Observable.of(19, 21, 23)
+
+temperatures
+  .map { "현재 온도: \($0)℃" }
+  .subscribe(onNext: { text in
+    print(text)
+  })
+  .dispose()
+```
+
+Observable은 값을 동기적으로 보낼 수도 있어요. `Observable.of`는 `subscribe` 호출 안에서 모든 값을 바로 보내고 완료하므로, “Observable은 항상 비동기”라고 이해하면 안 돼요.
+
+## 이벤트 문법은 한 방향으로만 끝나요
+
+Observable이 Observer에게 보낼 수 있는 문법은 다음과 같아요.
+
+```text
+next* (error | completed)?
+```
+
+1. `.next(element)`는 0번 이상 보낼 수 있어요.
+2. `.error(error)`와 `.completed`는 둘 중 하나만 최대 한 번 보낼 수 있어요.
+3. 종료 이벤트 뒤에는 다른 이벤트가 올 수 없어요.
+4. 버튼 탭처럼 종료 이벤트 없이 계속 살아 있는 시퀀스도 가능해요.
+
+이 규칙 덕분에 다운스트림 연산자는 “오류 뒤에 값이 다시 올지”를 매번 방어하지 않아도 돼요. 실패 후 다시 값을 받고 싶다면 같은 Observable이 되살아나는 것이 아니라 `catch`로 대체 시퀀스를 연결하거나 `retry`로 새 구독을 만들어야 해요.
+
+## subscribe는 관찰을 시작하고 Disposable을 돌려줘요
+
+```swift
+let disposeBag = DisposeBag()
+
+Observable.of("Swift", "RxSwift")
+  .subscribe(
+    onNext: { value in
+      print("값:", value)
+    },
+    onError: { error in
+      print("오류:", error)
+    },
+    onCompleted: {
+      print("완료")
+    },
+    onDisposed: {
+      print("자원 정리")
+    }
+  )
+  .disposed(by: disposeBag)
+```
+
+- `subscribe`는 Observer를 연결하고 `Disposable`을 반환해요.
+- Observable이 `.completed` 또는 `.error`를 보내면 해당 구독의 자원이 정리돼요.
+- 소비자가 먼저 `dispose()`해도 구독과 기반 작업을 정리할 수 있어요.
+- `DisposeBag`은 자신이 해제될 때 보관한 Disposable을 모두 폐기해요.
+
+### `dispose()`는 `.completed`가 아니에요
+
+`.completed`는 생산자가 Observer에게 보내는 **정상 종료 이벤트**예요. `dispose()`는 소비자가 더는 결과가 필요 없다고 알려 **연결을 끊는 동작**이에요. 따라서 폐기된 Observer의 `onCompleted`가 호출된다고 기대하면 안 돼요.
+
+또한 이벤트 생산과 폐기를 서로 다른 Scheduler에서 동시에 실행하면 폐기 시점과 이미 진행 중인 이벤트가 경쟁할 수 있어요. “`dispose()` 호출 뒤에는 어떤 상황에서도 값이 단 한 개도 도착하지 않는다”는 보장이 필요하다면 같은 serial Scheduler에서 생산과 폐기를 순서화하거나, UI 계층에서 최신 요청 식별자 같은 별도 상태 검증을 함께 사용하세요.
+
+## create에서는 취소 방법까지 반환해요
+
+`Observable.create`는 이벤트를 보내는 방법뿐 아니라 구독이 끝날 때 기반 작업을 취소하는 방법도 정의해야 해요.
+
+```swift
+import Foundation
+import RxSwift
+
+struct Profile: Decodable {
+  let name: String
+}
+
+enum ProfileError: Error {
+  case missingData
+}
+
+let profileURL = URL(string: "https://example.com/profile")!
+
+func fetchProfile() -> Observable<Profile> {
+  Observable.create { observer in
+    let task = URLSession.shared.dataTask(with: profileURL) { data, _, error in
+      if let error {
+        observer.onError(error)
+        return
+      }
+
+      guard let data else {
+        observer.onError(ProfileError.missingData)
+        return
+      }
+
+      do {
+        let profile = try JSONDecoder().decode(Profile.self, from: data)
+        observer.onNext(profile)
+        observer.onCompleted()
+      } catch {
+        observer.onError(error)
+      }
+    }
+
+    task.resume()
+
+    return Disposables.create {
+      task.cancel()
+    }
+  }
+}
+```
+
+핵심은 세 가지예요.
+
+1. 모든 성공 경로는 필요한 값을 보낸 뒤 정상 완료해요.
+2. 실패 경로는 오류 하나로 끝내요.
+3. 반환한 Disposable에서 `URLSessionTask.cancel()`처럼 실제 기반 작업을 취소해요.
+
+한 번의 비동기 결과라면 값 개수 계약이 더 분명한 `Single<Profile>`이 적합할 수 있어요. 이 예제는 `create`의 생명 주기를 보여 주기 위해 Observable을 사용했어요.
+
+## cold Observable은 구독마다 부수 효과를 반복해요
+
+위 `fetchProfile()`은 cold Observable이에요. Observable 값을 변수에 한 번 담았더라도 구독을 두 번 하면 `create` 클로저도 두 번 실행돼 네트워크 요청이 두 번 시작돼요.
+
+```swift
+let profile = fetchProfile()
+
+profile.subscribe(onNext: { print("이름:", $0.name) })
+profile.subscribe(onNext: { print("로그:", $0.name) })
+```
+
+요청 하나의 결과를 화면 표시와 로그에 함께 쓰려는 의도라면 공유 범위를 명시하세요.
+
+```swift
+let sharedProfile = fetchProfile()
+  .share(replay: 1, scope: .whileConnected)
+
+sharedProfile
+  .map(\.name)
+  .subscribe(onNext: { print("이름:", $0) })
+  .disposed(by: disposeBag)
+
+sharedProfile
+  .subscribe(onNext: { print("로그:", $0.name) })
+  .disposed(by: disposeBag)
+```
+
+### 공유 옵션을 의도로 선택해요
+
+| 선택                                | 늦은 구독자에게 과거 값 | 연결 수명                                                  | 적합한 상황                         |
+| ----------------------------------- | ----------------------- | ---------------------------------------------------------- | ----------------------------------- |
+| 공유하지 않음                       | 해당 없음               | Subscriber마다 독립                                        | 구독마다 새 작업이 필요한 요청      |
+| `share(replay: 0, .whileConnected)` | 없음                    | Subscriber가 모두 사라지면 연결과 상태를 버려요.           | 일회성 UI 이벤트                    |
+| `share(replay: 1, .whileConnected)` | 연결 중 최신 값 1개     | Subscriber가 모두 사라지면 연결과 replay 상태를 버려요.    | 화면이 살아 있는 동안 공유하는 상태 |
+| `share(replay: 1, .forever)`        | 최신 값 1개             | 연결이 끊겨도 같은 공유 Subject의 종료·replay 상태를 써요. | 의도적으로 오래 유지할 결과         |
+
+`replay`는 “캐시처럼 보이는 동작”이지 디스크 캐시나 영구 저장소가 아니에요. 메모리에 남길 값의 크기, 오류·완료를 새 구독자에게 재생할지, Subscriber가 0명이 됐을 때 상태를 버릴지를 함께 정해야 해요. 자세한 연결 동작은 [공유와 연결](./operators-share-connect)에서 설명해요.
+
+## hot과 cold는 타입 이름이 아니라 생산 방식이에요
+
+`Observable<Element>` 타입만 보고 hot인지 cold인지 알 수 없어요.
+
+- `Observable.just`, `deferred`, 일반 네트워크 래퍼는 보통 cold예요.
+- 버튼 탭, NotificationCenter, 이미 작동 중인 위치 센서, Subject는 보통 hot한 성격을 가져요.
+- cold Observable도 `share`, `publish`, `replay`로 하나의 구독을 여러 Observer가 보게 만들 수 있어요.
+
+hot 시퀀스에 늦게 구독하면 이전 값을 놓칠 수 있어요. 이전 값이 필요한 **상태**라면 `BehaviorRelay`, `Driver`, 제한된 `replay`처럼 최신 값을 보존하는 모델이 맞는지 확인하세요. 반대로 탭이나 토스트 같은 **사건**에 replay를 적용하면 화면 재구성 때 과거 사건이 다시 실행될 수 있어요.
+
+## Scheduler는 두 질문으로 나눠요
+
+RxSwift에서 자주 혼동하는 두 연산자는 영향을 주는 범위가 달라요.
+
+| 연산자           | 바꾸는 것                                                      |
+| ---------------- | -------------------------------------------------------------- |
+| `subscribe(on:)` | 소스의 구독 시작과 구독 해제 작업이 실행될 Scheduler를 정해요. |
+| `observe(on:)`   | 이 연산자 아래로 이벤트가 전달될 Scheduler를 정해요.           |
+
+```swift
+let background = SerialDispatchQueueScheduler(qos: .userInitiated)
+
+fetchProfile()
+  .subscribe(on: background)
+  .map(\.name)
+  .observe(on: MainScheduler.instance)
+  .subscribe(onNext: { name in
+    // 메인 스레드에서 UI를 갱신해요.
+    print(name)
+  })
+  .disposed(by: disposeBag)
+```
+
+`subscribe(on:)`을 파이프라인 여러 곳에 붙여도 가장 가까운 소스의 구독 동작을 이해하기 어려워질 수 있어요. 무거운 작업을 만드는 경계에 한 번 두고, UI 직전에는 `observe(on: MainScheduler.instance)` 또는 RxCocoa의 `Driver`처럼 메인 실행 계약이 타입에 담긴 도구를 선택하는 편이 읽기 쉬워요.
+
+::::warning 모든 연산자가 비동기 경계를 만들지는 않아요
+`map`, `filter`, `scan` 같은 연산자는 별도 Scheduler를 지정하지 않으면 이벤트가 들어온 실행 문맥에서 동기적으로 처리돼요. RxSwift를 썼다는 이유만으로 무거운 계산이 자동으로 백그라운드로 이동하지 않아요.
+::::
+
+## Subject, Relay, Trait의 경계를 구분해요
+
+| 요구사항                                      | 우선 고려할 타입            |
+| --------------------------------------------- | --------------------------- |
+| 외부 콜백에서 값·오류·완료를 모두 넣어야 해요 | `PublishSubject` 등 Subject |
+| 종료 없이 상태를 저장하고 새 구독자에게 줘요  | `BehaviorRelay`             |
+| 종료 없이 새 사건만 전달해요                  | `PublishRelay`              |
+| 비동기 결과가 정확히 하나예요                 | `Single`                    |
+| 비동기 결과가 없을 수도 있어요                | `Maybe`                     |
+| UI 상태를 메인에서 최신 값과 함께 공유해요    | RxCocoa `Driver`            |
+| UI 사건을 메인에서 과거 재생 없이 전달해요    | RxCocoa `Signal`            |
+
+Subject와 Relay는 값을 외부에서 주입할 수 있으므로 편리하지만, 공개 프로퍼티로 그대로 노출하면 어느 코드가 상태를 바꾸는지 추적하기 어려워져요. 입력 메서드는 좁게 유지하고 외부에는 `Observable`, `Driver`, `Signal` 같은 읽기 전용 형태를 노출하세요. 구체적인 선택은 [RxRelay 상태와 이벤트](./rxrelay)에서 다뤄요.
+
+## Swift Concurrency와 필요한 경계에서 변환해요
+
+RxSwift 6.10.2는 Observable과 `AsyncSequence` 사이의 브리지를 제공해요.
+
+### Observable을 `for await`로 읽어요
+
+```swift
+let task = Task {
+  do {
+    for try await profile in fetchProfile().values {
+      print(profile.name)
+    }
+  } catch is CancellationError {
+    print("작업 취소")
+  } catch {
+    print("조회 실패:", error)
+  }
+}
+
+task.cancel()
+```
+
+일반 Observable은 오류가 날 수 있으므로 `values`가 `AsyncThrowingStream` 성격의 비동기 시퀀스를 제공해요. `Infallible`, `Driver`, `Signal`처럼 오류가 없는 타입의 `values`는 오류 없는 비동기 시퀀스로 순회할 수 있어요.
+
+### AsyncSequence를 Observable로 바꿔요
+
+```swift
+let stream = AsyncStream<Int> { continuation in
+  continuation.yield(1)
+  continuation.yield(2)
+  continuation.finish()
+}
+
+stream
+  .asObservable()
+  .subscribe(onNext: { value in
+    print(value)
+  })
+  .disposed(by: disposeBag)
+```
+
+변환은 앱 전체를 한 번에 Rx 또는 async/await로 통일하기 위한 의무가 아니에요. 기존 Rx 파이프라인과 새 async API가 만나는 **어댑터 경계 한 곳**에서 변환하고, 내부 계층은 한 가지 추상화를 유지하면 취소와 오류 흐름을 추적하기 쉬워요.
+
+## 자주 하는 실수를 점검해요
+
+### 구독할 때마다 요청이 다시 실행되는 것을 놓쳐요
+
+원인은 cold Observable을 여러 번 구독한 것이에요. 하나의 작업을 공유할 의도라면 `share` 또는 적절한 Trait을 경계에서 적용하고, replay 개수와 scope를 명시하세요.
+
+### DisposeBag을 전역 저장소처럼 사용해요
+
+DisposeBag이 오래 살수록 그 안의 구독도 오래 살아요. 화면 전용 구독은 View Controller나 View Model처럼 같은 수명의 객체가 소유해야 해요. 재사용 셀은 `prepareForReuse()`에서 셀 전용 bag을 교체하는 패턴을 고려하세요.
+
+### 오류가 나도 이후 값이 계속 올 것으로 기대해요
+
+`.error`는 해당 구독을 종료해요. 계속 관찰하려면 오류를 값으로 모델링하거나 `catch`, `retry`로 새 시퀀스 또는 새 구독 규칙을 설계하세요.
+
+### 모든 작업이 자동으로 직렬화된다고 생각해요
+
+Rx 규약은 한 구독의 이벤트를 순서 있게 전달하는 것을 전제로 하지만, 여러 Subject·Relay·Scheduler가 공유 가변 상태를 동시에 수정하는 문제까지 해결하지 않아요. 상태 소유자와 직렬 실행 경계를 별도로 정해야 해요.
+
+## 적용 체크리스트
+
+- Observable이 몇 개의 값을 보내고 어떻게 끝나는지 계약을 설명할 수 있나요?
+- Observable이 cold인지 hot인지, 구독마다 어떤 부수 효과가 실행되는지 확인했나요?
+- 공유한다면 `replay` 개수와 `.whileConnected`·`.forever` 범위를 의도적으로 선택했나요?
+- `Disposable`과 `DisposeBag`의 수명이 화면·요청·서비스 수명과 일치하나요?
+- `subscribe(on:)`과 `observe(on:)`을 각각 왜 쓰는지 설명할 수 있나요?
+- UI 갱신 직전의 메인 실행 계약이 보장되나요?
+- 오류, 정상 완료, 소비자 취소를 서로 다른 경로로 처리하나요?
+- async/await 변환이 여러 계층에 흩어지지 않고 경계에 모여 있나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### Observable은 항상 비동기로 동작하나요?
+
+아니요. Observable은 이벤트를 push하는 추상화일 뿐이고, `just`나 `of`처럼 구독 호출 안에서 동기적으로 값을 보낼 수도 있어요. 실제 실행 위치는 소스 구현과 Scheduler 연산자에 따라 달라져요.
+
+### `subscribe(on:)`과 `observe(on:)`은 무엇이 다른가요?
+
+`subscribe(on:)`은 소스 구독과 해제의 실행 위치에 영향을 주고, `observe(on:)`은 이후 다운스트림으로 이벤트를 전달할 위치를 바꿔요.
+
+### `share(replay: 1)`은 영구 캐시인가요?
+
+아니요. 구독 하나를 공유하고 메모리에서 최근 이벤트를 재생하는 연산이에요. scope와 소스 종료 여부에 따라 연결과 replay 상태가 사라질 수 있고, 앱 재실행 뒤에도 유지되는 영구 저장소는 아니에요.
+
+### `dispose()` 뒤에 `.completed`가 호출되나요?
+
+그렇지 않아요. `dispose()`는 소비자가 연결을 폐기하는 동작이고 `.completed`는 생산자가 보내는 정상 종료 이벤트예요. 두 생명 주기는 같은 의미가 아니에요.
+
+## 참고 자료
+
+- [ReactiveX/RxSwift 6.10.2](https://github.com/ReactiveX/RxSwift/tree/6.10.2)
+- [RxSwift 공식 API 문서](https://docs.rxswift.org/)
+- [Getting Started](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/GettingStarted.md)
+- [Observable 공식 API](https://docs.rxswift.org/classes/observable)
+- [Hot and Cold Observables](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/HotAndColdObservables.md)
+- [Schedulers](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Schedulers.md)
+- [Subjects](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Subjects.md)
+- [Swift Concurrency](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/SwiftConcurrency.md)

--- a/docs/guide/rxswift/rxswift-core.md
+++ b/docs/guide/rxswift/rxswift-core.md
@@ -13,6 +13,17 @@ reviewed: '2026-09-06'
 
 이 문서는 **RxSwift 6.10.2** 공식 저장소와 API 문서를 기준으로 코어 모듈의 실행 원리를 설명해요. 개별 연산자의 사용법은 [모든 연산자 문서](./operators-create-convert)에서 이어서 볼 수 있어요.
 
+## 이 모듈의 상세 문서
+
+- [설치와 모듈 구성](./installation-and-modules): 다섯 제품의 의존 관계와 SPM·XCFramework·Carthage 설치 기준
+- [Observable·Observer·Event](./observable-observer-event): 이벤트 문법, 구독, 타입 지우기와 직접 생성
+- [Disposable과 자원](./disposables-and-resources): DisposeBag과 목적별 Disposable, 취소·완료의 차이
+- [Scheduler와 동시성](./schedulers-and-concurrency): 구독·관찰 위치, Scheduler 종류와 Swift Concurrency 브리지
+- [Subject와 Traits](./subjects-and-traits): 네 가지 Subject와 Single·Maybe·Completable·Infallible
+- [디버깅과 사용자 정의 연산자](./debugging-hooks-and-custom-operators): `debug`, `do`, Hooks, Resources와 연산자 확장
+
+공개 API 전체 범위와 문서 대응표는 [공식 API 범위와 학습 순서](./official-api-inventory)에서 확인하세요.
+
 ## 먼저 알아둘 용어
 
 | 용어                   | 뜻                                                                                                |

--- a/docs/guide/rxswift/rxtest.md
+++ b/docs/guide/rxswift/rxtest.md
@@ -1,0 +1,243 @@
+---
+title: RxTest로 가상 시간 테스트하기
+description: TestScheduler, hot·cold Observable, Recorded Event와 Subscription을 사용해 debounce·구독·폐기 시점을 실제 대기 없이 검증하는 방법을 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/UnitTests.md
+reviewed: '2026-09-06'
+---
+
+# RxTest로 가상 시간 테스트하기
+
+> **면접 답변 한 줄 요약:** RxTest는 TestScheduler의 가상 시계로 입력 사건과 구독·폐기 시간을 기록해 debounce, retry, timeout 같은 시간 기반 Rx 흐름을 실제 sleep 없이 결정적으로 검증해요.
+
+비동기 테스트에서 실제로 300ms를 기다리면 테스트가 느리고 실행 환경에 따라 흔들릴 수 있어요. RxTest는 시간을 정수 tick으로 표현하고 예약된 사건만 순서대로 실행해 같은 결과를 재현해요.
+
+## RxTest의 핵심 타입
+
+| 타입                       | 역할                                                 |
+| -------------------------- | ---------------------------------------------------- |
+| `TestScheduler`            | 정수 tick 기반 가상 시간 Scheduler예요.              |
+| `Recorded<Event<Element>>` | 특정 시각의 next·error·completed를 기록해요.         |
+| `HotObservable`            | 구독 여부와 관계없이 절대 가상 시각에 사건을 보내요. |
+| `ColdObservable`           | 각 구독 시점으로부터 상대 시각에 사건을 보내요.      |
+| `TestableObserver`         | 받은 Event와 시각을 `events`에 기록해요.             |
+| `Subscription`             | source가 구독되고 폐기된 가상 시각을 기록해요.       |
+
+## TestScheduler의 기본 시각
+
+`scheduler.start`의 기본값은 공식 구현에서 다음과 같아요.
+
+| 단계        | 기본 tick |
+| ----------- | --------- |
+| source 생성 | 100       |
+| 구독        | 200       |
+| 폐기        | 1000      |
+
+그래서 cold Observable의 `.next(10, value)`는 기본 구독 시각 200을 기준으로 결과에 210으로 기록돼요.
+
+## hot과 cold의 시간을 비교해요
+
+```text
+Hot:  절대 시간  ── 100 ── 200(구독) ── 300
+Cold: 구독 기준  ────────── 0 ── +10 ── +100
+```
+
+- hot은 구독 전 150에 발생한 값도 이미 지나가므로 기본 200 구독에서 받지 못해요.
+- cold는 Subscriber마다 구독 시점부터 같은 상대 타임라인을 새로 시작해요.
+
+## map 흐름을 검증해요
+
+```swift
+import XCTest
+import RxSwift
+import RxTest
+
+final class NumberPipelineTests: XCTestCase {
+  func testMap() {
+    let scheduler = TestScheduler(initialClock: 0)
+    let source = scheduler.createHotObservable([
+      .next(150, 99),
+      .next(210, 1),
+      .next(220, 2),
+      .completed(230),
+    ])
+
+    let result = scheduler.start {
+      source.map { $0 * 10 }
+    }
+
+    XCTAssertEqual(
+      result.events,
+      [
+        .next(210, 10),
+        .next(220, 20),
+        .completed(230),
+      ]
+    )
+    XCTAssertEqual(
+      source.subscriptions,
+      [Subscription(200, 230)]
+    )
+  }
+}
+```
+
+값뿐 아니라 `.completed`와 source subscriptions를 함께 검증해요. 그래야 연산자가 값을 맞게 내보내면서 구독을 필요 이상으로 오래 유지하는 문제도 찾을 수 있어요.
+
+## debounce를 실제 대기 없이 테스트해요
+
+```swift
+func testDebounce() {
+  let scheduler = TestScheduler(initialClock: 0)
+  let source = scheduler.createHotObservable([
+    .next(210, "R"),
+    .next(220, "Rx"),
+    .next(260, "RxS"),
+    .completed(400),
+  ])
+
+  let result = scheduler.start {
+    source.debounce(
+      .seconds(30),
+      scheduler: scheduler
+    )
+  }
+
+  XCTAssertEqual(
+    result.events,
+    [
+      .next(250, "Rx"),
+      .next(290, "RxS"),
+      .completed(400),
+    ]
+  )
+}
+```
+
+가상 시간 단위에서는 `.seconds(30)`이 TestScheduler converter의 tick 해석을 따라요. 실제 앱의 300ms 값을 그대로 테스트하고 싶다면 Scheduler와 시간 설정을 의존성으로 주입해 제품과 테스트에서 일관된 단위를 사용하세요.
+
+## 직접 Observer를 만들어 여러 입력을 제어해요
+
+```swift
+let scheduler = TestScheduler(initialClock: 0)
+let observer = scheduler.createObserver(String.self)
+
+let disposable = output
+  .subscribe(observer)
+
+scheduler.scheduleAt(10) {
+  input.accept("Swift")
+}
+scheduler.scheduleAt(20) {
+  input.accept("RxSwift")
+}
+scheduler.start()
+
+XCTAssertEqual(
+  observer.events.map(\.value.element),
+  ["Swift", "RxSwift"].map(Optional.some)
+)
+
+disposable.dispose()
+```
+
+`scheduler.start { factory }`는 기본 생성·구독·폐기 시점을 자동 관리하고, `createObserver`와 `scheduleAt` 조합은 여러 입력과 특정 dispose 시점을 직접 제어할 때 유용해요.
+
+## 오류와 완료도 값만큼 검증해요
+
+```swift
+enum TestError: Error {
+  case failed
+}
+
+let source = scheduler.createColdObservable([
+  .next(10, 1),
+  .error(20, TestError.failed),
+])
+```
+
+`Recorded<Event<T>>`는 종료 사건도 포함해요. 오류 타입이 Equatable이 아니라면 event 패턴을 분해하거나 테스트용 오류를 Equatable하게 설계하세요.
+
+종료되지 않는 시퀀스의 값만 검사할 때는 공식 `XCTAssertRecordedElements` helper를 사용할 수 있어요. 이 helper는 error나 completed 같은 stop event가 있으면 실패하므로 목적을 확인하세요.
+
+## View Model 입력·출력을 테스트해요
+
+```swift
+func testLatestQueryWins() {
+  let scheduler = TestScheduler(initialClock: 0)
+  let query = scheduler.createHotObservable([
+    .next(210, "Swift"),
+    .next(220, "RxSwift"),
+  ])
+  let firstResult = scheduler.createColdObservable([
+    .next(50, ["old"]),
+    .completed(50),
+  ])
+  let secondResult = scheduler.createColdObservable([
+    .next(10, ["new"]),
+    .completed(10),
+  ])
+
+  let result = scheduler.start {
+    query.flatMapLatest { value in
+      value == "Swift" ? firstResult : secondResult
+    }
+  }
+
+  XCTAssertEqual(
+    result.events,
+    [
+      .next(230, ["new"]),
+    ]
+  )
+  XCTAssertEqual(
+    firstResult.subscriptions,
+    [Subscription(210, 220)]
+  )
+}
+```
+
+최종 값뿐 아니라 첫 요청이 220에 폐기됐는지 검증하면 `flatMapLatest`의 취소 의미까지 확인할 수 있어요.
+
+## 테스트 가능한 설계 기준
+
+- 시간 연산자에 들어갈 Scheduler를 주입해요.
+- 네트워크와 저장소는 입력에 따라 cold Observable을 돌려주는 fake로 바꿀 수 있게 해요.
+- View Model 출력은 Observable·Driver를 구독할 수 있는 형태로 노출해요.
+- 테스트에서 실제 DispatchQueue와 sleep을 섞지 않아요.
+- 상태 값뿐 아니라 종료와 source subscription을 검증해요.
+
+## 자주 하는 실수
+
+- 실제 시간을 기다리는 expectation과 TestScheduler를 섞어요.
+- hot과 cold의 시간을 같은 의미로 계산해요.
+- 기본 구독 시각 200을 잊고 예상 시간을 10으로 적어요.
+- next 값만 비교하고 error·completed·dispose를 놓쳐요.
+- 제품 코드가 MainScheduler를 내부에 고정해 가상 시간으로 바꾸지 못해요.
+- 하나의 TestScheduler에서 테스트 간 상태를 공유해요.
+
+## 적용 체크리스트
+
+- 입력은 hot과 cold 중 실제 의미에 맞나요?
+- 절대 시각과 구독 기준 상대 시각을 구분했나요?
+- Scheduler 기본 created·subscribed·disposed 시각을 반영했나요?
+- 값, 종료 Event, source subscriptions를 함께 검증했나요?
+- 실제 sleep 없이 시간 연산을 테스트하나요?
+- 각 테스트가 새로운 Scheduler와 독립 상태를 사용하나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### RxTest의 hot Observable과 cold Observable은 무엇이 다른가요?
+
+hot은 Subscriber와 무관한 절대 가상 시각에 사건을 보내고, cold는 각 구독 시점부터 상대 시각으로 같은 사건 시퀀스를 시작해요.
+
+### TestScheduler의 장점은 무엇인가요?
+
+실제 시간을 기다리지 않고 예약된 사건을 즉시 실행해 테스트가 빠르고 결정적이에요. 값뿐 아니라 이벤트 시각과 구독·폐기 시점도 검증할 수 있어요.
+
+## 참고 자료
+
+- [RxSwift Unit Tests 공식 문서](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/UnitTests.md)
+- [TestScheduler 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxTest/Schedulers/TestScheduler.swift)
+- [HotObservable 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxTest/HotObservable.swift)
+- [ColdObservable 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxTest/ColdObservable.swift)
+- [TestableObserver 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxTest/TestableObserver.swift)

--- a/docs/guide/rxswift/schedulers-and-concurrency.md
+++ b/docs/guide/rxswift/schedulers-and-concurrency.md
@@ -1,0 +1,210 @@
+---
+title: Scheduler와 Swift Concurrency 연결
+description: RxSwift의 subscribe(on:)·observe(on:) 차이, 내장 Scheduler 선택, 직렬화와 시간 연산, Observable·AsyncSequence·Single 사이의 동시성 브리지를 설명합니다.
+source: https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Schedulers.md
+reviewed: '2026-09-06'
+---
+
+# Scheduler와 Swift Concurrency 연결
+
+> **면접 답변 한 줄 요약:** `subscribe(on:)`은 소스 구독·해제 위치를, `observe(on:)`은 이후 이벤트 전달 위치를 바꾸며, async/await와 연결할 때는 변환 경계를 한곳에 두고 Task와 Disposable 취소를 함께 설계해요.
+
+Scheduler는 단순히 “백그라운드 스레드”를 의미하지 않아요. 현재 스레드, 메인 큐, 직렬·병렬 DispatchQueue, OperationQueue, 가상 시간을 같은 인터페이스로 표현하는 실행 추상화예요.
+
+## 두 Scheduler 연산자를 구분해요
+
+```swift
+let background = ConcurrentDispatchQueueScheduler(qos: .userInitiated)
+
+api.loadFeed()
+  .subscribe(on: background)
+  .map { items in
+    items.sorted { $0.date > $1.date }
+  }
+  .observe(on: MainScheduler.instance)
+  .subscribe(onNext: { items in
+    collectionView.apply(items)
+  })
+  .disposed(by: disposeBag)
+```
+
+| 연산자           | 영향을 주는 범위                                         |
+| ---------------- | -------------------------------------------------------- |
+| `subscribe(on:)` | 소스의 `subscribe` 실행과 구독 해제가 수행될 Scheduler   |
+| `observe(on:)`   | 이 연산자 아래로 next·error·completed가 전달될 Scheduler |
+
+`observe(on:)`을 여러 번 쓰면 각 지점 아래의 실행 문맥이 바뀌어요. 반면 `subscribe(on:)`은 소스 구독 경계에 영향을 주므로 여러 곳에 흩어 놓으면 실제 시작 위치를 읽기 어려워져요.
+
+Scheduler를 지정하지 않으면 소스가 이벤트를 만든 현재 실행 문맥에서 연산자가 이어져요. `map`이나 `filter`가 자동으로 백그라운드 실행되는 것은 아니에요.
+
+## 내장 Scheduler를 선택해요
+
+| Scheduler                          | 직렬성·특징                                                         | 대표 용도                                  |
+| ---------------------------------- | ------------------------------------------------------------------- | ------------------------------------------ |
+| `CurrentThreadScheduler`           | 현재 스레드의 trampoline 큐를 사용해 재귀 예약을 순서대로 처리해요. | 기본 생성 연산자, 내부 재귀 완화           |
+| `MainScheduler`                    | 메인 스레드를 추상화하며 메인에서 예약하면 즉시 실행될 수 있어요.   | `observe(on:)`을 통한 UI 갱신              |
+| `ConcurrentMainScheduler`          | 메인 큐로 구독 작업을 보내는 데 최적화돼요.                         | `subscribe(on:)`이 반드시 메인이어야 할 때 |
+| `SerialDispatchQueueScheduler`     | 전달받은 큐가 concurrent여도 직렬 실행을 보장해요.                  | 상태 변경, 순차 I/O                        |
+| `ConcurrentDispatchQueueScheduler` | DispatchQueue 기반 병렬 실행을 제공해요.                            | 독립적인 백그라운드 작업                   |
+| `OperationQueueScheduler`          | OperationQueue와 `maxConcurrentOperationCount` 정책을 사용해요.     | 큰 작업의 동시 실행 수 제어                |
+| `HistoricalScheduler`              | `Date`와 `TimeInterval` 기반의 가상 시간을 사용해요.                | 시간 이동 시뮬레이션                       |
+| `VirtualTimeScheduler`             | 사용자 정의 절대·상대 시간 변환으로 가상 실행을 제공해요.           | 테스트 Scheduler의 기반                    |
+
+UI 이벤트 관찰에는 `MainScheduler`, 메인에서 시작해야 하는 구독 최적화에는 `ConcurrentMainScheduler`라는 공식 권장 차이가 있어요. 일반 화면 코드에서는 RxCocoa의 Driver와 Signal이 메인 관찰 계약을 더 명시적으로 제공해요.
+
+## serial과 concurrent의 의미를 구분해요
+
+Rx 연산자는 한 Observer의 이벤트 순서를 보존해야 해요. RxSwift가 serial Scheduler임을 알 수 있으면 `observe(on:)` 같은 경계도 더 단순하게 최적화할 수 있어요.
+
+```swift
+let stateScheduler = SerialDispatchQueueScheduler(
+  internalSerialQueueName: "com.example.state"
+)
+
+actions
+  .observe(on: stateScheduler)
+  .scan(State.initial) { state, action in
+    state.reducing(action)
+  }
+  .share(replay: 1, scope: .whileConnected)
+```
+
+병렬 Scheduler에서 각각 계산한 결과가 하나의 가변 상태를 수정한다면 Rx 이벤트 순서만으로 충분하지 않아요. 상태를 변경하는 마지막 경계를 serial Scheduler나 actor 하나로 모으세요.
+
+## CurrentThreadScheduler는 재귀를 큐로 펴요
+
+CurrentThreadScheduler는 같은 스레드에서 처음 예약한 작업을 즉시 실행하고, 실행 중 다시 예약된 작업은 숨은 큐에 넣었다가 현재 작업 뒤에 처리해요. 이 trampoline 방식은 연산자가 재귀적으로 다음 작업을 예약할 때 호출 스택이 끝없이 깊어지는 것을 줄여요.
+
+직접 Scheduler를 지정하지 않은 여러 생성 연산자가 CurrentThreadScheduler를 기본으로 사용해요. “현재 스레드”라는 이름 때문에 모든 작업이 즉시 재귀 호출된다고 오해하면 안 돼요.
+
+## 시간 기반 연산자는 테스트 가능한 Scheduler를 받아요
+
+```swift
+let query = input
+  .debounce(
+    .milliseconds(300),
+    scheduler: MainScheduler.instance
+  )
+  .distinctUntilChanged()
+```
+
+`debounce`, `throttle`, `delay`, `timeout`, `timer`, `interval`은 시간의 기준이 되는 Scheduler를 받아요. 제품 코드에서 구체적인 메인 Scheduler를 함수 내부에 고정하면 가상 시간 테스트가 어려울 수 있으므로, 중요한 도메인 로직은 Scheduler를 주입하거나 파이프라인 바깥에서 선택하세요.
+
+## Observable을 AsyncSequence로 읽어요
+
+오류 가능한 Observable의 `values`는 `for try await`로 순회해요.
+
+```swift
+let task = Task {
+  do {
+    for try await update in updates.values {
+      await model.apply(update)
+    }
+  } catch {
+    await model.fail(error)
+  }
+}
+```
+
+Observable이 완료되지 않으면 loop도 계속 대기해요. Task가 취소되면 비동기 시퀀스의 종료 처리에서 Rx 구독이 폐기되지만, Observable을 만든 기반 작업도 dispose에 실제 취소를 연결해야 해요.
+
+`Infallible`, `Driver`, `Signal`은 오류가 없으므로 `for await`로 읽을 수 있어요.
+
+```swift
+for await state in stateDriver.values {
+  await renderer.render(state)
+}
+```
+
+## PrimitiveSequence의 한 값을 await해요
+
+```swift
+let user = try await userSingle.value
+let cachedUser = try await cachedUserMaybe.value
+try await saveCompletable.value
+```
+
+| Rx 타입           | await 결과 |
+| ----------------- | ---------- |
+| `Single<Element>` | `Element`  |
+| `Maybe<Element>`  | `Element?` |
+| `Completable`     | `Void`     |
+
+Maybe가 값 없이 완료하면 `nil`, Completable이 정상 완료하면 `Void`가 돌아와요. 오류 종료는 throw로 전달돼요.
+
+## AsyncSequence를 Observable로 바꿔요
+
+```swift
+let updates: AsyncStream<Update> = service.updates()
+
+updates
+  .asObservable(priority: .userInitiated)
+  .observe(on: MainScheduler.instance)
+  .subscribe(onNext: { update in
+    renderer.render(update)
+  })
+  .disposed(by: disposeBag)
+```
+
+RxSwift 6.10부터 `AsyncSequence.asObservable()`은 `Task.detached`로 순회하고 선택적으로 `TaskPriority`를 받아요. 호출한 actor 문맥을 뜻하지 않게 상속해 교착이나 불필요한 직렬화를 만드는 문제를 피하기 위한 변경이에요. UI 적용은 예제처럼 명시적으로 메인 Scheduler로 돌아오세요.
+
+## async 함수 결과를 Single로 감싸요
+
+```swift
+let profile: Single<Profile> = Single.create {
+  try await profileService.load()
+}
+
+profile
+  .observe(on: MainScheduler.instance)
+  .subscribe(onSuccess: { profile in
+    renderer.render(profile)
+  })
+  .disposed(by: disposeBag)
+```
+
+변환 후 dispose가 Task 취소와 어떻게 연결되는지, async 함수가 취소 협력적인지 확인하세요. 단순히 타입만 Single로 바꾼다고 내부 작업이 즉시 중단되는 것은 아니에요.
+
+## Rx와 actor 경계를 섞을 때 원칙을 세워요
+
+- actor 내부 상태 변경은 actor 메서드에서 완료해요.
+- Rx Scheduler를 actor 격리의 대체물로 생각하지 않아요.
+- `Task {}`를 `subscribe` 안에서 무제한 생성하지 말고 취소 소유자를 정해요.
+- 변환은 Repository adapter나 View Model 출력처럼 한 경계에 모아요.
+- UI는 Driver·Signal 또는 MainScheduler 중 한 계약으로 일관되게 전달해요.
+
+## 자주 하는 실수
+
+- RxSwift를 사용하면 연산자가 자동으로 백그라운드에서 실행된다고 생각해요.
+- `subscribe(on:)`으로 UI 관찰 위치까지 바뀐다고 오해해요.
+- `observe(on:)`을 너무 일찍 메인으로 바꿔 무거운 map·decode를 메인에서 실행해요.
+- concurrent Scheduler에서 하나의 Relay 상태를 read-modify-write해 갱신을 잃어요.
+- Task와 Disposable 중 어느 쪽이 취소를 소유하는지 정하지 않아요.
+- 끝나지 않는 Observable의 `values`를 기다리며 상위 Task가 완료될 것으로 기대해요.
+
+## 적용 체크리스트
+
+- 소스 구독 위치와 이벤트 관찰 위치를 각각 설명할 수 있나요?
+- UI 직전 메인 실행 계약이 있나요?
+- 무거운 동기 연산이 어느 Scheduler에서 실행되는지 확인했나요?
+- 상태 변경이 하나의 serial 또는 actor 경계에 있나요?
+- 시간 연산을 가상 Scheduler로 테스트할 수 있나요?
+- Rx↔async 변환 지점과 양쪽 취소 소유자가 명확한가요?
+
+## 면접에서 이어질 수 있는 질문
+
+### MainScheduler와 ConcurrentMainScheduler는 무엇이 다른가요?
+
+MainScheduler는 `observe(on:)`으로 UI 이벤트를 전달하는 데 최적화됐고 메인에서 예약하면 즉시 실행할 수 있어요. ConcurrentMainScheduler는 `subscribe(on:)`으로 구독 작업을 메인 큐에서 시작하는 경우에 최적화돼요.
+
+### Scheduler와 actor는 같은 문제를 해결하나요?
+
+아니요. Scheduler는 Rx 작업과 이벤트 전달의 실행 위치·시간을 정하고, actor는 Swift 가변 상태의 격리 규칙을 컴파일러와 런타임이 관리해요. 함께 사용할 수 있지만 서로 대체하지 않아요.
+
+## 참고 자료
+
+- [RxSwift Schedulers 공식 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Schedulers.md)
+- [SchedulerType 공식 API](https://docs.rxswift.org/protocols/schedulertype)
+- [MainScheduler 공식 API](https://docs.rxswift.org/classes/mainscheduler)
+- [Swift Concurrency 공식 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/SwiftConcurrency.md)
+- [RxSwift 6.10.2 릴리스 노트](https://github.com/ReactiveX/RxSwift/releases/tag/6.10.2)

--- a/docs/guide/rxswift/subjects-and-traits.md
+++ b/docs/guide/rxswift/subjects-and-traits.md
@@ -1,0 +1,235 @@
+---
+title: Subject와 RxSwift Traits
+description: PublishSubject·BehaviorSubject·ReplaySubject·AsyncSubject의 이벤트 보관 차이와 Single·Maybe·Completable·Infallible의 값·오류 계약을 비교합니다.
+source: https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md
+reviewed: '2026-09-06'
+---
+
+# Subject와 RxSwift Traits
+
+> **면접 답변 한 줄 요약:** Subject는 외부 이벤트를 Observable 세계로 넣는 양방향 경계이고, Trait은 Observable이 보낼 값의 개수와 실패 가능성을 타입으로 좁혀 호출자에게 계약을 전달해요.
+
+Subject와 Trait은 모두 Observable과 관련되지만 방향이 달라요. Subject는 값을 **넣는 기능**을 추가하고, Trait은 값을 **읽는 규칙**을 더 엄격하게 표현해요.
+
+## Subject는 Observer이면서 Observable이에요
+
+```text
+외부 콜백 ── onNext/onError/onCompleted ──▶ Subject ── subscribe ──▶ Observer
+```
+
+Subject를 사용하면 delegate, Notification, SDK callback처럼 Rx가 아닌 입력을 파이프라인에 연결할 수 있어요. 반면 여러 곳이 같은 Subject에 값을 넣으면 상태 변경 출처가 감춰지므로 소유자를 좁게 유지해야 해요.
+
+## 네 Subject의 보관 규칙
+
+| 타입                       | 구독 직후 받는 값                           | 대표 용도                     |
+| -------------------------- | ------------------------------------------- | ----------------------------- |
+| `PublishSubject<Element>`  | 구독 이후 새로 들어오는 값만 받아요.        | 실시간 사건, callback adapter |
+| `BehaviorSubject<Element>` | 초기값 또는 가장 최근 값 1개를 먼저 받아요. | 종료 가능한 현재 상태         |
+| `ReplaySubject<Element>`   | 정한 버퍼의 과거 값을 순서대로 받아요.      | 제한된 기록 재생              |
+| `AsyncSubject<Element>`    | 정상 완료 시 마지막 값 1개와 완료를 받아요. | 완료 시점의 최종 결과         |
+
+모든 Subject는 `.error`나 `.completed`로 종료될 수 있고, 종료 뒤 새 값을 받지 않아요.
+
+## PublishSubject는 과거 사건을 보관하지 않아요
+
+```swift
+let subject = PublishSubject<String>()
+
+subject.onNext("구독 전")
+
+subject
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+
+subject.onNext("구독 후")
+// 구독 후
+```
+
+구독 전 값이 필요한 상태라면 PublishSubject가 아니라 BehaviorSubject 또는 상태 저장소를 고려하세요. 과거 사건이 필요하지 않은데 ReplaySubject를 쓰면 화면 재구성 시 옛 사건이 다시 실행될 수 있어요.
+
+## BehaviorSubject는 최신 값과 종료를 함께 표현해요
+
+```swift
+let subject = BehaviorSubject(value: ConnectionState.disconnected)
+
+let current = try subject.value()
+print(current)
+
+subject.onNext(.connecting)
+subject.onNext(.connected)
+subject.onCompleted()
+```
+
+`value()`는 최신 값을 동기적으로 읽지만 Subject가 오류로 종료됐다면 그 오류를 throw할 수 있어요. 종료 없는 앱 상태가 필요하고 오류를 값으로 표현한다면 `BehaviorRelay.value`가 더 단순해요.
+
+## ReplaySubject의 버퍼를 제한해요
+
+```swift
+let subject = ReplaySubject<String>.create(bufferSize: 2)
+
+subject.onNext("A")
+subject.onNext("B")
+subject.onNext("C")
+
+subject
+  .subscribe(onNext: { print($0) })
+  .disposed(by: disposeBag)
+
+// B, C
+```
+
+`createUnbounded()`는 모든 값을 보관하므로 값 개수와 크기에 상한이 없는 스트림에는 사용하지 마세요. replay는 메모리 이벤트 재생이고 디스크 캐시가 아니에요.
+
+## AsyncSubject는 완료돼야 마지막 값을 보내요
+
+```swift
+let subject = AsyncSubject<Int>()
+
+subject.onNext(1)
+subject.onNext(2)
+subject.onNext(3)
+subject.onCompleted()
+
+// Observer는 3과 completed를 받아요.
+```
+
+정상 완료 전에 여러 값을 받아도 마지막 값만 보관했다가 완료와 함께 전달해요. 값 없이 완료하면 값 없이 완료하고, 오류로 끝나면 보관한 값 대신 오류를 전달해요. 한 번의 결과를 직접 만드는 앱 API라면 대개 `Single`이 더 명확해요.
+
+## Subject를 외부에 그대로 공개하지 않아요
+
+```swift
+final class SessionStore {
+  private let stateSubject = BehaviorSubject(
+    value: SessionState.signedOut
+  )
+
+  var state: Observable<SessionState> {
+    stateSubject.asObservable()
+  }
+}
+```
+
+구독자는 상태를 읽을 수 있지만 `onNext`, `onError`, `onCompleted`로 내부 상태를 바꿀 수 없어요. 입력은 의도가 드러나는 메서드로 제한하세요.
+
+## Trait은 Observable의 제약을 타입에 담아요
+
+Trait은 별도 이벤트 엔진이 아니라 하나의 Observable을 감싼 구조예요. `asObservable()`로 다시 일반 Observable로 바꿀 수 있고, 계약을 보존하는 연산자를 연결할 수 있어요.
+
+| Trait                 | 성공 값 수   | 실패 | 정상 완료의 의미         | 부수 효과 공유  |
+| --------------------- | ------------ | ---- | ------------------------ | --------------- |
+| `Single<Element>`     | 정확히 1개   | 가능 | 성공 값 하나로 종료      | 기본 공유 안 함 |
+| `Maybe<Element>`      | 0개 또는 1개 | 가능 | 값이 없을 수도 있는 종료 | 기본 공유 안 함 |
+| `Completable`         | 0개          | 가능 | 값 없이 작업 성공        | 기본 공유 안 함 |
+| `Infallible<Element>` | 0개 이상     | 불가 | 선택적으로 정상 완료     | 소스에 따름     |
+
+Trait이 부수 효과를 자동 공유한다고 생각하면 안 돼요. Single도 두 번 구독하면 cold 네트워크 요청이 두 번 실행될 수 있어요.
+
+## Single은 결과 하나를 표현해요
+
+```swift
+let profile: Single<Profile> = Single.create { single in
+  let task = service.loadProfile { result in
+    single(result)
+  }
+
+  return Disposables.create {
+    task.cancel()
+  }
+}
+```
+
+Single은 `.success(Element)` 또는 `.failure(Error)` 중 하나로 끝나요. HTTP 응답 하나, 데이터베이스 조회 하나처럼 결과 개수가 정확히 하나일 때 적합해요.
+
+## Maybe는 값이 없음을 정상 결과로 표현해요
+
+```swift
+let cachedProfile: Maybe<Profile> = cache.profile()
+
+cachedProfile
+  .subscribe(
+    onSuccess: { profile in
+      print(profile)
+    },
+    onError: { error in
+      print(error)
+    },
+    onCompleted: {
+      print("캐시 없음")
+    }
+  )
+  .disposed(by: disposeBag)
+```
+
+값 없음이 오류가 아닌 캐시 miss나 조건부 조회에 맞아요. “값 없음”이 도메인에서 실제 상태인지, `Single<Profile?>`이 호출자에게 더 익숙한지 팀 기준으로 선택하세요.
+
+## Completable은 값 없는 성공과 실패를 표현해요
+
+```swift
+let saved: Completable = repository.save(draft)
+
+saved
+  .andThen(repository.loadDraft())
+  .subscribe(onSuccess: { draft in
+    print(draft)
+  })
+  .disposed(by: disposeBag)
+```
+
+저장·삭제·로그아웃처럼 반환 값보다 성공 여부가 중요한 작업에 적합해요. `Observable<Void>`와 달리 next 값을 보내지 않는 계약이 타입에 드러나요.
+
+## Infallible은 실패하지 않는 여러 값을 표현해요
+
+```swift
+let appPhase: Infallible<AppPhase> = phaseObservable
+  .asInfallible(onErrorRecover: { error in
+    logger.record(error)
+    return .just(.inactive)
+  })
+```
+
+오류를 타입에서 제거하려면 반드시 대체 값이나 대체 시퀀스 정책이 필요해요. 오류를 숨기는 도구로 쓰지 말고 실패가 정말 계약상 불가능하거나 이미 값 상태로 변환된 경계에서 사용하세요.
+
+## Observable에서 Trait으로 바꿀 때 이벤트 수를 검증해요
+
+```swift
+let single = Observable.of(1, 2)
+  .asSingle()
+```
+
+`asSingle()`은 여러 값을 자동으로 첫 값 하나로 줄이지 않아요. 값이 두 개면 계약 위반 오류가 나요. 첫 값이 의도라면 `take(1)` 또는 `first`, 유일한 값이어야 한다면 `single()`처럼 선택 규칙을 먼저 표현하세요.
+
+## 자주 하는 실수
+
+- 상태를 PublishSubject로 만들어 새 구독자가 현재 값을 모르게 해요.
+- 탭 사건을 ReplaySubject로 재생해 화면 재진입 때 다시 실행해요.
+- Subject를 public으로 노출해 누구나 종료시킬 수 있게 해요.
+- Single은 구독을 자동 공유한다고 생각해 요청을 중복 실행해요.
+- `asSingle()`이 여러 값 중 하나를 알아서 고른다고 생각해요.
+- 오류를 무조건 fallback으로 바꾸고 원인 기록과 실패 UI를 잃어요.
+
+## 적용 체크리스트
+
+- 외부 이벤트를 Rx로 넣어야 해서 Subject가 필요한가요?
+- 새 구독자가 과거 값 또는 최신 값을 받아야 하나요?
+- Subject 소유자만 쓰기·종료 권한을 가지나요?
+- 공개 API가 값의 개수와 실패 가능성을 가장 좁은 Trait으로 표현하나요?
+- Trait 변환 전 실제 이벤트 개수를 검증했나요?
+- 여러 구독에서 부수 효과를 공유해야 하는지 정했나요?
+
+## 면접에서 이어질 수 있는 질문
+
+### BehaviorSubject와 BehaviorRelay는 무엇이 다른가요?
+
+둘 다 최신 값 하나를 보관하지만 BehaviorSubject는 오류와 완료로 종료될 수 있고 `value()`가 throw할 수 있어요. BehaviorRelay는 값만 accept하고 종료 API가 없으며 최신 값을 `value`로 읽어요.
+
+### Single과 Observable의 실행 방식이 다른가요?
+
+Single은 Observable 위에 값 하나 또는 오류 하나라는 계약을 표현한 PrimitiveSequence예요. 별도 네트워크 엔진이 아니며 cold 소스라면 구독마다 부수 효과가 실행되는 점도 같아요.
+
+## 참고 자료
+
+- [RxSwift Subjects 공식 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Subjects.md)
+- [Subjects 공식 API](https://docs.rxswift.org/rxswift/subjects)
+- [Traits 공식 설명](https://github.com/ReactiveX/RxSwift/blob/6.10.2/Documentation/Traits.md)
+- [PrimitiveSequence 공식 API](https://docs.rxswift.org/structs/primitivesequence)
+- [Infallible 공식 API](https://docs.rxswift.org/structs/infallible)

--- a/docs/guide/rxswift/uikit-control-bindings.md
+++ b/docs/guide/rxswift/uikit-control-bindings.md
@@ -1,0 +1,230 @@
+---
+title: RxCocoa UIKit 컨트롤 바인딩 모음
+description: UIButton부터 UITextField, UISwitch, UIScrollView, UINavigationController, WKWebView까지 RxCocoa가 제공하는 UIKit 입력·출력 API를 역할별로 정리합니다.
+source: https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxCocoa/iOS
+reviewed: '2026-09-06'
+---
+
+# RxCocoa UIKit 컨트롤 바인딩 모음
+
+> **면접 답변 한 줄 요약:** RxCocoa의 UIKit 확장은 target-action·delegate·KVO 속성을 ControlEvent, ControlProperty, Binder, Observable로 변환하므로 값의 방향과 replay 규칙을 확인해 선택해야 해요.
+
+RxCocoa는 UIKit의 모든 API를 Rx로 다시 만들지 않아요. 반복적으로 관찰하거나 바인딩할 가치가 있는 속성과 사건을 `.rx` 아래에 제공하고, 반환값이 필요한 delegate 메서드나 명령형 화면 전환은 UIKit API를 그대로 쓰기도 해요.
+
+## 버튼과 기본 컨트롤
+
+| UIKit 타입                | 대표 Rx source                  | 대표 Rx sink                      |
+| ------------------------- | ------------------------------- | --------------------------------- |
+| `UIButton`                | `tap`                           | `title()`, `image()`, `isEnabled` |
+| `UIBarButtonItem`         | `tap`                           | `isEnabled`                       |
+| `UISwitch`                | `isOn`, `value`                 | 같은 ControlProperty sink         |
+| `UISlider`                | `value`                         | 같은 ControlProperty sink         |
+| `UIStepper`               | `value`                         | 같은 ControlProperty sink         |
+| `UISegmentedControl`      | `selectedSegmentIndex`, `value` | 같은 ControlProperty sink         |
+| `UIDatePicker`            | `date`                          | 같은 ControlProperty sink         |
+| `UIRefreshControl`        | `controlEvent(.valueChanged)`   | `isRefreshing`                    |
+| `UIActivityIndicatorView` | 해당 없음                       | `isAnimating`                     |
+
+```swift
+submitButton.rx.tap
+  .withLatestFrom(formState)
+  .bind(to: viewModel.submit)
+  .disposed(by: disposeBag)
+
+viewModel.canSubmit
+  .drive(submitButton.rx.isEnabled)
+  .disposed(by: disposeBag)
+
+viewModel.isLoading
+  .drive(activityIndicator.rx.isAnimating)
+  .disposed(by: disposeBag)
+```
+
+컨트롤 source는 보통 메인 Scheduler에서 사용자 사건을 내보내고, Binder는 메인에서 UI를 갱신해요.
+
+## 텍스트 입력 컨트롤
+
+| UIKit 타입           | 대표 API                                                          |
+| -------------------- | ----------------------------------------------------------------- |
+| `UITextField`        | `text`, `attributedText`, `controlEvent`, `isEditing` 관련 바인딩 |
+| `UITextView`         | `text`, `attributedText`, `didBeginEditing`, `didEndEditing` 등   |
+| `UISearchBar`        | `text`, `value`, `textDidChange`, 검색·취소 버튼 사건             |
+| `UISearchController` | `isActive`, presentation·dismiss 관련 delegate 사건               |
+| `NSTextStorage`      | 편집 처리와 layout manager 관련 이벤트                            |
+
+```swift
+let query = searchBar.rx.text.orEmpty
+  .debounce(
+    .milliseconds(300),
+    scheduler: MainScheduler.instance
+  )
+  .distinctUntilChanged()
+
+query
+  .bind(to: viewModel.query)
+  .disposed(by: disposeBag)
+```
+
+`orEmpty`는 `String?`을 빈 문자열 기본값으로 바꿔요. nil과 빈 문자열이 도메인에서 다른 의미라면 무조건 사용하지 말고 Optional을 유지하세요.
+
+## UIScrollView 계열의 공통 API
+
+UITableView와 UICollectionView는 UIScrollView delegate 프록시를 기반으로 공통 이벤트를 사용할 수 있어요.
+
+| API                            | 의미                             |
+| ------------------------------ | -------------------------------- |
+| `contentOffset`                | 현재 스크롤 위치 ControlProperty |
+| `contentSize`                  | 콘텐츠 크기 변화                 |
+| `contentInset`                 | 콘텐츠 inset 변화                |
+| `didScroll`                    | 스크롤 delegate 사건             |
+| `willBeginDragging`            | 드래그 시작                      |
+| `didEndDragging`               | 감속 여부와 함께 드래그 종료     |
+| `didEndDecelerating`           | 감속 종료                        |
+| `isDragging`, `isDecelerating` | 현재 스크롤 상태                 |
+
+```swift
+scrollView.rx.contentOffset
+  .map { $0.y > 200 }
+  .distinctUntilChanged()
+  .bind(to: floatingButton.rx.isHidden)
+  .disposed(by: disposeBag)
+```
+
+고빈도 스크롤 이벤트에서 레이아웃 계산과 네트워크 요청을 직접 실행하지 마세요. 필요한 값만 map하고 `distinctUntilChanged`, `throttle`을 의미에 맞게 적용하세요.
+
+## 선택과 표시 수명 이벤트
+
+UITableView와 UICollectionView는 다음과 같은 ControlEvent를 제공해요.
+
+- `itemSelected`, `itemDeselected`
+- `modelSelected`, `modelDeselected`
+- `willDisplayCell`, `didEndDisplayingCell`
+- accessory button, highlight, supplementary view 관련 이벤트
+- iOS 10 이상 prefetch와 cancel prefetch 이벤트
+
+```swift
+collectionView.rx.modelSelected(Product.self)
+  .bind(to: viewModel.selectProduct)
+  .disposed(by: disposeBag)
+
+collectionView.rx.prefetchItems
+  .bind(to: imageLoader.prefetch)
+  .disposed(by: disposeBag)
+```
+
+`modelSelected`는 `rx.items` 또는 `SectionedViewDataSourceType`을 구현한 data source가 모델 조회를 제공할 때 사용할 수 있어요. 일반 UIKit data source를 직접 설정했다면 모델 매핑을 별도로 관리하세요.
+
+## 제스처를 관찰해요
+
+RxCocoa는 `UIGestureRecognizer.rx.event`로 인식기 자체를 내보내요.
+
+```swift
+let tapGesture = UITapGestureRecognizer()
+contentView.addGestureRecognizer(tapGesture)
+
+tapGesture.rx.event
+  .filter { $0.state == .recognized }
+  .subscribe(onNext: { gesture in
+    print(gesture.location(in: gesture.view))
+  })
+  .disposed(by: disposeBag)
+```
+
+RxCocoa는 기본 UIGestureRecognizer 연결을 제공하지만 여러 제스처 조합과 편의 연산자를 제공하는 외부 RxGesture 라이브러리와는 범위가 달라요.
+
+## 내비게이션과 탭 UI
+
+| 타입                     | 관찰 가능한 대표 사건                    |
+| ------------------------ | ---------------------------------------- |
+| `UINavigationController` | willShow, didShow와 delegate 프록시      |
+| `UITabBar`               | 항목 선택·customizing 관련 delegate 사건 |
+| `UITabBarController`     | View Controller 선택과 delegate 사건     |
+
+화면 전환 명령 자체를 무조건 Binder로 감쌀 필요는 없어요. View Model은 `Signal<Route>`처럼 전환 의도만 내보내고 View Controller가 UIKit 내비게이션을 수행하면 책임이 선명해요.
+
+```swift
+viewModel.route
+  .emit(with: self) { owner, route in
+    owner.router.navigate(route)
+  }
+  .disposed(by: disposeBag)
+```
+
+## WKWebView 상태와 내비게이션 사건
+
+RxCocoa의 WKWebView 확장은 KVO 상태와 `WKNavigationDelegate` 프록시를 제공해요.
+
+| 종류            | 대표 값                                                     |
+| --------------- | ----------------------------------------------------------- |
+| 페이지 상태     | `title`, `url`, `isLoading`, `estimatedProgress`            |
+| 이동 가능 여부  | `canGoBack`, `canGoForward`                                 |
+| 내비게이션 사건 | didStart, didCommit, didFinish, provisional·navigation 실패 |
+
+```swift
+webView.rx.estimatedProgress
+  .map(Float.init)
+  .bind(to: progressView.rx.progress)
+  .disposed(by: disposeBag)
+
+webView.rx.title
+  .bind(to: titleLabel.rx.text)
+  .disposed(by: disposeBag)
+```
+
+인증 challenge나 정책 결정처럼 delegate 반환 completion handler가 필요한 동작은 단순 관찰 이벤트만으로 처리할 수 있는지 확인하고, 필요하면 실제 WKNavigationDelegate를 함께 설치하세요.
+
+## UIApplication 사건
+
+UIApplication 확장은 앱 상태와 메모리 경고 같은 시스템 사건을 Observable로 연결해요. 시스템 Notification을 직접 사용할 수도 있으므로 팀에서 한 접근을 정하고 중복 구독하지 마세요.
+
+앱 생명 주기를 영구 Relay 하나로 다시 방송하기보다 필요한 화면·서비스가 적절한 수명으로 구독하도록 설계하세요.
+
+## macOS 바인딩도 별도 제공돼요
+
+RxCocoa에는 `NSButton`, `NSControl`, `NSSlider`, `NSTextField`, `NSTextView`, `NSView`용 확장도 있어요. iOS의 UIKit 타입과 이름이 같다고 가정하지 말고 플랫폼 조건과 반환 Trait을 확인하세요.
+
+## UIKit API를 그대로 쓰는 편이 나은 경우
+
+- 한 번만 값을 설정하고 이후 변화가 없어요.
+- delegate 반환값으로 동기 정책을 결정해야 해요.
+- Rx로 바꾸면 작은 명령 하나가 여러 Relay와 바인딩을 거쳐야 해요.
+- Swift Concurrency 기반 화면과 섞을 이유가 없어요.
+- RxCocoa가 해당 API를 제공하지 않아 런타임 interception이 지나치게 복잡해져요.
+
+RxCocoa는 UIKit을 대체하는 프레임워크가 아니라 반복되는 비동기 UI 연결을 조합 가능하게 만드는 adapter예요.
+
+## 자주 하는 실수
+
+- Optional 의미를 확인하지 않고 모든 text에 `orEmpty`를 적용해요.
+- 스크롤 이벤트마다 무거운 동기 작업을 실행해요.
+- `modelSelected`를 Rx data source 없이 사용해요.
+- 화면 이동 사건을 Driver로 replay해 같은 화면을 다시 열어요.
+- RxCocoa가 UIKit의 모든 delegate 반환 정책을 자동 처리한다고 생각해요.
+- 셀 재사용 시 이전 모델 구독을 폐기하지 않아요.
+
+## 적용 체크리스트
+
+- 사용할 API가 source, sink, 양방향 속성 중 무엇인지 확인했나요?
+- 상태는 Driver, 사건은 Signal이라는 replay 기준을 검토했나요?
+- 고빈도 이벤트에서 필요한 값만 추출하고 중복을 줄였나요?
+- table·collection 모델 매핑이 data source와 일치하나요?
+- delegate 반환값이 필요한 기능의 소유자가 명확한가요?
+- 컨트롤과 셀의 DisposeBag 수명이 올바른가요?
+
+## 면접에서 이어질 수 있는 질문
+
+### RxCocoa가 모든 UIKit API를 제공하나요?
+
+아니요. 자주 쓰는 속성·target-action·delegate 사건을 Rx로 제공하지만, 반환값이 필요한 delegate 정책이나 명령형 API는 직접 UIKit으로 처리하거나 별도 adapter가 필요해요.
+
+### ControlProperty에 값을 bind하면 사용자 이벤트도 다시 발생하나요?
+
+일반적으로 property setter는 값을 설정할 뿐 동일한 UIControl event를 자동 발생시키지 않아요. 하지만 사용자 정의 컨트롤은 구현이 다를 수 있으므로 양방향 흐름의 순환 여부를 확인해야 해요.
+
+## 참고 자료
+
+- [RxCocoa iOS 공식 소스](https://github.com/ReactiveX/RxSwift/tree/6.10.2/RxCocoa/iOS)
+- [UIButton Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/UIButton%2BRx.swift)
+- [UIScrollView Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/UIScrollView%2BRx.swift)
+- [UIGestureRecognizer Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/UIGestureRecognizer%2BRx.swift)
+- [WKWebView Rx 구현](https://github.com/ReactiveX/RxSwift/blob/6.10.2/RxCocoa/iOS/WKWebView%2BRx.swift)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docs:check-collection-views": "node scripts/check-collection-view-coverage.mjs",
     "docs:check-mapbox-guides": "node scripts/check-mapbox-guide-coverage.mjs",
     "docs:check-rxswift-operators": "node scripts/check-rxswift-operator-coverage.mjs",
+    "docs:check-rxswift-sections": "node scripts/check-rxswift-section-coverage.mjs",
     "format": "prettier --write .",
     "lint": "eslint .",
     "preview": "rspress preview"

--- a/scripts/check-rxswift-section-coverage.mjs
+++ b/scripts/check-rxswift-section-coverage.mjs
@@ -1,0 +1,96 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const docsDirectory = path.resolve('docs/guide/rxswift');
+
+const expectedGroups = {
+  RxSwift: [
+    'installation-and-modules',
+    'rxswift-core',
+    'observable-observer-event',
+    'disposables-and-resources',
+    'schedulers-and-concurrency',
+    'subjects-and-traits',
+    'debugging-hooks-and-custom-operators',
+  ],
+  RxCocoa: [
+    'rxcocoa',
+    'reactive-binder-control-traits',
+    'driver-signal-shared-sequence',
+    'uikit-control-bindings',
+    'list-bindings-and-delegate-proxy',
+    'foundation-bindings',
+  ],
+  RxRelay: [
+    'rxrelay',
+    'relay-types-and-replay',
+    'relay-state-store-and-concurrency',
+  ],
+  'Rx 테스트': ['rxtest', 'rxblocking'],
+  '모든 연산자': [
+    'operators-create-convert',
+    'operators-transform-filter',
+    'operators-select-time',
+    'operators-combine',
+    'operators-error-lifecycle',
+    'operators-share-connect',
+    'operators-traits-deprecated',
+  ],
+};
+
+const metadataPath = path.join(docsDirectory, '_meta.json');
+const metadata = JSON.parse(await readFile(metadataPath, 'utf8'));
+const failures = [];
+
+const inventory = metadata.find(
+  (entry) => entry.link === '/guide/rxswift/official-api-inventory',
+);
+
+if (!inventory) {
+  failures.push('공식 API 범위와 학습 순서 문서가 사이드바에 없습니다.');
+}
+
+for (const [label, slugs] of Object.entries(expectedGroups)) {
+  const group = metadata.find((entry) => entry.label === label);
+
+  if (!group) {
+    failures.push(`${label} 그룹이 사이드바에 없습니다.`);
+    continue;
+  }
+
+  if (group.collapsible !== true || group.collapsed !== true) {
+    failures.push(`${label} 그룹은 기본으로 닫힌 접이식 목차여야 합니다.`);
+  }
+
+  const links = new Set((group.items ?? []).map((item) => item.link));
+
+  for (const slug of slugs) {
+    const documentPath = path.join(docsDirectory, `${slug}.md`);
+    const content = await readFile(documentPath, 'utf8').catch(() => null);
+
+    if (content === null) {
+      failures.push(`${slug}.md 문서가 없습니다.`);
+      continue;
+    }
+
+    if (!links.has(`/guide/rxswift/${slug}`)) {
+      failures.push(
+        `${slug}.md 문서가 ${label} 사이드바에 연결되지 않았습니다.`,
+      );
+    }
+
+    if (!content.includes('description:')) {
+      failures.push(`${slug}.md 문서에 description frontmatter가 없습니다.`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join('\n'));
+  process.exitCode = 1;
+} else {
+  const documentCount = Object.values(expectedGroups).flat().length + 2;
+  console.log(
+    `Rx 문서 ${documentCount}개의 존재 여부와 모듈별 기본 닫힘 목차 연결을 확인했습니다.`,
+  );
+}


### PR DESCRIPTION
## 작업 내용

- RxSwift 6.10.2의 다섯 제품과 공개 API 계열을 문서별로 연결하는 공식 범위 인벤토리를 추가했습니다.
- `RxSwift`를 설치·모듈, Observable·Observer·Event, Disposable, Scheduler·Swift Concurrency, Subject·Traits, 디버깅·사용자 정의 연산자 문서로 세분화했습니다.
- `RxCocoa`를 Reactive·Binder·Control Traits, Driver·Signal·SharedSequence, UIKit 컨트롤, 리스트·DelegateProxy, Foundation 바인딩 문서로 세분화했습니다.
- `RxRelay`를 세 Relay의 재생 규칙과 상태 Store·동시성 문서로 확장했습니다.
- `RxTest`의 가상 시간 테스트와 `RxBlocking`의 동기 검사·교착 위험을 별도 문서로 추가했습니다.
- 기존 일곱 연산자 문서는 RxSwift 공개 연산자 이름 89개의 설명을 유지합니다.
- 좌측 목차를 `RxSwift`, `RxCocoa`, `RxRelay`, `Rx 테스트`, `모든 연산자`로 분리하고 모두 기본으로 닫았습니다.
- 27개 Rx 문서의 존재 여부와 모듈별 목차 연결을 검사하는 자동 검증 스크립트를 추가했습니다.

## 범위 기준

- 일반 iOS 앱 개발자가 선택하고 조합하는 공개 제품, 핵심 개념, 공개 API 계열과 RxSwift 연산자 이름을 다룹니다.
- 내부 `Producer`·`Sink`·lock 구현, 같은 의미의 모든 generic·플랫폼 오버로드 복제, 공식 문장별 번역은 범위에서 제외하고 필요한 원리와 공식 소스 링크를 제공합니다.

## 확인 방법

- `npm run format`
- `npm run lint`
- `npm run docs:check-rxswift-operators`
- `npm run docs:check-rxswift-sections`
- `npm run build`
- Rx 문서의 상대 링크 대상 확인

Closes #69
